### PR TITLE
Duel: real Xalian squads with squad picker

### DIFF
--- a/lambda/src/database/userTableCRUDLambdas.js
+++ b/lambda/src/database/userTableCRUDLambdas.js
@@ -150,8 +150,10 @@ module.exports.updateXalianUser = (event, context, callback) => {
 	const request = JSON.parse(event.body);
 	console.log(`action=${request.action} :: userId=${request.userId} :: value=${request.value}`);
 
+	const userId = request.userId.toLowerCase();
+
 	delegate.getUser(
-		request.userId,
+		userId,
 		function onSuccess(user) {
 
 			console.log('got user to update: \n' + JSON.stringify(user));

--- a/lambda/src/json/mock/xalianSamples.json
+++ b/lambda/src/json/mock/xalianSamples.json
@@ -943,7 +943,7 @@
     "createTimestamp": 1656021179720,
     "species": {
       "id": "00008",
-      "name": "Hypnox",
+      "name": "Tizzie",
       "planet": "Telypso",
       "description": "It uses its tail to draw attention to its big, hypnotic eyes. Once eye contact is made, this creature can attack from within your mind.",
       "height": "35 in / 89 cm",

--- a/my-app/src/gameplay/duel/duelPieceBuilder.js
+++ b/my-app/src/gameplay/duel/duelPieceBuilder.js
@@ -28,7 +28,9 @@ export function buildDuelPiece(xalian) {
     ranges['medium'] = 2;
     ranges['low'] = 1;
 
-    let attackRange = ranges[selectedSpecies.traits.attackRange];
+    // real saved xalians may predate the current species list — default rather than crash
+    let traits = (selectedSpecies && selectedSpecies.traits) || { attackRange: 'medium', canFly: false };
+    let attackRange = ranges[traits.attackRange] || 2;
 
     function buildReducedSpecies(fullSpecies) {
         return {
@@ -54,6 +56,6 @@ export function buildDuelPiece(xalian) {
             health: duelConstants.MAX_HEALTH_POINTS,
             stamina: duelConstants.MAX_STAMINA_POINTS
         },
-        traits: selectedSpecies.traits
+        traits: traits
     }
 }

--- a/my-app/src/json/mock/xalianSamples.json
+++ b/my-app/src/json/mock/xalianSamples.json
@@ -943,7 +943,7 @@
     "createTimestamp": 1656021179720,
     "species": {
       "id": "00008",
-      "name": "Hypnox",
+      "name": "Tizzie",
       "planet": "Telypso",
       "description": "It uses its tail to draw attention to its big, hypnotic eyes. Once eye contact is made, this creature can attack from within your mind.",
       "height": "35 in / 89 cm",

--- a/my-app/src/pages/games/duelPage.js
+++ b/my-app/src/pages/games/duelPage.js
@@ -29,19 +29,52 @@ class DuelPage extends React.Component {
 	};
 
 	componentDidMount() {
-		// retrievalUtil.getCurrentUserAndXalians().then((user) => {
+		// build the piece pools once so re-renders don't reshuffle mid-game
 		if (!this.state.xalians) {
-
-			retrievalUtil.getMockCurrentUserAndXalians().then((user) => {
-				let xalians = [];
-				user.xalians.forEach((x) => {
-					// xalians.push(this.buildSpeciesIcon(x.attributes));
-					xalians.push(x.attributes);
-				});
-				
-				this.setState({ user: user, xalians: xalians });
-			});
+			this.setState({ xalians: this.buildTeams() });
 		}
+	}
+
+	buildTeams = () => {
+		let details = this.props.gameDetails;
+		let xaliansPerTeam = details.numberOfPieces;
+
+		let allPieces = [];
+		let playerPieces = [];
+		let opponentPieces = [];
+
+		// the player's chosen real xalians, if any, go on team 0 first
+		let squad = (details.playerSquad || []).slice(0, xaliansPerTeam);
+		let squadIds = new Set(squad.map((x) => x.xalianId));
+		squad.forEach((x) => {
+			let transformed = duelPieceBuilder.buildDuelPiece(x);
+			allPieces.push(transformed);
+			playerPieces.push(transformed);
+		});
+
+		// copy the shared module array so shuffling/popping doesn't destroy it for later renders/games
+		let samples = [...retrievalUtil.getMockXalianList()].filter((s) => !squadIds.has(s.xalianId));
+		gsap.utils.shuffle(samples);
+
+		while (playerPieces.length < xaliansPerTeam && samples.length > 0) {
+			let sample = samples.pop();
+			if (sample) {
+				let transformed = duelPieceBuilder.buildDuelPiece(sample);
+				allPieces.push(transformed);
+				playerPieces.push(transformed);
+			}
+		}
+
+		while (opponentPieces.length < xaliansPerTeam && samples.length > 0) {
+			let sample = samples.pop();
+			if (sample) {
+				let transformed = duelPieceBuilder.buildDuelPiece(sample);
+				allPieces.push(transformed);
+				opponentPieces.push(transformed);
+			}
+		}
+
+		return { allPieces: allPieces, playerPieces: playerPieces, opponentPieces: opponentPieces };
 	}
 
 	// handleClick = (id) => {
@@ -116,48 +149,8 @@ class DuelPage extends React.Component {
 		);
 		// let xaliansPerTeam = duelConstants.XALIANS_PER_TEAM;
 
-		if (this.state.xalians && this.state.xalians.length > 0) {
-			let allPieces = [];
-			let playerPieces = [];
-			let opponentPieces = [];
-
-			// copy the shared module array so shuffling/popping doesn't destroy it for later renders/games
-			let samples = [...retrievalUtil.getMockXalianList()];
-			gsap.utils.shuffle(samples);
-
-			while (playerPieces.length < xaliansPerTeam && samples.length > 0) {
-				let sample = samples.pop();
-				if (sample) {
-					let transformed = duelPieceBuilder.buildDuelPiece(sample); 
-					allPieces.push(transformed);
-					playerPieces.push(transformed);
-				}
-			}
-
-			while (opponentPieces.length < xaliansPerTeam && samples.length > 0) {
-				let sample = samples.pop();
-				if (sample) {
-					let transformed = duelPieceBuilder.buildDuelPiece(sample); 
-					allPieces.push(transformed);
-					opponentPieces.push(transformed);
-				}
-			}
-
-
-
-
-				// IMPLEMENT ONCE YOU SETUP USING XALIANS FROM PLAYER'S FACTION
-			// this.state.xalians.forEach( x => {
-			// 	let transformed = this.transformXalianToGamePiece(x); 
-			// 	allPieces.push(transformed);
-			// 	playerPieces.push(transformed);
-			// })
-			// let opponentXalians = retrievalUtil.getMockXalianList();
-			// opponentXalians.forEach(x => {
-			// 	let transformed = this.transformXalianToGamePiece(x); 
-			// 	allPieces.push(transformed);
-			// 	opponentPieces.push(transformed);
-			// })
+		if (this.state.xalians) {
+			let { allPieces, playerPieces, opponentPieces } = this.state.xalians;
 
 			let teams = [];
 			teams.push(playerPieces.map(x => (x.xalianId)));

--- a/my-app/src/pages/games/duelStartPage.js
+++ b/my-app/src/pages/games/duelStartPage.js
@@ -29,7 +29,8 @@ class DuelStartPage extends React.Component {
 
     state = {
         randomizeStartingPositions: true,
-        debugMode: true
+        debugMode: true,
+        selectedXalianIds: []
     }
 
     // componentDidUpdate(prevProps, prevState) {
@@ -38,39 +39,52 @@ class DuelStartPage extends React.Component {
         // }
     // }
 
-    setGameDetails = (passedIn = null) => {
-        // let details = {
-        //     numberOfPieces: this.state.numberOfPieces,
-        //     players: this.state.players,
-        //     bot: this.state.players == 1 ? true : false,
-        //     randomizeStartingPositions: this.state.randomizeStartingPositions,
-        //     debugMode: this.state.debugMode
-        // };
+    setGameDetails = (playerSquad = null) => {
         let details = {
             numberOfPieces: this.state.numberOfPieces,
             players: 2,
             bot: this.state.players == 1 ? true : false,
             randomizeStartingPositions: this.state.randomizeStartingPositions,
-            debugMode: this.state.debugMode
+            debugMode: this.state.debugMode,
+            playerSquad: playerSquad
         };
-        this.setState({gameDetails: passedIn || details})
+        this.setState({gameDetails: details})
     }
 
     componentDidMount() {
-        // DEBUG
-        // this.setGameDetails({
-        //     numberOfPieces: 6,
-        //     players: 2,
-        //     bot: true,
-        //     randomizeStartingPositions: true
-        // });
+        retrievalUtil.getCurrentUserAndXalians()
+            .then((user) => {
+                if (user && user.xalians && user.xalians.length > 0) {
+                    this.setState({ userXalians: user.xalians.map((x) => x.attributes) });
+                }
+            })
+            .catch(() => {
+                // signed out or API unavailable — duel falls back to random squads
+            });
+    }
 
-        // this.setGameDetails({
-        //     numberOfPieces: 2,
-        //     players: 2,
-        //     bot: false,
-        //     randomizeStartingPositions: true
-        // });
+    handleStartClicked = () => {
+        if (this.state.userXalians && this.state.userXalians.length > 0) {
+            this.setState({ choosingSquad: true });
+        } else {
+            this.setGameDetails();
+        }
+    }
+
+    toggleXalianSelection = (xalianId) => {
+        this.setState((prev) => {
+            if (prev.selectedXalianIds.includes(xalianId)) {
+                return { selectedXalianIds: prev.selectedXalianIds.filter((id) => id !== xalianId) };
+            } else if (prev.selectedXalianIds.length < prev.numberOfPieces) {
+                return { selectedXalianIds: [...prev.selectedXalianIds, xalianId] };
+            }
+            return null;
+        });
+    }
+
+    startWithSelectedSquad = () => {
+        let squad = this.state.userXalians.filter((x) => this.state.selectedXalianIds.includes(x.xalianId));
+        this.setGameDetails(squad);
     }
 
 
@@ -87,6 +101,48 @@ class DuelStartPage extends React.Component {
         if (this.state.gameDetails) {
             return (
                 <DuelPage gameDetails={this.state.gameDetails} />
+            );
+        } else if (this.state.choosingSquad) {
+            let needed = this.state.numberOfPieces;
+            let selectedCount = this.state.selectedXalianIds.length;
+            let fillerCount = needed - selectedCount;
+            return (
+                <React.Fragment>
+                    <Container fluid className="content-background-container">
+                        <XalianNavbar></XalianNavbar>
+
+                        <div style={{ display: 'flex', flexDirection: 'column', justifyItems: 'center', maxWidth: '600px', margin: 'auto' }}>
+                            <h4 style={{ margin: 'auto', textAlign: 'center', marginTop: '25px', marginBottom: '10px' }}>Choose Your Squad ({selectedCount}/{needed}):</h4>
+
+                            <Row style={{ margin: 'auto', justifyContent: 'center' }}>
+                                {this.state.userXalians.map((x) => {
+                                    let selected = this.state.selectedXalianIds.includes(x.xalianId);
+                                    return (
+                                        <Col key={`squad-pick-${x.xalianId}`} xs={4} sm={3} style={{ padding: '5px' }}>
+                                            <a onClick={() => this.toggleXalianSelection(x.xalianId)} style={{ cursor: 'pointer' }}>
+                                                <div style={{ borderRadius: '10px', padding: '3px', border: selected ? '3px solid #4caf50' : '3px solid transparent', opacity: selected || selectedCount < needed ? 1 : 0.4 }}>
+                                                    <XalianImage colored bordered speciesName={x.species.name} primaryType={x.elements.primaryType} moreClasses="xalian-image-grid" />
+                                                    <h6 className="condensed-row" style={{ textAlign: 'center', marginTop: '5px', marginBottom: '0px' }}>{x.species.name}</h6>
+                                                    <p style={{ textAlign: 'center', fontSize: '8pt', marginBottom: '0px', opacity: 0.7 }}>#{x.xalianId.split('-').pop().substring(0, 8)}</p>
+                                                </div>
+                                            </a>
+                                        </Col>
+                                    );
+                                })}
+                            </Row>
+
+                            {selectedCount > 0 && fillerCount > 0 &&
+                                <p style={{ margin: 'auto', textAlign: 'center', marginTop: '10px', opacity: 0.7 }}>{fillerCount} remaining squad slot{fillerCount > 1 ? 's' : ''} will be filled randomly</p>
+                            }
+
+                            <div style={{ display: 'flex', justifyContent: 'center', gap: '20px', marginTop: '30px', marginBottom: '50px' }}>
+                                <Button onClick={() => this.setGameDetails()} size='lg' variant='xalianGray' style={{ width: 'fit-content' }}>Random Squad</Button>
+                                <Button onClick={this.startWithSelectedSquad} size='lg' disabled={selectedCount < 1} variant='xalianGreen' style={{ width: 'fit-content' }}>Enter Duel!</Button>
+                            </div>
+                        </div>
+
+                    </Container>
+                </React.Fragment>
             );
         } else {
             return (
@@ -159,9 +215,7 @@ class DuelStartPage extends React.Component {
 
                                 </div>
 
-                                <Button onClick={ () => {
-                                    this.setGameDetails();
-                                } }
+                                <Button onClick={this.handleStartClicked}
                                 size='lg' disabled={!this.state.players  || !this.state.numberOfPieces} variant='xalianGreen' style={{ width: 'fit-content', margin: 'auto', marginTop: '50px'}}>Start Duel!</Button>
                             </div>
 

--- a/my-app/src/utils/retrievalUtil.js
+++ b/my-app/src/utils/retrievalUtil.js
@@ -5,29 +5,16 @@ import mockUserData from '../json/mock/mockUserData.json';
 import mockXalianList from '../json/mock/mockXalianList.json';
 import xalianSamples from '../json/mock/xalianSamples.json';
 
+// resolves with the user record (xalians populated) when signed in, or null when signed out;
+// rejects if the API call itself fails
 export function getCurrentUserAndXalians() {
-    return new Promise((resolve) => {
-        try {
-            Auth.currentUserInfo().then((data) => {
-                if (data) {
-                    let u = authUtil.buildAuthState(data);
-                    let username = u.username;
-                    dbApi
-                    .callGetUser(username, true)
-                    .then((user) => {
-                        console.log(JSON.stringify(user, null, 2));
-                        resolve(user);
-                    })
-                    .catch((e) => {
-                       console.log(`ERROR : ${JSON.stringify(e, null, 2)}`);
-                    });
-                }
-            });
-        } catch (e) {
-          console.log("caught ERROR : " + e);
+    return Auth.currentUserInfo().then((data) => {
+        if (!data) {
+            return null;
         }
-      });
-    
+        let u = authUtil.buildAuthState(data);
+        return dbApi.callGetUser(u.username, true);
+    });
 }
 
 export function getMockCurrentUserAndXalians() {


### PR DESCRIPTION
## Milestone 1 of the duel roadmap: play with your own generated Xalians.

### What changed
- **Squad picker**: after choosing game settings, a signed-in player with saved Xalians gets a "Choose Your Squad" step — pick up to team-size creatures from your faction (remaining slots fill randomly), or take a fully random squad. Signed-out players go straight to a random duel exactly as before.
- **duelPage** now builds both teams once on mount from the chosen squad + random samples (chosen ids excluded from the random pool), instead of always drawing everything from mocks.
- **retrievalUtil.getCurrentUserAndXalians** rewritten as a real promise chain: resolves `null` when signed out, rejects on API failure (previously it could hang forever and swallowed errors).
- **Backend fix (prerequisite)**: `updateXalianUser`'s ADD/REMOVE_XALIAN_ID paths referenced an undefined `userId` (`ReferenceError` → 500), which broke saving a generated Xalian to your account — the very thing that populates the squad picker. Fixed to use `request.userId`, lowercased to match the retrieve path.
- **duelPieceBuilder** defaults `traits` when a saved xalian's species id isn't in `species.json` (old saved xalians could predate the current species list) instead of crashing.
- **Mock data fix**: `xalianSamples.json` had a "Hypnox" whose species (id 00008) was renamed to **Tizzie** in canon — the missing `hypnox.svg` hard-crashed the board whenever the random shuffle drew it. Sample updated to canon.

### Tested
- Production build passes.
- Browser-tested (dev server + devtools): picker renders with element-themed cards and selection cap; entered a duel and verified via DOM that the player's pieces are exactly the chosen xalian ids plus random fillers; signed-out flow goes straight to a working random 6v6 with no console errors beyond pre-existing warnings.
- The picker's real data path (`getCurrentUserAndXalians`) was exercised with the mock user record, which has the identical shape as the live `GET /db/user?populateXalians=true` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
