### PR TITLE
Polish pass: fix real bugs across site, duel game, and lambda backend

### DIFF
--- a/lambda/src/ai.js
+++ b/lambda/src/ai.js
@@ -41,7 +41,10 @@ if (debug) {console.log(`\ninitial totals:\n\tmaxStatPoints=${totalUnallocatedSt
 
 function selectSpecies(xalian) {
     // return tools.selectRandom(species);
-    return tools.selectRandom(tools.shuffle(species));
+    // deep-copy the selected record: populateStats writes rolled ratings onto the species,
+    // and mutating the shared species.json module state would leak one generation's
+    // ratings into every later generation in the same process (e.g. a warm lambda)
+    return JSON.parse(JSON.stringify(tools.selectRandom(tools.shuffle(species))));
 }
 
 function selectElements(xalian) {
@@ -344,7 +347,9 @@ function generateStatFromRange(xalian, statName) {
 // -- get highest possible category between 'VERY_HIGH', 'HIGH', 'MEDIUM', 'LOW', 'VERY_LOW'
 //      -- range can be limited by remaining points to allocate for a range category  
 function getHighestPossibleRatingValue(maxLeftForCategory, remainingCount) {
-    if (remainingCount == 1) { return maxLeftForCategory; }
+    // cap at VERY_HIGH so pickStatisticalRandomRating recognizes the value; an uncapped
+    // leftover budget (6+) fell through to VERY_LOW, forcing the last stat in a category low
+    if (remainingCount == 1) { return Math.min(maxLeftForCategory, statLevelConstants.levels.VERY_HIGH.pointValue); }
     let numberOfCategoriesToAllocateAfterThisIteration = remainingCount - 1;
     let remainingAmountThatCanBeAllocatedAssumingAllOtherRangesRandomizedToLowest = maxLeftForCategory - (numberOfCategoriesToAllocateAfterThisIteration * statLevelConstants.levels.VERY_LOW.pointValue);
     return Math.min(remainingAmountThatCanBeAllocatedAssumingAllOtherRangesRandomizedToLowest, statLevelConstants.levels.VERY_HIGH.pointValue);

--- a/lambda/src/database/userDbDelegate.js
+++ b/lambda/src/database/userDbDelegate.js
@@ -30,11 +30,12 @@ function getUser(id, onSuccess, onNotFound, onFail) {
 				if (data.Item) {
 
 					console.log(`SUCCESS :: data:\n${JSON.stringify(data.Item, null, 2)}`);
+					var attributes = data.Item.attributes || {};
 					var user = {
 						userId: data.Item.userId,
 						xalianIds: data.Item.xalianIds,
-						tokens: data.Item.attributes.tokens || 0,
-						attributes: data.Item.attributes
+						tokens: attributes.tokens || 0,
+						attributes: attributes
 					};
 					onSuccess(user);
 				} else {
@@ -98,7 +99,11 @@ function updateUserAttributes(id, updatedAttributes, onSuccess, onFail) {
 			Key: {
 				userId: id
 			},
-			UpdateExpression: 'set attributes = :attr',
+			// 'attributes' is a DynamoDB reserved word, so it needs an expression attribute name
+			UpdateExpression: 'set #attrs = :attr',
+			ExpressionAttributeNames: {
+				'#attrs': 'attributes',
+			},
 			ExpressionAttributeValues: {
 				':attr': updatedAttributes,
 			},

--- a/lambda/src/database/userTableCRUDLambdas.js
+++ b/lambda/src/database/userTableCRUDLambdas.js
@@ -34,7 +34,7 @@ module.exports.retrieveXalianUser = (event, context, callback) => {
 						},
 						function onFail(error) {
 							console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-							callback(builder.buildError(err));
+							callback(null, builder.buildError(error));
 						}
 						);
 					} else {
@@ -52,12 +52,12 @@ module.exports.retrieveXalianUser = (event, context, callback) => {
 				callback(null, builder.buildXalianError('USER_NOT_FOUND', 'Did not find user with userId=' + userId));
 			},
 			function onFail(error) {
-				console.log(`ERROR :: ${JSON.stringify(err, null, 2)}`);
-				callback(builder.buildError(error));
+				console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
+				callback(null, builder.buildError(error));
 			}
 		);
 	} catch (e) {
-		callback(builder.buildError(e));
+		callback(null, builder.buildError(e));
 	}
 };
 
@@ -74,8 +74,8 @@ module.exports.createXalianUser = (event, context, callback) => {
 				callback(undefined, builder.buildSuccess());
 			},
 			function onFail(error) {
-				console.log(`ERROR :: ${JSON.stringify(err, null, 2)}`);
-				callback(builder.buildError(error));
+				console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
+				callback(null, builder.buildError(error));
 			}
 		);
 	} catch (e) {
@@ -121,7 +121,7 @@ module.exports.createXalianUser = (event, context, callback) => {
 // 				},
 // 				function onFail(error) {
 // 					console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-// 					callback(builder.buildError(error));
+// 					callback(null, builder.buildError(error));
 // 				}
 // 			);
 // 		},
@@ -130,7 +130,7 @@ module.exports.createXalianUser = (event, context, callback) => {
 // 		},
 // 		function onFail(error) {
 // 			console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-// 			callback(builder.buildError(error));
+// 			callback(null, builder.buildError(error));
 // 		}
 // 	);
 // };
@@ -163,23 +163,23 @@ module.exports.updateXalianUser = (event, context, callback) => {
 				const index = updatedXalianIds.indexOf(request.value);
 				if (index > -1) {
 					updatedXalianIds.splice(index, 1);
-					updateUserXalianIds(request.userId, updatedXalianIds, callback);
+					updateUserXalianIds(userId, updatedXalianIds, callback);
 				} else {
 					callback(null, builder.buildXalianError('XALIAN_NOT_FOUND_IN_USER', 'Did not find xalian with xalianId=' + request.value));
 				}
 			} else if (request.action === 'ADD_XALIAN_ID') {
 				updatedXalianIds.push(request.value);
-				updateUserXalianIds(request.userId, updatedXalianIds, callback);
+				updateUserXalianIds(userId, updatedXalianIds, callback);
 			} else if (request.action === 'ADD_TOKENS') {
 				attributes.tokens =  existingTokens + parseInt(request.value);
-				updateUserAttributes(request.userId, attributes, callback);
+				updateUserAttributes(userId, attributes, callback);
 			} else if (request.action === 'REMOVE_TOKENS') {
 				let tokensToRemove = parseInt(request.value);
 				if (tokensToRemove > existingTokens) {
 					callback(null, builder.buildXalianError('INSUFFICIENT_TOKENS', `User tokens [${existingTokens}] was not enough to remove requested [${tokensToRemove}]`));
 				} else {
 					attributes.tokens =  existingTokens - tokensToRemove;
-					updateUserAttributes(request.userId, attributes, callback);
+					updateUserAttributes(userId, attributes, callback);
 				}
 			} else {
 				callback(null, builder.buildXalianError('UNKNOWN_ACTION', 'Update action [' + request.action + '] is not valid'));
@@ -190,7 +190,7 @@ module.exports.updateXalianUser = (event, context, callback) => {
 		},
 		function onFail(error) {
 			console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-			callback(builder.buildError(error));
+			callback(null, builder.buildError(error));
 		}
 	);
 };
@@ -205,7 +205,7 @@ function updateUserXalianIds(userId, updatedXalianIds, callback) {
 		},
 		function onFail(error) {
 			console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-			callback(builder.buildError(error));
+			callback(null, builder.buildError(error));
 		}
 	);
 }
@@ -219,7 +219,7 @@ function updateUserAttributes(userId, updatedAttributes, callback) {
 		},
 		function onFail(error) {
 			console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-			callback(builder.buildError(error));
+			callback(null, builder.buildError(error));
 		}
 	);
 }

--- a/lambda/src/database/xalianTableCRUDLambdas.js
+++ b/lambda/src/database/xalianTableCRUDLambdas.js
@@ -2,11 +2,11 @@ const delegate = require('./xalianDbDelegate.js');
 const builder = require('./responseBuilder.js');
 
 module.exports.createXalian = (event, context, callback) => {
-	const xalian = JSON.parse(event.body);
 	console.log(`inbound event: ` + JSON.stringify(event, null, 2));
-	console.log(`inbound xalian: ` + JSON.stringify(xalian, null, 2));
 
 	try {
+		const xalian = JSON.parse(event.body);
+		console.log(`inbound xalian: ` + JSON.stringify(xalian, null, 2));
 		delegate.createXalian(
 			xalian,
 			function onSuccess() {
@@ -14,19 +14,20 @@ module.exports.createXalian = (event, context, callback) => {
 			},
 			function onFail(error) {
 				console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-				callback(builder.buildError(err));
+				callback(null, builder.buildError(error));
 			}
 		);
 	} catch (e) {
-		callback(builder.buildError(e));
+		callback(null, builder.buildError(e));
 	}
 
 };
 
 module.exports.retrieveXalian = (event, context, callback) => {
-  if (!event.queryStringParameters.xalianId) {
-    callback(null, builder.buildXalianError('BAD_REQUEST', 'No xalianId found in query string parameters'));
-  }
+	if (!event.queryStringParameters || !event.queryStringParameters.xalianId) {
+		callback(null, builder.buildXalianError('BAD_REQUEST', 'No xalianId found in query string parameters'));
+		return;
+	}
 
 	let xalianIds = event.queryStringParameters.xalianId.split(',');
 
@@ -44,8 +45,8 @@ module.exports.retrieveXalian = (event, context, callback) => {
 				callback(null, builder.buildXalianError('XALIAN_NOT_FOUND', 'Did not find xalian with xaianId=' + xalianId));
 			},
 			function onFail(error) {
-				console.log(`ERROR :: ${JSON.stringify(err, null, 2)}`);
-				callback(builder.buildError(err));
+				console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
+				callback(null, builder.buildError(error));
 			}
 		);
 
@@ -59,11 +60,15 @@ module.exports.retrieveXalian = (event, context, callback) => {
 			},
 			function onFail(error) {
 				console.log(`ERROR :: ${JSON.stringify(error, null, 2)}`);
-				callback(builder.buildError(err));
+				callback(null, builder.buildError(error));
 			}
 		);
 	}
 };
+
+// GET /db/xalians is wired to this handler in main.tf; it accepts the same
+// comma-separated xalianId query param as retrieveXalian
+module.exports.retrieveXalianBatch = module.exports.retrieveXalian;
 
 
 

--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -849,7 +849,6 @@ a:active {
   max-height: 100vh;
   height: 100%;
   background-color: black;
-  background-image: url("");
   background-repeat: no-repeat;
   background-size: cover;
   background-position: 50% 50%;
@@ -1347,7 +1346,7 @@ section {
 # Planet Xalia Section
 --------------------------------------------------------------*/
 .planet-xalia-section {
-  background: radial-gradient(circle, rgba(0, 0, 0, 0.94) 0%, rgba(0, 0, 0, 0.90) 53%, rgba(0, 0, 0, 0.54) 85%, rgba(0, 0, 0, 0.34) 95%, rgba(0, 0, 0, 0) 100%), url("../img/background/eclipse_background.jpg") fixed center center;
+  background: radial-gradient(circle, rgba(0, 0, 0, 0.94) 0%, rgba(0, 0, 0, 0.90) 53%, rgba(0, 0, 0, 0.54) 85%, rgba(0, 0, 0, 0.34) 95%, rgba(0, 0, 0, 0) 100%) fixed center center;
 
   background-size: cover;
   padding: 60px 0;

--- a/my-app/public/index.html
+++ b/my-app/public/index.html
@@ -56,9 +56,6 @@
   * License: https://bootstrapmade.com/license/
   ======================================================== -->
 
-  <!-- adding custom constants -->
-  <script src="constants/constants.js"></script>
-
 </head>
 
 <body>

--- a/my-app/src/components/auth/authButtonGroup.js
+++ b/my-app/src/components/auth/authButtonGroup.js
@@ -139,11 +139,6 @@ class AuthButtonGroup extends React.Component {
     }
 
     render() {
-        let list = [];
-        for (const key in this.props.stats) {
-            let val = this.props.stats[key];
-            list.push(this.buildMoveRow(val));
-        }
         return (
             <React.Fragment>
                 {this.state.loggedInUser &&

--- a/my-app/src/components/auth/signInModal.js
+++ b/my-app/src/components/auth/signInModal.js
@@ -47,6 +47,13 @@ class SignInModal extends React.Component {
             this.setState({isThinking: false});
             this.props.callback();
             this.closeModal();
+        }).catch(e => {
+            // UserNotConfirmedException / UserNotFoundException are handled by the
+            // 'auth' Hub listener above; surface everything else here
+            if (e && e.code !== 'UserNotConfirmedException' && e.code !== 'UserNotFoundException') {
+                this.setState({errorMessage: e.message || 'Sign in failed'});
+            }
+            this.setState({isThinking: false});
         });
     }
 

--- a/my-app/src/components/auth/signUpModal.js
+++ b/my-app/src/components/auth/signUpModal.js
@@ -71,10 +71,11 @@ class SignUpModal extends React.Component {
                 this.setState({isThinking: false});
                 console.log('error signing up:', error);
                 if (error.code === 'UsernameExistsException') {
-                    this.setState({isThinking: false});
                     this.setError('username', 'Username already exists');
-
-
+                } else if (error.code === 'InvalidPasswordException') {
+                    this.setError('password', error.message || 'Password does not meet requirements');
+                } else {
+                    this.setError('general', (error && error.message) || 'Sign up failed — please try again');
                 }
             });
 

--- a/my-app/src/components/auth/verifyEmailModal.js
+++ b/my-app/src/components/auth/verifyEmailModal.js
@@ -32,6 +32,8 @@ class VerifyEmailModal extends React.Component {
             this.setState({ isThinking: false });
             this.props.callback();
             // this.props.onHide();
+        }).catch(e => {
+            this.setState({ isThinking: false, errorMessage: (e && e.message) || 'Verification failed — please check the code and try again' });
         });
     }
 
@@ -39,9 +41,9 @@ class VerifyEmailModal extends React.Component {
         var user = this.state.username || this.props.username
         if (user) {
             authUtil.resendConfirmationCode(user).then(response => {
-                console.log(JSON.stringify(response, null, 2));
-                this.props.callback(response);
-                this.setState({ verificationMessage: 'Email sent!' });
+                this.setState({ verificationMessage: 'Email sent!', errorMessage: null });
+            }).catch(e => {
+                this.setState({ errorMessage: (e && e.message) || 'Could not send a new code — please try again' });
             });
         } else {
             this.setState({ errorMessage: 'Please enter your username' })

--- a/my-app/src/components/games/duel/board/duelBoard.js
+++ b/my-app/src/components/games/duel/board/duelBoard.js
@@ -120,7 +120,8 @@ class DuelBoard extends React.Component {
 		} else {
 		}
 		if (this.props.ctx.gameover && this.state.winnerText == undefined) {
-			this.setState({ winnerText: this.props.ctx.gameover.winner !== undefined && this.props.ctx.gameover.winner == 0 ? 'You Win!' : 'You Lose!' });
+			let myPlayerId = this.props.playerID != null ? this.props.playerID : '0';
+			this.setState({ winnerText: this.props.ctx.gameover.winner !== undefined && this.props.ctx.gameover.winner == myPlayerId ? 'You Win!' : 'You Lose!' });
 		}
 
 		// fixing issue where sometimes the piece would have some weird extra leftovr x and y transform translation

--- a/my-app/src/components/games/duel/board/duelBoardCell.js
+++ b/my-app/src/components/games/duel/board/duelBoardCell.js
@@ -231,7 +231,7 @@ class DuelBoardCell extends React.Component {
 						}
 					})
 
-					if (hoverCellIndex) {
+					if (hoverCellIndex != null && hoverCellIndex >= 0) {
 						attackablePathsFromHoverSpot = duelCalculator.calculateAttackablePaths(hoverCellIndex, draggingXalian, props.boardState, props.ctx, false);
 						attackableIndicesFromHoverSpot = attackablePathsFromHoverSpot.map(p => (p.endIndex));
 					}

--- a/my-app/src/components/games/duel/duel.js
+++ b/my-app/src/components/games/duel/duel.js
@@ -478,11 +478,11 @@ function doAttack(G, ctx, path, data = {}) {
 	let defenderIndex = path.endIndex;
 	let attackerId = G.cells[attackerIndex];
 	let attacker = G.xalians.filter((x) => x.xalianId === attackerId)[0];
-	// attacker.state.stamina = attacker.state.stamina - duelConstants.ATTACK_STAMINA_COST;
-	attacker.state.stamina = attacker.state.stamina - path.spacesMoved;
 	let defenderId = G.cells[defenderIndex];
 	let defender = G.xalians.filter((x) => x.xalianId === defenderId)[0];
 	if (attacker && defender) {
+		// attacker.state.stamina = attacker.state.stamina - duelConstants.ATTACK_STAMINA_COST;
+		attacker.state.stamina = attacker.state.stamina - path.spacesMoved;
 		// console.log('xalian ' + attacker.species.name + ' from square ' + attackerIndex + ' is attacking xalian ' + defender.species.name + ' on square ' + defenderIndex);
 		var existingDefenderHealth = parseInt(defender.state.health);
 		let attackResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx);

--- a/my-app/src/components/navbar.js
+++ b/my-app/src/components/navbar.js
@@ -23,7 +23,7 @@ class XalianNavbar extends React.Component {
 		var navbar = document.getElementById('navvy');
 
 
-		Hub.listen('navbar-channel', (data) => {
+		this.hubListener = (data) => {
 			if (navbar) {
 				if (data.payload.event === 'show-navbar') {
 					navbar.classList.remove('hidden');
@@ -31,44 +31,51 @@ class XalianNavbar extends React.Component {
 				} else if (data.payload.event === 'hide-navbar') {
 					navbar.classList.remove('visible');
 					navbar.classList.add('hidden');
-				} 
+				}
 			}
-		})
+		};
+		Hub.listen('navbar-channel', this.hubListener);
 
 		// var animationTimeline = gsap.timeline({ repeat: 0});
 		// animationTimeline.fromTo("#navvy", {opacity: 0}, {opacity: 1, duration: 2, ease:'sine.in'});
 
-		// this.flipShowAuth = this.flipShowAuth.bind(this);
-		// var navbar = document.getElementById('navvy');
-		document.addEventListener('DOMContentLoaded', function () {
-			if (navbar) {
-				var last_scroll_top = 0;
-				window.addEventListener('scroll', function () {
-					let scroll_top = window.scrollY;
-					if (scroll_top > 30) {
-						// navbar.classList.remove('no-height');
-						if (scroll_top < last_scroll_top) {
-							// gsap.fromTo("#navvy", {opacity: 0, duration: 0.25}, {opacity: 1, duration: 0.25});
-							navbar.classList.remove('hidden');
-							navbar.classList.add('visible');
-						} else {
-							// gsap.fromTo("#navvy", {opacity: 1, height: '35px', duration: 2, ease:'sine.in'}, {opacity: 0, height: '0px', duration: 2, ease:'sine.out'});
-							// gsap.fromTo("#navvy", {opacity: 1, duration: 0.25}, {opacity: 0, duration: 0.25});
-							navbar.classList.remove('visible');
-							navbar.classList.add('hidden');
-						}
+		if (navbar) {
+			var last_scroll_top = 0;
+			this.scrollListener = function () {
+				let scroll_top = window.scrollY;
+				if (scroll_top > 30) {
+					if (scroll_top < last_scroll_top) {
+						navbar.classList.remove('hidden');
+						navbar.classList.add('visible');
+					} else {
+						navbar.classList.remove('visible');
+						navbar.classList.add('hidden');
 					}
+				} else {
+					// at the top of the page the navbar should always be visible
+					navbar.classList.remove('hidden');
+					navbar.classList.add('visible');
+				}
 
-					last_scroll_top = scroll_top;
-				});
-			}
-		});
+				last_scroll_top = scroll_top;
+			};
+			window.addEventListener('scroll', this.scrollListener);
+		}
 
 		Auth.currentUserInfo().then((data) => {
 			if (data && data.attributes) {
 				this.handleUserAuthAction(authUtil.buildAuthState(data));
 			}
 		});
+	}
+
+	componentWillUnmount() {
+		if (this.hubListener) {
+			Hub.remove('navbar-channel', this.hubListener);
+		}
+		if (this.scrollListener) {
+			window.removeEventListener('scroll', this.scrollListener);
+		}
 	}
 
 	handleUserAuthAction = (user) => {

--- a/my-app/src/components/planetTable.js
+++ b/my-app/src/components/planetTable.js
@@ -25,8 +25,15 @@ class PlanetTable extends React.Component {
   toggleShowHistory = () => {
     if (!this.state.showing) {
       Hub.dispatch('navbar-channel', { event: 'hide-navbar', data: null, message: null });
+    } else {
+      Hub.dispatch('navbar-channel', { event: 'show-navbar', data: null, message: null });
     }
     this.setState({ showing: !this.state.showing });
+  }
+
+  hideHistory = () => {
+    Hub.dispatch('navbar-channel', { event: 'show-navbar', data: null, message: null });
+    this.setState({ showing: false });
   }
 
   getHistoryParagraphs(history) {
@@ -102,9 +109,9 @@ class PlanetTable extends React.Component {
         <TextReaderModal 
           title={'The History of ' + this.props.planet.name} 
           body={this.getHistoryParagraphs(this.props.planet.history)} 
-          show={this.state.showing} 
+          show={this.state.showing}
           light
-          onHide={() => this.setState({ showing: false })}>
+          onHide={this.hideHistory}>
         </TextReaderModal>
       }
 		</React.Fragment>

--- a/my-app/src/components/verifyRemoveXalianModal.js
+++ b/my-app/src/components/verifyRemoveXalianModal.js
@@ -28,8 +28,9 @@ class VerifyRemoveXalianModal extends React.Component {
             this.props.onXalianDelete();
         }).catch(error => {
             console.log(JSON.stringify(error, null, 2));
+            alertUtil.sendAlert('Could not delete Xalian — please try again', null, 'danger');
             this.setState({
-                isLoading: false
+                isThinking: false
             });
         });
     }
@@ -50,7 +51,7 @@ class VerifyRemoveXalianModal extends React.Component {
             >
                 <Modal.Header closeButton  closeVariant={this.props.light ? '' : 'white'}>
                     <Modal.Title id="contained-modal-title-vcenter">
-                        Delete this {this.getXalianName} Xalian?
+                        Delete this {this.getXalianName()} Xalian?
                     </Modal.Title>
                 </Modal.Header>
                 <Modal.Body>

--- a/my-app/src/components/views/smokeEffectBackground.js
+++ b/my-app/src/components/views/smokeEffectBackground.js
@@ -29,7 +29,9 @@ class SmokeEffectBackground extends React.Component {
 	// };
 
 	componentWillUnmount() {
-		// window.removeEventListener('resize', this.updateSize);
+		if (this.smokeInterval) {
+			clearInterval(this.smokeInterval);
+		}
 	}
 
     componentDidMount() {
@@ -71,8 +73,7 @@ class SmokeEffectBackground extends React.Component {
         };
 
         // Once the callback is arranged then set the source of the image
-        // imageObj.src = '${resourcesFolderName}/Smoke.png';
-        imageObj.src = 'http://www.blog.jonnycornwell.com/wp-content/uploads/2012/07/Smoke10.png';
+        imageObj.src = '/assets/img/elements/smoke_particle.png';
 
         let canvasId = this.props.id;
 
@@ -217,7 +218,7 @@ class SmokeEffectBackground extends React.Component {
 
         // If the context is set then we can draw the scene (if not then the browser does not support canvas)
         if (context) {
-            setInterval(function () {
+            this.smokeInterval = setInterval(function () {
                 // Update the scene befoe drawing
                 update();
 
@@ -231,7 +232,7 @@ class SmokeEffectBackground extends React.Component {
 		return (
 			<React.Fragment>
 
-				<canvas id={this.props.id} className="" ></canvas>
+				<canvas id={this.props.id} width={this.props.width || 400} height={this.props.height || 400} className="" ></canvas>
 			</React.Fragment>
 		);
 	}

--- a/my-app/src/components/views/splashGalaxyBackground.js
+++ b/my-app/src/components/views/splashGalaxyBackground.js
@@ -39,7 +39,7 @@ class SplashGalaxyBackground extends React.Component {
 					options={{
 						background: {
 							// image: "url('assets/img/background/galaxy-splash.png')",
-							image: "url('assets/img/background/stars_bg.png')",
+							image: "url('/assets/img/background/stars_bg.png')",
 							position: "center center",
 							size: "50%",
 							repeat: "repeat"

--- a/my-app/src/components/xalianStatChart.js
+++ b/my-app/src/components/xalianStatChart.js
@@ -7,6 +7,7 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Table from 'react-bootstrap/Table';
 import * as valueTranslator from '../utils/valueTranslator';
+import * as constants from '../constants/constants';
 
 class XalianStatChart extends React.Component {
 	state = {};
@@ -43,7 +44,9 @@ class XalianStatChart extends React.Component {
 		let translated = this.props.abbreviatedNames ? valueTranslator.statFieldToDescriptionCondensed(key) : valueTranslator.statFieldToDescription(key);
 		let rangeVal = valueTranslator.statRangeToScaledVal(stat.range);
 		let rangeName = valueTranslator.statFieldToDescription(stat.range);
-		let percentageText = this.props.longDescription ? stat.points + ' Points, ' + stat.initialPointAllocationPercentage + '%' : stat.points;
+		let percentageText = this.props.longDescription ? stat.points + ' Points, ' + stat.percentage + '%' : stat.points;
+		let maxPoints = constants.STAT_POINT_MAX;
+		let potentialPoints = Math.max(0, maxPoints - stat.points);
 		return {
 			statName: key,
 			statLabel: translated,
@@ -51,8 +54,8 @@ class XalianStatChart extends React.Component {
 			rangeNumber: rangeVal,
 			points: stat.points,
 			percentageText: percentageText,
-			potentialPoints: (stat.maxPoints - stat.points),
-			potentialPointsLabel: (stat.maxPoints - stat.points).toString()
+			potentialPoints: potentialPoints,
+			potentialPointsLabel: potentialPoints.toString()
 		};
 	};
 

--- a/my-app/src/gameplay/duel/boardStateManager.js
+++ b/my-app/src/gameplay/duel/boardStateManager.js
@@ -25,6 +25,9 @@ export function getLastActionOfPlayer(fullLog, playerID) {
 }
 
 export function getAllMoveActionsFromLog(logs) {
+    if (!logs || logs.length === 0) {
+        return [];
+    }
     let filtered = logs.filter(log =>
         log.action &&
         log.action.type &&

--- a/my-app/src/gameplay/duel/duelActionBuilder.js
+++ b/my-app/src/gameplay/duel/duelActionBuilder.js
@@ -49,7 +49,7 @@ export function buildAttackActionsWithScore(currentIndex, attacker, G, ctx) {
         attackMoves.push(attack);
     });
     attackMoves.sort(function (a, b) {
-        return a.score < b.score ? -1 : a.score > b.score ? 1 : 0;
+        return a.score > b.score ? -1 : a.score < b.score ? 1 : 0;
     });
 
     if (attackMoves.length > 0) {
@@ -133,13 +133,13 @@ export function buildMoveActionsWithScore(currentIndex, xalian, paths, G, ctx) {
 
     let xalianIdOnTargetFlagIfAny = G.cells[flagIndexToRetrieve];
     let targetFlagIsOpen = xalianIdOnTargetFlagIfAny ? false : true;
-    let targetFlagIsGuardedByEnemy = xalianIdOnTargetFlagIfAny ? enemyState.activeXalianIds.includes[xalianIdOnTargetFlagIfAny] : false;
+    let targetFlagIsGuardedByEnemy = xalianIdOnTargetFlagIfAny ? enemyState.activeXalianIds.includes(xalianIdOnTargetFlagIfAny) : false;
     let targetFlagIsHeldByTeam = flagToRetrieve.holder ? true : false;
     let isHoldingTargetFlag = flagToRetrieve.holder === xalian.xalianId;
     
     let xalianIdOnTeamFlagIfAny = G.cells[flagIndexToGuard];
     let teamFlagIsOpen = xalianIdOnTeamFlagIfAny ? false : true;
-    let teamFlagIsGuardedByTeam = xalianIdOnTeamFlagIfAny ? playerState.activeXalianIds.includes[xalianIdOnTeamFlagIfAny] : false;
+    let teamFlagIsGuardedByTeam = xalianIdOnTeamFlagIfAny ? playerState.activeXalianIds.includes(xalianIdOnTeamFlagIfAny) : false;
     let teamFlagIsHeldByEnemy = flagToGuard.holder ? true : false;
     let isGuardingTeamFlag = currentIndex == flagIndexToGuard;
 
@@ -248,8 +248,8 @@ function scorePathsWhenHoldingTargetFlag(currentIndex, moveActions, G, ctx) {
         }
         let endCoord = grid.map[action.path.endIndex];
         // SCORE :: DISTANCE TO WINNING WITH FLAG
-        let yRowDifference = parseInt(endCoord[1]) - parseInt(startCoord[1]);
-        // let yRowFactor = (duelConstants.BOARD_COLUMN_SIZE * 2) - yRowDifference;
+        // the bot (player 1) scores at row 0, so moving to a LOWER row index is progress
+        let yRowDifference = parseInt(startCoord[1]) - parseInt(endCoord[1]);
         let yRowFactor = yRowDifference;
         action.description += `:: Y ROW DISTANCE FACTOR : +${yRowFactor}`;
         action.score += yRowFactor;
@@ -363,7 +363,7 @@ function scorePathsMovingTowardsTargetFlag(flagIndex, actions, G, ctx) {
         let flagClosenessFactorFromStart = (duelConstants.BOARD_COLUMN_SIZE * 2) - pathToTargetFlagFromMoveStart.spacesMoved;
         let flagClosenessFactorFromEnd = (duelConstants.BOARD_COLUMN_SIZE * 2) - pathToTargetFlagFromMoveResult.spacesMoved;
         let progressTowardsFlag = flagClosenessFactorFromEnd - flagClosenessFactorFromStart;
-        if (flagIndex != action.endIndex) {
+        if (flagIndex != action.path.endIndex) {
             action.description += `:: PROGRESS TOWARDS TARGET FLAG : +${progressTowardsFlag}`;
             action.score += progressTowardsFlag;
         }
@@ -494,7 +494,7 @@ export function buildComboActionsWithScore(currentIndex, attacker, allPaths, G, 
 
     
     comboActions.sort(function (a, b) {
-        return a.score < b.score ? -1 : a.score > b.score ? 1 : 0;
+        return a.score > b.score ? -1 : a.score < b.score ? 1 : 0;
     });
     return comboActions.slice(0, 10);
 }

--- a/my-app/src/pages/games/duelPage.js
+++ b/my-app/src/pages/games/duelPage.js
@@ -121,7 +121,8 @@ class DuelPage extends React.Component {
 			let playerPieces = [];
 			let opponentPieces = [];
 
-			let samples = retrievalUtil.getMockXalianList();
+			// copy the shared module array so shuffling/popping doesn't destroy it for later renders/games
+			let samples = [...retrievalUtil.getMockXalianList()];
 			gsap.utils.shuffle(samples);
 
 			while (playerPieces.length < xaliansPerTeam && samples.length > 0) {

--- a/my-app/src/pages/generatorPage.js
+++ b/my-app/src/pages/generatorPage.js
@@ -120,7 +120,7 @@ class GeneratorPage extends React.Component {
 		// this.setState({ showXalian: false }, () => {
 			// gsap.to('#generated-xalian-div', { opacity: 0, duration: 1, ease: 'power2.in' });
 			gsap.timeline()
-                .to('#generated-xalian-div', { opacity: 0, duration: 1, ease: 'power2.in' })
+                .to('#generated-xalian-fragment', { opacity: 0, duration: 1, ease: 'power2.in' })
 				.to('#smokeBackgroundCanvas', { opacity: 1, duration: 1, ease: 'power2.out' }, '<')
 				.then(() => {
 					xalianApi.callGenerateXalian().then((x) => {
@@ -133,10 +133,14 @@ class GeneratorPage extends React.Component {
 							() => {
 								// this.setState({ showXalian: true }, () => {
 									gsap.to('#smokeBackgroundCanvas', { opacity: 0, duration: 1, ease: 'power2.in' });
-									gsap.to('#generated-xalian-div', { opacity: 1, duration: 0.5, ease: 'power2.out' }, '<');
+									gsap.to('#generated-xalian-fragment', { opacity: 1, duration: 0.5, ease: 'power2.out' }, '<');
 								// });
 							}
 						);
+					}).catch(() => {
+						alertUtil.sendAlert('Could not generate a Xalian — please try again', null, 'danger');
+						gsap.to('#smokeBackgroundCanvas', { opacity: 0, duration: 1, ease: 'power2.in' });
+						gsap.to('#generated-xalian-fragment', { opacity: 1, duration: 0.5, ease: 'power2.out' }, '<');
 					});
 				});
 		// });
@@ -146,10 +150,10 @@ class GeneratorPage extends React.Component {
 		this.setState({
 			isLoading: true,
 		});
-		dbApi.callCreateXalian(this.state.xalian);
-
+		// create the xalian record first so the user record never references a xalian that doesn't exist
 		dbApi
-			.callUpdateUserAddXalian(this.state.loggedInUser.username, this.state.xalian.xalianId)
+			.callCreateXalian(this.state.xalian)
+			.then(() => dbApi.callUpdateUserAddXalian(this.state.loggedInUser.username, this.state.xalian.xalianId))
 			.then((x) => {
 				this.setState({ isLoading: false });
 				console.log(JSON.stringify(x, null, 2));
@@ -158,6 +162,7 @@ class GeneratorPage extends React.Component {
 			.catch((error) => {
 				this.setState({ isLoading: false });
 				console.log(JSON.stringify(error, null, 2));
+				alertUtil.sendAlert('Could not save your Xalian — please try again', null, 'danger');
 			});
 	};
 

--- a/my-app/src/pages/planetPage.js
+++ b/my-app/src/pages/planetPage.js
@@ -27,8 +27,8 @@ class PlanetPage extends React.Component {
           });
 
         var list = [];
-        for (var ind in planets) {
-            const p = planets[ind];
+        for (var ind in sortedPlanets) {
+            const p = sortedPlanets[ind];
             list.push(<PlanetTable planet={p}/>);
         }
         return list;

--- a/my-app/src/pages/speciesDetailPage.js
+++ b/my-app/src/pages/speciesDetailPage.js
@@ -24,17 +24,16 @@ class SpeciesDetailPage extends React.Component {
 	state = {};
 
 	componentDidMount() {
-		console.log(`INBOUND: ${JSON.stringify(this.props, null, 2)} :: ${this.props.id.toString()}`);
-		var map = new Map();
-		for (var ind in species) {
-			let x = species[ind];
-			map[x.id] = x;
+		let inboundId = this.props.id ? this.props.id.toString() : '';
+		// ids in species.json are zero-padded 5-digit strings; accept "/species/1" as well as "/species/00001"
+		if (inboundId && inboundId.length < 5) {
+			inboundId = inboundId.padStart(5, '0');
 		}
-		let inboundId = this.props.id;
-		let xal = map[inboundId];
+		let xal = species.find((x) => x.id === inboundId);
 		this.setState({
 			id: inboundId,
 			xalian: xal,
+			notFound: !xal,
 		});
 	}
 
@@ -43,6 +42,17 @@ class SpeciesDetailPage extends React.Component {
 	render() {
 		return (
 			<React.Fragment>
+				{this.state.notFound && (
+					<Container fluid className="content-background-container">
+						<XalianNavbar></XalianNavbar>
+						<Container className="content-container">
+							<h1 className="page-title-text">Species not found</h1>
+							<p style={{ textAlign: 'center' }}>
+								No Xalian species matches this id. <a href="/species">Browse all species</a>
+							</p>
+						</Container>
+					</Container>
+				)}
 				{this.state.xalian && (
 					<Container fluid className="content-background-container">
 						<XalianNavbar></XalianNavbar>

--- a/my-app/src/pages/trainingGroundsPage.js
+++ b/my-app/src/pages/trainingGroundsPage.js
@@ -34,8 +34,8 @@ class TrainingGroundsPage extends React.Component {
     }
 
     change = () => {
-        let g = this.state.games[this.state.selectedGameIndex];
-        this.setState({ selectedGameIndex: 1, selectedGame: g })
+        let nextIndex = (this.state.selectedGameIndex + 1) % this.state.games.length;
+        this.setState({ selectedGameIndex: nextIndex, selectedGame: this.state.games[nextIndex] })
     }
 
     render() {

--- a/my-app/src/pages/userAccountPage.js
+++ b/my-app/src/pages/userAccountPage.js
@@ -35,7 +35,11 @@ class UserAccountPage extends React.Component {
 				let u = authUtil.buildAuthState(data);
 				this.setState({ loggedInUser: u });
 				this.updateXaliansState(u.username);
+			} else {
+				this.setState({ isLoading: false, message: 'Sign in to see your Xalian Faction' });
 			}
+		}).catch(() => {
+			this.setState({ isLoading: false, message: 'Sign in to see your Xalian Faction' });
 		});
 	}
 
@@ -51,7 +55,7 @@ class UserAccountPage extends React.Component {
 				});
 			})
 			.catch((e) => {
-				this.setState({ message: `ERROR : ${JSON.stringify(e, null, 2)}` });
+				this.setState({ isLoading: false, message: 'Could not load your Xalians — please try again later' });
 			});
 	};
 
@@ -76,16 +80,13 @@ class UserAccountPage extends React.Component {
 
 	verifyRemoveXalianCallback = () => {
 		let deleted = this.state.xalianToDelete;
-		console.log(deleted);
-		let rows = this.state.xalianRows;
-		rows.forEach( row => {
-			let x = row.props.xalian;
-			if (x.xalianId == deleted.xalianId) {
-				rows.splice(rows.indexOf(row), 1);
-			}
-		})
-
-		this.setState({ verifyRemoveXalianModalShow: false, xalianToDelete: false });
+		let remaining = (this.state.xalians || []).filter((x) => x.xalianId != deleted.xalianId);
+		this.setState({
+			xalians: remaining,
+			xalianRows: this.state.xalianRows.filter((row) => row.props.xalian.xalianId != deleted.xalianId),
+			verifyRemoveXalianModalShow: false,
+			xalianToDelete: false,
+		});
 	};
 
 	closeModalCallback = () => {
@@ -102,6 +103,7 @@ class UserAccountPage extends React.Component {
 						<Row className='account-page-xalians-title vertically-center-contents'>
 							<h1>Your Xalian Faction</h1>
 						</Row>
+						{this.state.message && <Row><p style={{ textAlign: 'center' }}>{this.state.message}</p></Row>}
 						<Row className="">{this.state.xalianRows}</Row>
 					</Container>
 

--- a/my-app/src/pages/userDetailsPage.js
+++ b/my-app/src/pages/userDetailsPage.js
@@ -31,7 +31,7 @@ class UserAccountPage extends React.Component {
             this.setState({ isLoading: false });
             this.setState({ user: u, xalians: u.xalians });
         }).catch(e => {
-            this.setState({ message: `ERROR : ${JSON.stringify(e, null, 2)}`, isLoading: false });
+            this.setState({ message: 'Could not load this user\'s Xalians — please try again later', isLoading: false });
         })
 
         // let mockXalians = JSON.parse('[ { "speciesId": "00014", "xalianId": "00014-b049976e-1a31-4728-8817-923d444a80b8", "attributes": { "xalianId": "00014-b049976e-1a31-4728-8817-923d444a80b8", "species": { "generation": "0", "planet": "Drainov", "name": "Venemist", "description": "The toxic mist expelled from a tube in its mouth helps to dissolve its prey. With only 2 teeth, this tactic is necessary for the creature to survive.", "weight": "103 lbs / 46 kg", "id": "00014", "height": "38 in / 96 cm" }, "healthPoints": 999, "stats": { "evasionPoints": { "name": "evasionPoints", "range": "medium", "points": 458, "percentage": 91 }, "standardAttackPoints": { "name": "standardAttackPoints", "range": "medium", "points": 551, "percentage": 110 }, "standardDefensePoints": { "name": "standardDefensePoints", "range": "medium", "points": 440, "percentage": 88 }, "staminaPoints": { "name": "staminaPoints", "range": "high", "points": 680, "percentage": 90 }, "specialDefensePoints": { "name": "specialDefensePoints", "range": "low", "points": 238, "percentage": 95 }, "recoveryPoints": { "name": "recoveryPoints", "range": "low", "points": 284, "percentage": 113 }, "specialAttackPoints": { "name": "specialAttackPoints", "range": "medium", "points": 418, "percentage": 83 }, "speedPoints": { "name": "speedPoints", "range": "low", "points": 270, "percentage": 108 } }, "moves": [ { "name": "Modest Infectious Shot", "rating": 9, "description": "Chemical-typed sufficiently sized attack hard enough to cause injury", "cost": 10, "type": "Chemical", "element": "Infectious" }, { "name": "Irritating Lunge", "rating": 6, "description": "Causing physical discomfort, sudden forward strike", "cost": 10 }, { "name": "Unfriendly Microbe Bang", "rating": 8, "description": "Chemical-typed disagreeable or hostile, vigorous attack", "cost": 10, "type": "Chemical", "element": "Microbe" }, { "name": "Heroic Boot", "rating": 10, "description": "Impressive and courageous attack with the foot", "cost": 10 } ], "meta": { "avgPercentage": 97, "totalStatPoints": 3339 }, "elements": { "secondaryType": "Dark", "primaryType": "Chemical", "secondaryElement": "Shadow", "primaryElement": "Poison" }, "speciesId": "00014", "createTimestamp": 1644614990305 } } ]');
@@ -69,7 +69,7 @@ class UserAccountPage extends React.Component {
 
                     <Row className='account-page-xalians-title vertically-center-contents'>
                         {this.state.user && 
-                            <h1>{this.state.user.username || this.state.user.userId + "'s Xalian Faction"}</h1>
+                            <h1>{(this.state.user.username || this.state.user.userId) + "'s Xalian Faction"}</h1>
                         }
 							
 						</Row>

--- a/my-app/src/utils/authUtil.js
+++ b/my-app/src/utils/authUtil.js
@@ -80,53 +80,18 @@ export const signUp = (email, user, pass) => {
 }
 
 export const confirmSignUp = (user, code) => {
-    return new Promise((resolve) => {
-        try {
-            Auth.confirmSignUp(user, code).then(() => {
-                console.log('confirmed');
-                resolve();
-            });
-        } catch (error) {
-            console.log('error confirming signing up:', error);
-        }
-    });
+    return Auth.confirmSignUp(user, code);
 }
 
 export const resendConfirmationCode = (user) => {
-    return new Promise((resolve) => {
-        try {
-            Auth.resendSignUp(user).then(() => {
-                resolve();
-            });
-        } catch (error) {
-            console.log('error resending confirmation code:', error);
-        }
-    });
+    return Auth.resendSignUp(user);
 }
 
 export const signIn = (user, pass) => {
-    return new Promise((resolve, reject) => {
-        try {
-            Auth.signIn(user, pass).then(() => {
-                resolve();
-            }).catch(e => {
-                reject();
-            });
-        } catch (error) {
-            console.log('error signing in:', error);
-        }
-    });
+    return Auth.signIn(user, pass);
 }
 
 export const signOut = () => {
-    return new Promise((resolve) => {
-        try {
-            Auth.signOut().then(() => {
-                resolve(true);
-            });
-        } catch (error) {
-            console.log('error signing out:', error);
-        }
-    });
+    return Auth.signOut().then(() => true);
 }
 

--- a/my-app/src/utils/dbApi.js
+++ b/my-app/src/utils/dbApi.js
@@ -3,18 +3,13 @@ import qs from "qs";
 import Amplify, { API, Auth } from "aws-amplify";
 import { Signer } from "@aws-amplify/core";
 
-async function signRequest(url, method, body, headers, qp) {
-  const urlParams = new URLSearchParams();
-  urlParams.set("ids", qp);
-  const editedUrl = qp ? url + "?" + urlParams.toString() : url;
-
+async function signRequest(url, method, body, headers) {
   const essentialCredentials = Auth.essentialCredentials(await Auth.currentCredentials());
   const params = {
     method: method,
-    url: editedUrl,
+    url: url,
     data: JSON.stringify(body),
     headers: headers,
-    params: qp,
   };
   const credentials = {
     secret_key: essentialCredentials.secretAccessKey,
@@ -30,7 +25,6 @@ export const callGetXalian = (id = "00009-4c1d8607-d3de-4313-91b1-84eecd5ce921")
 };
 
 export const callGetUser = (id, populateXalians = false) => {
-  // return callGet("https://api.xalians.com/prod/db/user?userId=" + encodeURIComponent(id));
   if (populateXalians) {
     return callGet("https://api.xalians.com/prod/db/user?userId=" + id + "&populateXalians=true");
   } else {
@@ -38,25 +32,12 @@ export const callGetUser = (id, populateXalians = false) => {
   }
 };
 
-export const callGet = (url, params) => {
-  return new Promise((resolve) => {
-    try {
-      signRequest(url, "GET").then((signedRequest) => {
-        axios.defaults.withCredentials = true;
-        axios
-          .get(signedRequest.url, { headers: signedRequest.headers })
-          .then((response) => {
-            console.log("RESPONSE: " + JSON.stringify(response));
-            resolve(response.data);
-          })
-          .catch((e) => {
-            alert("BOOOOO in get \n\n" + "axios GET ERROR : \n" + JSON.stringify(e, null, 2));
-            console.log("axios GET ERROR : " + e);
-          });
-      });
-    } catch (e) {
-      console.log("caught ERROR : " + e);
-    }
+export const callGet = (url) => {
+  return signRequest(url, "GET").then((signedRequest) => {
+    axios.defaults.withCredentials = true;
+    return axios
+      .get(signedRequest.url, { headers: signedRequest.headers })
+      .then((response) => response.data);
   });
 };
 
@@ -77,38 +58,6 @@ export const callGetXalianBatch = (ids) => {
   return callGet("https://api.xalians.com/prod/db/xalian?xalianId=" + encodeURIComponent(qString));
 };
 
-//   export const callGetUserBatch = (id) => {
-//     // return callGet("https://api.xalians.com/prod/db/user?userId=" + encodeURIComponent(id));
-//     return callGet("https://api.xalians.com/prod/db/user?userId=" + id);
-//   };
-
-export const callGetBatch = (url, ids) => {
-  var editedUrl = url + "?xalianId=";
-  // ids.
-  axios.defaults.withCredentials = true;
-  return new Promise((resolve) => {
-    try {
-      signRequest(editedUrl, "GET").then((signedRequest) => {
-        axios
-          .get(signedRequest.url, {
-            headers: signedRequest.headers,
-          })
-          .then((response) => {
-            console.log("RESPONSE: " + JSON.stringify(response));
-            console.log('\n\n' + JSON.stringify(response.data) + '\n\n');
-            resolve(response.data);
-          })
-          .catch((e) => {
-            alert("BOOOOO batch \n\n" + "axios GET ERROR : \n" + JSON.stringify(e, null, 2));
-            console.log("axios GET ERROR : " + e);
-          });
-      });
-    } catch (e) {
-      console.log("caught ERROR : " + e);
-    }
-  });
-};
-
 export const callCreateXalian = (xalian) => {
   return callCreate("https://api.xalians.com/prod/db/xalian", xalian);
 };
@@ -118,28 +67,14 @@ export const callCreateUser = (user) => {
 };
 
 export const callCreate = (url, data) => {
-  return new Promise((resolve) => {
-    try {
-      signRequest(url, "POST", data, { "content-type": "application/json" }).then((signedRequest) => {
-        axios.defaults.withCredentials = true;
-        axios({
-          method: "post",
-          url: signedRequest.url,
-          headers: signedRequest.headers,
-          data: signedRequest.data,
-        })
-          .then((response) => {
-            console.log("RESPONSE: " + JSON.stringify(response));
-            resolve(response.data);
-          })
-          .catch((e) => {
-            alert("axios ERROR : " + e);
-            console.log("caught ERROR : " + e);
-          });
-      });
-    } catch (e) {
-      console.log("caught ERROR : " + e);
-    }
+  return signRequest(url, "POST", data, { "content-type": "application/json" }).then((signedRequest) => {
+    axios.defaults.withCredentials = true;
+    return axios({
+      method: "post",
+      url: signedRequest.url,
+      headers: signedRequest.headers,
+      data: signedRequest.data,
+    }).then((response) => response.data);
   });
 };
 
@@ -161,28 +96,13 @@ export const callUpdateUserXalian = (action, userId, xalianId) => {
   const url = "https://api.xalians.com/prod/db/user";
   const method = "PATCH";
 
-  return new Promise((resolve) => {
-    try {
-      signRequest(url, method, data, { "content-type": "application/json" }).then((signedRequest) => {
-        axios.defaults.withCredentials = true;
-        axios({
-          method: method,
-          url: signedRequest.url,
-          headers: signedRequest.headers,
-          data: signedRequest.data,
-        })
-          .then((response) => {
-            console.log("RESPONSE: " + JSON.stringify(response));
-            resolve(response.data);
-          })
-          .catch((e) => {
-            alert("axios update user ERROR : " + e);
-            console.log("caught ERROR : " + e);
-          });
-      });
-    } catch (e) {
-      console.log("caught ERROR : " + e);
-    }
+  return signRequest(url, method, data, { "content-type": "application/json" }).then((signedRequest) => {
+    axios.defaults.withCredentials = true;
+    return axios({
+      method: method,
+      url: signedRequest.url,
+      headers: signedRequest.headers,
+      data: signedRequest.data,
+    }).then((response) => response.data);
   });
 };
-

--- a/my-app/src/utils/duelUtil.js
+++ b/my-app/src/utils/duelUtil.js
@@ -188,7 +188,7 @@ export function currentTurnHasMoveAvailable(boardState, ctx) {
 export function xalianHasValidActionAvailable(id, G, ctx) {
     let xalian = getXalianFromId(id, G);
     let ind = getIndexOfXalian(id, G);
-    if (ind) {
+    if (ind != null && ind >= 0) {
         var canAttack = true;
         var canMove = true;
 

--- a/my-app/src/utils/xalianApi.js
+++ b/my-app/src/utils/xalianApi.js
@@ -3,11 +3,6 @@ import axios from 'axios';
 export const callGenerateXalian = () => {
 
     const url = "https://api.xalians.com/xalian";
-    return new Promise((resolve) => {
-        axios.get(url)
-            .then(response => {
-                resolve(response.data);
-            });
-    });
+    return axios.get(url).then(response => response.data);
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "free-google-image-search": "^1.0.0",
         "morgan": "~1.9.1",
         "react-inlinesvg": "^3.0.0",
-        "terraform": "^1.20.1"
+        "terraform": "^1.20.1",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@babel/runtime": {
@@ -439,7 +440,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
     },
     "node_modules/boardgame.io": {
       "version": "0.49.11",
@@ -2257,6 +2259,16 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4057,6 +4069,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "free-google-image-search": "^1.0.0",
     "morgan": "~1.9.1",
     "react-inlinesvg": "^3.0.0",
-    "terraform": "^1.20.1"
+    "terraform": "^1.20.1",
+    "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
## Summary

A cleanup/polish pass targeting things that are **actually wrong** — no observability, no style churn. Every fix traces to a concrete failure scenario; nothing that looked like an intentionally-unexposed feature was deleted.

### The reported bug: navbar disappearing on /planets
Opening any planet story dispatched `hide-navbar`, but no `show-navbar` dispatch existed anywhere in the codebase, so the navbar stayed `scaleY(0)` forever after closing the story. Additionally the scroll-based hide/show never worked at all: its listener was registered inside a `DOMContentLoaded` handler that had already fired before React mounted. Both fixed and verified in the running app (open story → close → navbar returns; scroll down hides, scroll up shows, top always shows).

### Root cause of most stuck spinners
`dbApi`, `xalianApi`, and `authUtil` wrapped everything in `new Promise((resolve) => ...)` with no `reject` — any HTTP/auth failure left the promise pending forever, so every caller's `.catch` was dead code and pages hung on preloaders. All converted to real promise chains. Debug `alert("BOOOOO...")` popups removed.

### Auth flow dead-ends fixed
Wrong verification code → spinner forever (now shows error). "Send another verification code" → closed the modal and attempted sign-in, losing the code form (now stays and confirms). Wrong password → blank modal (now shows error). Non-duplicate sign-up failures → silent (now shown).

### Page fixes
/account black-screen preloader when logged out; /train switch button permanently stuck on game 1; /species/:id blank white page for unknown or non-padded ids; /generator dead button on API failure, save write-ordering race (user record patched before xalian existed), and fade targeting a nonexistent element id; /planets iterating the unsorted array; delete-modal title missing a function call; smoke canvas hotlinking a dead plain-http image (now uses the local asset, with interval cleanup and correct canvas size); stat chart rendering "NaN potential points"; index.html loading a nonexistent script on every page; empty `url("")` background causing the page HTML to be refetched as an image.

### Duel game (bot & rules bugs)
Bot's attack/combo candidates were sorted **ascending** then truncated to 10 — it kept its ten worst options; flag-carrier row bonus had an inverted sign (rewarded retreating); `.includes[...]` property access instead of calls; cell 0 treated as falsy in two places; stamina deducted before the attacker/defender guard; hot-seat winner text always from player 0's perspective; squad building destructively consumed the shared mock-sample module array (second render/game had almost no samples left).

### Lambda backend
- **Generator purity**: `selectSpecies` returned a reference into the shared `species.json` module and `populateStats` wrote rolled ratings back onto it — on a warm lambda, every later generation of that species inherited the first one's ratings. Now deep-copies. Verified: 50 generations leave the module untouched.
- Rating budget: last stat in a category was deterministically forced to Very Low whenever leftover budget exceeded 5.
- CRUD handlers: `err`/`error` typos threw `ReferenceError` inside every error path (hung invocation → 502 instead of a 500 body); error responses passed as the callback's first arg (also 502); missing `return` after 400s; unguarded `queryStringParameters`/`JSON.parse`.
- `updateXalianUser` didn't lowercase userId (records are stored lowercased) → USER_NOT_FOUND on valid users.
- `attributes` is a DynamoDB reserved word — ADD_TOKENS/REMOVE_TOKENS always failed with ValidationException; now uses an expression attribute name.
- `GET /db/xalians` was wired in main.tf to a handler that didn't exist; `retrieveXalianBatch` is now exported (same comma-separated behavior as `retrieveXalian`).
- `uuid` declared at root (required by xalianBuilder, previously undeclared).

### Verified
- Dev server runs (note: needs `NODE_OPTIONS=--openssl-legacy-provider` on Node 17+ with this toolchain; `src/aws-exports.js` is gitignored and must exist locally — I reconstructed mine from the deployed bundle)
- Browser-verified: navbar fix on /planets, /species/1 and /species/99999, /account logged-out state, /train switching both directions, /generator generating against the live API, /duel full board render vs bot with no new console errors
- Node-verified: 50 generations without shared-state mutation

### Known issues deliberately NOT addressed (bigger than a polish pass)
- Duel: moves/attacks are applied with no server-side validation and the UI computes paths from the animation's historical board state (stale-state moves possible); GSAP Draggables accumulate across board updates; the attack modal is the only thing that can unpause the animation timeline. These want a small refactor of the animation/input pipeline.
- Deploy/infra: the lambda zip ships no node_modules (`uuid`/`bluebird` come from the committed prebuilt zip), and the terraform module pins `nodejs12.x`, which Lambda no longer accepts for new deploys.
- The old dual-type effectiveness branch in `duelCalculator` is unreachable dead code that would crash if enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)