### PR TITLE
Add GitHub Actions CI/CD for frontend and backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: my-app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: my-app/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+
+      - name: Sync shared game data and engine code from lambda/
+        run: yarn copy-json && yarn copy-js
+
+      - name: Build
+        # legacy provider: the lockfile's webpack toolchain uses md4 hashing,
+        # which OpenSSL 3 (Node 17+) removed
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+          CI: "false" # CRA treats warnings as errors when CI=true; this codebase has known benign warnings
+        run: yarn build

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,61 @@
+name: Deploy frontend
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "my-app/**"
+      - "lambda/src/json/**"
+      - "lambda/src/constants/**"
+      - "lambda/src/gameplay/**"
+      - ".github/workflows/deploy-frontend.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write # required for OIDC
+  contents: read
+
+concurrency:
+  group: deploy-frontend
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy to xalians.com
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: my-app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: my-app/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+
+      - name: Sync shared game data and engine code from lambda/
+        run: yarn copy-json && yarn copy-js
+
+      - name: Build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+          CI: "false"
+        run: yarn build
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::174497891311:role/xalians-github-deploy
+          aws-region: us-east-1
+
+      - name: Sync build to S3
+        run: aws s3 sync build s3://xalians.com --delete
+
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id E25EPFZCU2J0HP --paths "/*"

--- a/my-app/.gitignore
+++ b/my-app/.gitignore
@@ -32,7 +32,8 @@ amplify/backend/.temp
 build/
 dist/
 node_modules/
-aws-exports.js
+# aws-exports.js is committed deliberately: it holds only public Cognito client ids
+# (already visible in the shipped JS bundle) and CI cannot build without it
 awsconfiguration.json
 amplifyconfiguration.json
 amplifyconfiguration.dart

--- a/my-app/src/aws-exports.js
+++ b/my-app/src/aws-exports.js
@@ -1,0 +1,29 @@
+/* eslint-disable */
+// Recreated from the deployed xalians.com bundle (this file is Amplify-generated and gitignored).
+const awsmobile = {
+    aws_project_region: 'us-east-1',
+    aws_cognito_identity_pool_id: 'us-east-1:63068dd5-2879-433e-9e18-03cff03c0fb8',
+    aws_cognito_region: 'us-east-1',
+    aws_user_pools_id: 'us-east-1_dDy7NYWbz',
+    aws_user_pools_web_client_id: '67ak7f8lbjlvk0ufj1r46oclmv',
+    oauth: {},
+    aws_cognito_username_attributes: [],
+    aws_cognito_social_providers: [],
+    aws_cognito_signup_attributes: ['EMAIL'],
+    aws_cognito_mfa_configuration: 'OFF',
+    aws_cognito_mfa_types: ['SMS'],
+    aws_cognito_password_protection_settings: {
+        passwordPolicyMinLength: 8,
+        passwordPolicyCharacters: [],
+    },
+    aws_cognito_verification_mechanisms: ['EMAIL'],
+    aws_cloud_logic_custom: [
+        {
+            name: 'AdminQueries',
+            endpoint: 'https://mqzl3wz9lh.execute-api.us-east-1.amazonaws.com/dev',
+            region: 'us-east-1',
+        },
+    ],
+};
+
+export default awsmobile;


### PR DESCRIPTION
## Summary

Complete GitHub-based CI/CD, replacing the manual `build-deploy` / local-`terraform apply` flow. Auth throughout is **GitHub OIDC — no AWS keys stored in GitHub**.

## Frontend
- **`ci.yml`** — builds the frontend on every PR to master.
- **`deploy-frontend.yml`** — push to master (touching `my-app/` or shared lambda sources) or manual dispatch: build → `aws s3 sync` to `xalians.com` → CloudFront invalidation (`E25EPFZCU2J0HP`). Role: `xalians-github-deploy` (trust: this repo's master ref; perms: the site bucket + that one distribution).
- **`aws-exports.js` is now committed** — it holds only public Cognito client IDs (already visible in the shipped bundle); CI cannot build without it.

## Backend
- **`deploy-backend.yml`** — PRs touching `lambda/`/terraform get `fmt`/`validate`/`terraform plan`; pushes to master get `terraform apply`. Role: `xalians-github-terraform` (trust: master + PRs for plan; perms scoped to the state bucket, `chronic-labs-*` artifact buckets, site bucket, this account's lambda/apigw/log-group/route53-zone resources, and the `serverless_lambda` exec role).
- **Remote state**: S3 backend `xalians-terraform-state-174497891311` (versioned, encrypted, public-blocked, S3-native lockfile). The old state was local-only and lost with the old laptop — **`imports.tf` rebuilt the entire state from live resource IDs** (53 resources imported cleanly: 0 add, 0 destroy on first plan).
- **Provider `~>3.48` → `~>5.0`**: `aws_s3_bucket_object` → `aws_s3_object`; react bucket's inline acl/policy/website/cors split into v5 resources with import blocks; `random_pet` bucket name replaced by a pinned variable (`chronic-labs-officially-correctly-relaxed-prawn` — random_pet can't be imported).
- **Lambda runtime `nodejs12.x` → `nodejs20.x`** across all 7 functions.
- **Real packaging**: `lambda/package.json` declares `uuid`, `bluebird`, `aws-sdk` v2 (Node 18+ runtimes don't bundle SDK v2); CI runs `npm ci` in `lambda/` before terraform zips it. The committed prebuilt zip is removed and gitignored — artifacts are always built from source.

## Already applied and verified
To establish the state (a chicken-and-egg: the workflow can't run without state), I ran the first apply locally: **53 imported, 9 changed (7 runtime bumps + artifact refresh), 0 destroyed**. Verified after:
- `https://api.xalians.com/xalian` generates successfully on **nodejs20.x** (served a Neph — the new engine code with the PR #1 fixes is live)
- Steady-state plan is clean except a known benign etag diff on the artifact object (multipart etag vs filemd5 — means every CI apply re-ships the latest zip, which is the desired CD behavior)
- The frontend CI check on this PR already passed

## Things found along the way (added context, no action in this PR)
- ⚠️ **There is a live, unmanaged route `POST /db/xalian/unauth` with NO auth** on the API — an unauthenticated write endpoint that exists in AWS but not in terraform. Probably an old experiment; recommend deleting it (`aws apigatewayv2 delete-route --api-id 6y8832nrlf --route-id w3sz1ai`). Left untouched pending your call.
- api.xalians.com has two extra unmanaged mappings (`prod` and `test` keys) besides the root mapping terraform manages — that's why both `/xalian` and `/prod/xalian` work. Also an unmanaged `debug.xalians.com` domain exists.
- Three older `chronic-labs-*` buckets from past applies are orphaned and could be deleted.
- `imports.tf` can be deleted after this merges (import blocks are no-ops once resources are in state).

## After merging
- Backend: pushes touching lambda/terraform auto-plan/apply. Frontend: pushes touching my-app auto-deploy. Both also have manual dispatch.
- The merge commit itself will trigger both deploys (it touches both path sets) — watch the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)