### PR TITLE
Run terraform plan on all PRs for auto-merge

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -10,15 +10,10 @@ on:
       - "outputs.tf"
       - "terraform/**"
       - ".github/workflows/deploy-backend.yml"
+  # no paths filter on PRs: "Terraform plan" is a required status check for
+  # auto-merge, so it must run (and pass) on every PR
   pull_request:
     branches: [master]
-    paths:
-      - "lambda/**"
-      - "main.tf"
-      - "variables.tf"
-      - "outputs.tf"
-      - "terraform/**"
-      - ".github/workflows/deploy-backend.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Auto-merge-on-green is now enabled for the repo, with master protected by two required status checks: **Build frontend** and **Terraform plan**. A required check that is path-filtered never completes on PRs that do not touch its paths, which would block those PRs from auto-merging — so the plan job now runs on every PR (~30s). The apply on master pushes keeps its path filter and still only runs for backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)