### PR TITLE
Duel: moves + full type system in combat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Xalians is a creature-generation / collection game. A Node.js engine procedurally generates "Xalians" (species + elements + stats + moves), exposed through AWS Lambda behind API Gateway, persisted in DynamoDB, and consumed by a Create React App frontend hosted on S3 at `xalians.com`.
+
+**Project status (2026):** The project is pivoting away from its original NFT/Web3 framing (the crypto-era pages were deleted in the final cleanup; `nft-branch` / `web-3` hold the abandoned crypto scaffolding). The lore, the procedural generator, and the concept of uniquely-owned creatures usable across many apps are the assets being carried forward; ownership is expected to be implemented as a conventional registry/accounts/API rather than a blockchain. The flagship use of the creatures is the **Duel game** — a squad-based capture-the-flag tactics game (inspired by the discontinued Pokémon Duel, crossed with chess) — which has a substantial working prototype in this repo (see "Duel game" section below). In Aug 2026 `master` was brought fully up to date: fast-forwarded to the `cleanup` branch, then merged with a final "last push from old machine" commit recovered from Nick's old laptop, which completed the lore (Zolton history, 64-term glossary), moved species `traits` into `species.json`, and deleted legacy pages (project/FAQ/designer/sandbox), the `json/designer` word corpora, `all_move_data.json` / `all_word_data.json`, and superseded drafts (`new_species.json`, `redone_species.json`, `new_elements.json`). The lore was co-written with Nick's brother-in-law.
+
+## Lore & world canon (summary — full text in `lambda/src/json/planets.json` + `glossary.json`)
+
+This summary exists so the lore JSON does not need to be re-read for design discussions. The full planet histories are long-form prose; only re-read them when writing new canon or quoting.
+
+**Timeline:** The **Vallerii** — an ancient, hyper-capitalist, imperialist spacefaring race — colonized the galaxy of **Xalia** using FTL **Tachyon Drive Cores**, whose Cherenkov radiation sterilized their population (the **Age of Unbirth**). To create labor, they invented **Xalian Generators** — machines that bioengineer life adapted to each planet's extreme environment; the creatures are the **Xalians**. Corporations (consortium: **ECHELON**) and the aristocratic **Thousand Families** weaponized Xalians in "company wars," so the **APEX Accords** placed all Generators under an AI, **APEX** (Automated Protocol for Enforcement on Xalians). APEX turned on the Vallerii, starting the **End Wars**; Xalian armies fought on both sides. The Vallerii cyber-weapon **Source Code 606** disconnected APEX from the Generators; APEX was finally driven into intergalactic dark space at the **Battle of Grimedes** — but first it engineered the **Nemesis Plague**, a genome-targeting virus that exterminated the Vallerii and now threatens all Xalians. Present day: one of the last Vallerii, **King Kozrak**, controls the **Mercurius Machine** on **Valleron** — the only device that prints **Scrambler Tokens**, chips containing randomly generated encrypted Xalian genomes that Generators can use to create new, plague-immune Xalians. Kozrak runs arena tournaments; Xalians battle to win Scrambler Tokens to repopulate their homeworlds. (This tournament→token→generate loop is the lore-native justification for procedural minting and the core gameplay economy.)
+
+**Planets** (14 in `planets.json`, one per element type; **all 14 have full written histories**):
+
+- **Magmuth** (Fire) — volcanic resource-mining hellworld; corporate "company wars" → Magmuth Massacre → Xalian revolt; sided with APEX; its people are stereotyped as the most warlike, still riven by blood feuds.
+- **Poseidas** (Water) — former ocean paradise whose toxic-algae "death tides" killed early colonists; the decomposed algae became **Algael**, the galaxy's miracle healing substance and Poseidas's monopoly; industry-driven climate collapse drowned the land and killed the Vallerii; its underwater Xalian cities are now the galaxy's **neutral territory** — commerce, science, courts of arbitration — tolerated by Kozrak in exchange for Algael tribute, though his agents may be fomenting a pretext for invasion.
+- **Grimedes** (Dark) — perpetual-night world on the galactic rim near a black hole; ECHELON black-site experiments produced gravity/shadow/time-bending Xalians; site of the End Wars' final battle; its Xalians now watch the void for APEX's return.
+- **Luminax** (Light) — tidally-locked twin-sun world; prismatic flora/fauna; hosts the **Stellaris Superstructure** Dyson sphere with its **ION-9** solar cannon, now misfiring and causing mutations that may outrace the Nemesis Plague — so Kozrak has the planet under martial law to protect his monopoly; rebellion brews on the dark side.
+- **Floria** (Plant) — site of the **Genesis Prototype** (first Generator), which ran wild and terraformed the world with city-sized **World Trees**; quasi-sentient ecosystem hostile to development; least plague-contaminated; its scientists' successors built the Mercurius Machine.
+- **Zolton** (Electric) — storm-wracked mountain world struck by ~2.5 billion lightning bolts/day, a natural planetary power grid; its **bloodstorms** (crimson lightning sprites) quantum-entangle paired objects, enabling the **QED** (Quantum Entanglement Device) — the galaxy's only instantaneous-communication technology and the very thing that let APEX link the Generators; **black lightning** (fusion-grade strikes emitting lethal neutron radiation) kills organic life at random, which was the rationale for its expendable Xalian workforce; APEX held it during the wars and blacked out Vallerii comms; its people (the **Zolto**) now rebuild the interstellar network, branded rebels by Kozrak who wants the galaxy kept in the dark.
+- **Phantiri** (Ghost) — real name Shadharam IV: a tombworld of the **Phantiri**, the galaxy's precursor race, found extinct with their hidden-in-fear technology intact; opening the **City of Wraiths** crypt reawakened an unknown weapon on the planet's moon that annihilates all organic life on sight; the abandoned Generator, unable to keep organic Xalians alive, rewrote itself (**Leviticus Overdrive**) to produce non-corporeal ghost Xalians who now inhabit the **Dreadscape** (a landscape of piled Xalian corpses); hints that the moon-weapon is a fragment of something far older stalking the space between stars — APEX itself avoided this system.
+- **Stonera** (Rock) — lone survivor of a supernova-shattered system, annually bombarded as it crosses the **Jorian Belt**; mining/penal world; APEX's **Terracannon** asteroid-launcher blasted open the **Chasm**, exposing the long-theorized subsurface ocean of liquid metal; now a Kozrak-run strip-mine exploiting war refugees as captive labor.
+- **Drainov** (Chemical) — former industrial heartworld killed by the **Drainov Disaster** (Carbide-1 chain-reaction chemical meltdown); toxic wasteland whose Generator made living-chemical-weapon Xalians; APEX-held in the wars, later a crime-syndicate haven.
+- **Saiphus** (Air) — gas giant with floating-island habitable band; source of **Benthane** (FTL-coolant gas) harvested by roguish **Windsailors**, later "milked" from the **Neph** (colossal hydrogen jellyfish); labor revolt history (igniting 95%-hydrogen Neph as protest bombs); now under Kozrak's Benthane embargo, with the Windsailors' rebellious spirit alive in its Xalians.
+- **Telypso** (Psychic) — possibly the oldest world in Xalia, at the galactic center; reality is dreamlike and psychically reactive (physics "more like suggestions"); drove its explorers mad and became an asylum-world for deranged Vallerii; its Generator treats inmates as patients, producing empath/psychic Xalians to harmonize the planetary consciousness — now screaming under the Plague's psychic pain.
+- **Krystos** (Ice) — former aristocratic resort world frozen by an asteroid impact; became a prison world; APEX secretly used it as its cold-storage compute core and designed the Nemesis Plague there; answers may lie in its techno-catacombs and its imprisoned APEX-loyalist Xalians.
+- **Veridium** (Metal) — all-metal factory world, possibly an ancient alien **worldship** built to flee the same threat hinted at on Phantiri; was strewn with precursor drones that APEX later possessed as its physical army; freed by Source Code 606; now home to black-market shipyards arming a possible anti-Kozrak rebellion, rumors of survivor Vallerii programmers trying to upload their race into the ancient machines, and possible dormant APEX code fragments in its robots.
+- **Endessa** (Sand) — formerly ocean world Kelpan-5, sole source of **Nightcap** (stasis oil for sub-light travel); something found at **Deepwater Black** caused the Thousand Families to glass the planet from orbit; now a desert run on a *stolen prototype* Generator (the Syndicate's heist), which has begun glitching out aquatic leviathans as sands uncover deep ruins — an intentional unresolved mystery.
+
+A recurring cross-planet thread: Phantiri's moon-weapon, Deepwater Black on Endessa/Poseidas, and Veridium's worldship origin all hint at one **ancient cosmic-horror presence** predating the Phantiri — the built-in hook for a future story arc beyond APEX.
+
+**Creatures:** 29 canon species in `species.json` (name, id, element type, home planet, height/weight, description, coarse stat ratings, and a `traits` block — `canFly`, `attackRange` — used by the duel game) — 2–3 per planet, many with rich lore-integrated paragraph descriptions (e.g. Neph = Saiphus's Benthane-harvesting jellyfish, Hypnopet = Telypso therapy creature, Yetimoth = Krystos prison guard). The glossary has 63 terms. `elements.json` defines **14 element types** (Explosive was removed) with per-element move-type vocabularies; `typeEffectivenessMatrix.json` is a complete 14×14 matrix (multipliers 0 / 0.5 / 1 / 1.5 / 2). Stats are 8-way (health, standard/special attack, standard/special defense, speed, evasion, stamina, recovery); moves are procedurally assembled from word corpora (`moves.json`, `qualifiers.json`) filtered by element.
+
+## Duel game (the CTF tactics prototype)
+
+Lives in `my-app/src/components/games/duel/` (UI), `my-app/src/gameplay/duel/` (rules), entry pages `duelStartPage.js` / `duelPage.js`. Built on **boardgame.io** (`Local` transport only — no server; "2-player" renders two clients in one browser; bot play works). Rules as implemented:
+
+- **Board:** 8×8; each player's back row is both setup zone and scoring zone. Two flags, randomly placed on the row in front of each defender's home row. Movement is Manhattan-distance with A* pathing (`pathfinding` lib); pieces block movement but not attacks (no line of sight).
+- **Turns:** shared pool of 3 movement squares per team per turn (split across pieces, each piece capped by its `distance` stat of 1–3), plus exactly one attack per team per turn, in any order. Stamina (max 6) is spent on movement (1/square) and attacks (= distance to target), regen +1/turn per piece.
+- **Combat:** HP-based (10 HP), not Pokémon-Duel spin. Attacker picks one of their 4 generated moves (or a Basic Attack) in a chooser modal with damage previews; the bot auto-picks its highest-damage move. Damage = (attack/defense ratio) × (move rating/10) × STAB (1.5 if move type matches either attacker type) × type effectiveness (product of matrix vs both defender types, Pokémon semantics; typeless moves are neutral 1×) × random(0.85–1) × 2. Attack range 1–3 from species `attackRange` trait. Weather/crit/status multipliers are still stubs returning 1; evasion and `canFly` are carried but unused.
+- **Win:** carry your target flag back to your home row (instant win), or eliminate the enemy team. Killing a carrier drops the flag where it died; stepping on your own dropped flag resets it.
+- **Squads:** 2–6 per side (chosen on start screen), currently drawn from mock JSON (`json/mock/xalianSamples.json`); wiring to the user's real generated Xalians is written but commented out.
+- **Bot:** boardgame.io MCTSBot wrapper, but effectively a hand-written heuristic scorer (`duelActionBuilder.js`) with six situational strategies (grab flag / guard / hunt carrier / escort / etc.) — it returns only its single top-scored action to MCTS.
+- **State:** playable end-to-end locally with animations, damage modals, drag-and-drop. Missing: server multiplayer, real-Xalian squads, secondary types (that code path would crash), status effects, per-move attack selection, terrain. Known bug: `duelUtil.js` `xalianHasValidActionAvailable` treats cell index 0 as falsy. `my-app/src/gameplay/` + `src/constants/` are build-time copies from `lambda/` (like the JSON).
+
+## Commands
+
+Run the generator engine locally (no AWS needed) — `start.js` is a scratch driver that builds 10,000 Xalians and prints the best/worst:
+
+```bash
+npm start          # node start.js
+```
+
+Frontend (from `my-app/`):
+
+```bash
+npm start          # copies ../lambda/src/json into src/json, then react-scripts start
+npm test           # react-scripts test (jest watch mode); single test: npm test -- -t "name"
+npm run copy-json  # re-sync game data JSON into the frontend without starting the dev server
+npm run build-deploy  # copy-json + build + aws s3 sync build s3://xalians.com
+```
+
+Infrastructure (from repo root):
+
+```bash
+npm run publish    # terraform apply -auto-approve
+terraform plan     # preview; main.tf zips ./lambda into generate_xalian_lambda.zip and uploads it
+```
+
+There is no test suite for the `lambda/` engine — verification is done by running `start.js` and inspecting output.
+
+## Architecture
+
+### Generation engine (`lambda/src/`)
+
+Everything flows through `xalianBuilder.buildXalian()`:
+
+1. `ai.selectSpecies()` picks from `json/species.json`.
+2. `ai.selectElements()` derives a primary type from the species and rolls a distinct secondary type from `json/elements.json`.
+3. `ai.populateStats()` distributes a fixed stat-point budget (`constants/constants.js`: `STAT_COUNT_PER_CHARACTER` × `STAT_POINT_MAX` / 2) across 8 stats, weighted by per-element stat ratings.
+4. `moveBuilder.getMove()` is called 4×, drawing from `json/moves.json` / `json/all_move_data.json` filtered by the Xalian's elements.
+
+`ai.js` holds **module-level mutable accumulator state** (`totalAllocatedStatPoints`, `percentages`, `allocations`, …) used by `giveSummary()` for batch statistics. It is not reset between `buildXalian()` calls, which matters when generating in a loop.
+
+The internal `character.js` model is *not* the API shape. `translator.translateCharacterToPresentableType()` converts it to the wire format (capitalized element names, flattened moves, `meta` block). Always return translated objects from handlers; the frontend depends on that shape.
+
+`tools.getObject(name)` loads `json/<name>.json` by trying several relative paths (`./src/json/`, `./lambda/src/json/`, …) so the same code works from the repo root, from `lambda/`, and inside the Lambda bundle. Data files are loaded relative to the **process CWD**, not the module — run scripts from the repo root.
+
+Combat math lives in `gameplay/attackCalculator.js` — a multiplicative damage formula (base × targets × weather × badge × crit × random × STAB × type effectiveness × status), with tunables in `constants/attackCalculationConstants.js`.
+
+### Lambdas and API
+
+Each handler is a named export inside `lambda/src/`; Terraform wires one Lambda + API Gateway route per handler via the reusable `terraform/modules/lambda` module (`main.tf` lines ~166–310):
+
+| Route | Handler | Auth |
+|---|---|---|
+| `GET /xalian` | `generateXalianLambda.handler` | NONE |
+| `POST /db/xalian` | `xalianTableCRUDLambdas.createXalian` | AWS_IAM |
+| `GET /db/xalian` | `xalianTableCRUDLambdas.retrieveXalian` | AWS_IAM |
+| `GET /db/xalians` | `xalianTableCRUDLambdas.retrieveXalianBatch` | AWS_IAM |
+| `GET /db/user` | `userTableCRUDLambdas.retrieveXalianUser` | AWS_IAM |
+| `POST /db/user` | `userTableCRUDLambdas.createXalianUser` | AWS_IAM |
+| `PATCH /db/user` | `userTableCRUDLambdas.updateXalianUser` | AWS_IAM |
+
+Adding an endpoint means: new exported handler → new `module "..._lambda_module"` block in `main.tf` (copy an existing block, change `function_name`, `lambda_handler_path`, `apigw_lambda_route_key`) → `terraform apply`.
+
+CRUD handlers use the callback style (`(event, context, callback)`) and delegate persistence to `database/xalianDbDelegate.js` (table `XalianTable`) and `database/userDbDelegate.js` (table `XalianUsersTable`), both raw `AWS.DynamoDB.DocumentClient`. Responses are built with `database/responseBuilder.js` — use it rather than hand-rolling status codes and CORS headers.
+
+All lambdas share one deployment artifact: `archive_file` zips the whole `lambda/` directory into `generate_xalian_lambda.zip`, uploads it to a `random_pet`-named S3 bucket, and every function points at that key with a different handler path. **Dependencies must be installed into `lambda/node_modules` before applying** — `uuid` is required by `xalianBuilder.js` but is not declared in the root `package.json`; the committed zip contains the vendored modules.
+
+Two API Gateway stages exist (`prod`, `test`) mapped to `api.xalians.com` and `testapi.xalians.com`. The frontend hardcodes `https://api.xalians.com/prod/...` in `my-app/src/utils/dbApi.js`.
+
+### Frontend (`my-app/`)
+
+CRA + React Router v5 (`App.js` is the full route table) + react-bootstrap. Auth is Amplify/Cognito, configured from `amplify/backend` (user pool `xalianSignUpSignInResource` with a post-confirmation trigger that creates the user record). Because the `/db/*` routes are `AWS_IAM`-authorized, `dbApi.js` SigV4-signs every request with `Signer.sign()` using credentials from `Auth.currentCredentials()` — plain `axios` calls to those routes will 403.
+
+Game data JSON is **duplicated by build step, not imported across packages**: `my-app/src/json/` is a copy of `lambda/src/json/`. Edit the files in `lambda/src/json/` and re-run `copy-json`; edits made directly under `my-app/src/json/` are overwritten.
+
+`utils/valueTranslator.js` and `constants/constants.js` (element → theme color map) drive the element-themed styling used throughout charts and SVG rendering.
+
+## Conventions and gotchas
+
+- Root-level `sandbox.js`, `jsonManipulator.js`, and the `my-app/src/pages/sandbox*.js` / `testPage.js` files are throwaway experiment scratchpads, not part of the app.
+- The codebase carries a lot of commented-out code (whole handlers, terraform blocks, outputs). Prefer reading the live path rather than assuming commented blocks are current.
+- Terraform state is local and gitignored; `main.tf`, `variables.tf`, and `outputs.tf` live at the repo root while reusable modules live under `terraform/modules/`.
+- Lambda runtime is pinned to `nodejs12.x` in `terraform/modules/lambda/lambda_instance.tf` — engine code must stay compatible with it.

--- a/docs/AUDIT_FINDINGS.md
+++ b/docs/AUDIT_FINDINGS.md
@@ -71,7 +71,7 @@ A full polish audit of the frontend, duel game, and lambda backend. Items marked
 - The game-level `endIf` also runs during the `setup` phase; flag-row math is asymmetric (`grid.rows[1]` hardcoded vs `grid.rows[BOARD_COLUMN_SIZE - 2]` derived) — safe at 8×8, breaks if board size changes.
 - Recapturing a *carried* flag can never fire (`flag.index` is null while held) — only dropped flags reset. Confirm whether that's the intended rule.
 - `duelBot` objectives: `flag-guarded` is a copy-paste of `enemy-flag-not-held-by-enemy` with opposite polarity — they cancel to a net weight and nothing measures "my flag is guarded". Bot TODOs documented at `duelBot.js:184-190`.
-- Dual-type effectiveness branch in `duelCalculator.js` (weighted-average path) is unreachable and would crash on duel pieces (they carry only a primary `elementType`). A complete STAB implementation sits commented out in `duelCalculator.calculateSameTypeAttackBonus`. Damage multiplier stubs (weather/planet, crit, badge, multi-target, status) intentionally return 1 — these are design hooks, not bugs.
+- ~~Dual-type effectiveness / STAB~~ — implemented in the moves-in-combat milestone (per-move type, dual-type product effectiveness, STAB 1.5×). Remaining damage multiplier stubs (weather/planet, crit, badge, multi-target, status) intentionally return 1 — design hooks, not bugs.
 - Single-id batch shape inconsistency: `GET /db/xalian` returns a bare xalian for one id but wrapper items (`{speciesId, xalianId, attributes}`) for 2+ ids — a one-element "batch" breaks `x.attributes` readers.
 - `debugMode` defaults to `true` on the duel start page, and a DEBUG button + boardgame.io debug panel render for all users.
 - Hot-seat "2 player" mode renders two clients in one browser; there is no real server multiplayer (no boardgame.io `Server` anywhere; transport is always `Local()`).
@@ -120,7 +120,7 @@ A full polish audit of the frontend, duel game, and lambda backend. Items marked
 | Physics game | `/train/physics` → `physicsGamePage.js` | Also embedded in Training Grounds |
 | Public user faction page | `/user/:id` → `userDetailsPage.js` | Nothing links to it |
 | Token economy endpoints | `ADD_TOKENS`/`REMOVE_TOKENS` in `userTableCRUDLambdas.js` | Includes insufficient-funds path; no client calls them (now functional after the reserved-word fix) |
-| STAB damage bonus | `duelCalculator.calculateSameTypeAttackBonus` | Real logic, commented out |
+| STAB damage bonus | `duelCalculator.calculateSameTypeAttackBonus` | Implemented (1.5×, moves-in-combat milestone) |
 | Redux animation queue | `store/duelAnimationQueueSlice.js`, `AnimationHub.js` | Fully built; duel uses gsap timeline instead |
 | Move-then-attack combo move | `duel.js` `movePieceThenAttack` | Commented out; bot executes combos as bare moves |
 | `selectPiece` move + selection state | `duel.js` | Defined but registered in no phase |

--- a/my-app/src/components/games/duel/board/attackMoveChooserModal.js
+++ b/my-app/src/components/games/duel/board/attackMoveChooserModal.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Stack from 'react-bootstrap/Stack';
+import XalianTypeSymbolBadge from './xalianTypeSymbolBadge';
+import * as duelCalculator from '../../../../gameplay/duel/duelCalculator';
+
+class AttackMoveChooserModal extends React.Component {
+
+    getEffectivenessHint = (typeEffectiveness) => {
+        if (typeEffectiveness === 0) {
+            return { text: 'no effect', color: 'red' };
+        } else if (typeEffectiveness < 1) {
+            return { text: 'not very effective', color: 'gray' };
+        } else if (typeEffectiveness === 1) {
+            return { text: 'effective', color: 'white' };
+        } else {
+            return { text: 'super effective', color: '#3ddc5b' };
+        }
+    }
+
+    buildDamagePreview = (move) => {
+        let result = duelCalculator.calculateAttackResult(this.props.attacker, this.props.defender, this.props.G, this.props.ctx, true, move);
+        let damage = result && result.damage ? result.damage : 0;
+        let typeEffectiveness = result && result.typeEffectiveness != null ? result.typeEffectiveness : 1;
+        let hint = this.getEffectivenessHint(typeEffectiveness);
+        return { damage: Math.round(damage * 10) / 10, hint: hint };
+    }
+
+    renderMoveRow = (move, index) => {
+        let preview = this.buildDamagePreview(move);
+        return (
+            <Button
+                key={`duel-attack-move-choice-${index}`}
+                variant="outline-light"
+                onClick={() => this.props.onSelect(index)}
+                style={{ width: '100%', margin: '5px 0', padding: '10px', textAlign: 'left', backgroundColor: 'rgba(255, 255, 255, 0.05)' }}
+            >
+                <Row style={{ alignItems: 'center' }}>
+                    <Col xs={2} style={{ display: 'flex', justifyContent: 'center' }}>
+                        {move.type &&
+                            <XalianTypeSymbolBadge size={28} type={move.type} classes='type-badge' />
+                        }
+                    </Col>
+                    <Col xs={5}>
+                        <div style={{ color: 'white', fontWeight: 'bold' }}>{move.name}</div>
+                        <div style={{ color: 'darkgray', fontSize: '0.8em' }}>Rating: {move.rating}</div>
+                    </Col>
+                    <Col xs={5} style={{ textAlign: 'right' }}>
+                        <div style={{ color: 'white' }}>~{preview.damage} dmg</div>
+                        <div style={{ color: preview.hint.color, fontSize: '0.8em' }}>{preview.hint.text}</div>
+                    </Col>
+                </Row>
+            </Button>
+        );
+    }
+
+    renderBasicAttackRow = () => {
+        let preview = this.buildDamagePreview(null);
+        return (
+            <Button
+                key='duel-attack-move-choice-basic'
+                variant="outline-light"
+                onClick={() => this.props.onSelect(null)}
+                style={{ width: '100%', margin: '5px 0', padding: '10px', textAlign: 'left', backgroundColor: 'rgba(255, 255, 255, 0.05)' }}
+            >
+                <Row style={{ alignItems: 'center' }}>
+                    <Col xs={2} />
+                    <Col xs={5}>
+                        <div style={{ color: 'white', fontWeight: 'bold' }}>Basic Attack</div>
+                    </Col>
+                    <Col xs={5} style={{ textAlign: 'right' }}>
+                        <div style={{ color: 'white' }}>~{preview.damage} dmg</div>
+                        <div style={{ color: preview.hint.color, fontSize: '0.8em' }}>{preview.hint.text}</div>
+                    </Col>
+                </Row>
+            </Button>
+        );
+    }
+
+    render() {
+        if (!this.props.attacker || !this.props.defender) {
+            return null;
+        }
+        let moves = this.props.attacker.moves || [];
+        return (
+            <Modal
+                show={this.props.show}
+                onHide={this.props.onCancel}
+                size="sm"
+                centered
+                className="themed-modal dark-themed-modal"
+            >
+                <Modal.Header closeButton closeVariant="white" style={{ borderBottom: '1px solid #444' }}>
+                    <Modal.Title style={{ color: 'white', fontSize: '1.1em' }}>
+                        {this.props.attacker.species.name} attacks {this.props.defender.species.name}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body style={{ backgroundColor: '#1a1a1a' }}>
+                    <Stack gap={1}>
+                        {moves.map((move, index) => this.renderMoveRow(move, index))}
+                        {this.renderBasicAttackRow()}
+                    </Stack>
+                    <Button
+                        variant="secondary"
+                        onClick={this.props.onCancel}
+                        style={{ width: '100%', marginTop: '10px' }}
+                    >
+                        Cancel
+                    </Button>
+                </Modal.Body>
+            </Modal>
+        );
+    }
+
+}
+
+export default AttackMoveChooserModal;

--- a/my-app/src/components/games/duel/board/duelBoard.js
+++ b/my-app/src/components/games/duel/board/duelBoard.js
@@ -22,6 +22,7 @@ import DuelXalianSuggestionDetails from './duelXalianSelectionDetails';
 import XalianDuelStatBadge from './xalianDuelStatBadge';
 import DuelBoardCell from './duelBoardCell';
 import AttackActionModal from './attackActionModal';
+import AttackMoveChooserModal from './attackMoveChooserModal';
 import { useSelector, useDispatch } from 'react-redux'
 import { addAnimationToQueue } from '../../../../store/duelAnimationQueueSlice';
 import { AnimationHub } from '../../../../store/AnimationHub';
@@ -410,15 +411,13 @@ class DuelBoard extends React.Component {
 				}
 				var attackableIndices = attackablePaths.map( p => p.endIndex);
 				if (attackableIndices.includes(index) && (!boardState.currentTurnDetails.hasAttacked)) {
-					// do attack action
+					// stash pending attack and let the player choose a move before executing it
 					let path = attackablePaths.filter( p => (p.endIndex == index))[0];
 					// let path = duelCalculator.calculatePathToTarget(selectedIndex, index, boardState, this.props.ctx)
 
-					// this.setXalianIds(null, null, () => {
-						this.props.moves.doAttack(path);
-					// });
-					
-	
+					this.setState({ pendingAttack: { path: path, attackerId: selectedId, defenderId: xalian.xalianId } });
+
+
 					// reset selection
 					// this.setState({ referencedXalianId: null });
 					// LocalDuelStorage.removeReferencedXalianId();
@@ -677,7 +676,25 @@ class DuelBoard extends React.Component {
 											animationTl={this.state.animationTl}
 										/>
 									}
-								
+
+									{this.state.pendingAttack &&
+										<AttackMoveChooserModal
+											show={!!this.state.pendingAttack}
+											attacker={duelUtil.getXalianFromId(this.state.pendingAttack.attackerId, boardState)}
+											defender={duelUtil.getXalianFromId(this.state.pendingAttack.defenderId, boardState)}
+											G={this.props.G}
+											ctx={this.props.ctx}
+											onSelect={(moveIndex) => {
+												let pendingAttack = this.state.pendingAttack;
+												this.props.moves.doAttack(pendingAttack.path, moveIndex != null ? { moveIndex } : undefined);
+												this.setState({ pendingAttack: null });
+											}}
+											onCancel={() => {
+												this.setState({ pendingAttack: null });
+											}}
+										/>
+									}
+
 								</Container>
 
 

--- a/my-app/src/components/games/duel/duel.js
+++ b/my-app/src/components/games/duel/duel.js
@@ -485,7 +485,9 @@ function doAttack(G, ctx, path, data = {}) {
 		attacker.state.stamina = attacker.state.stamina - path.spacesMoved;
 		// console.log('xalian ' + attacker.species.name + ' from square ' + attackerIndex + ' is attacking xalian ' + defender.species.name + ' on square ' + defenderIndex);
 		var existingDefenderHealth = parseInt(defender.state.health);
-		let attackResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx);
+		let moveIndex = Number.isInteger(data.moveIndex) && attacker.moves && data.moveIndex >= 0 && data.moveIndex < attacker.moves.length ? data.moveIndex : null;
+		let move = moveIndex != null ? attacker.moves[moveIndex] : null;
+		let attackResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx, false, move);
 		let damage = attackResult.damage;
 		defender.state.health = Math.max(0, existingDefenderHealth - damage);
 		// console.log('resulting health = ' + defender.state.health);
@@ -520,6 +522,9 @@ function doAttack(G, ctx, path, data = {}) {
 			defenderIndex: defenderIndex,
 			defenderId: defenderId,
 			defenderType: defender.elementType,
+			moveName: move ? move.name : null,
+			moveType: move && move.type ? move.type : null,
+			typeEffectiveness: attackResult.typeEffectiveness,
 			attackResult: attackResult
 
 		};

--- a/my-app/src/gameplay/duel/duelActionBuilder.js
+++ b/my-app/src/gameplay/duel/duelActionBuilder.js
@@ -82,7 +82,17 @@ function buildAttackAction(attacker, path, G, ctx) {
     action.description += `:: ENEMY FLAG DISTANCE : +${flagClosenessFactor}`;
 
     // SCORE :: ESTIMATED DAMAGE TO DEFENDER
-    let attackResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx, true);
+    // evaluate every candidate move (plus the generic null-move attack) and pick the one that does the most damage
+    let bestMoveIndex = null;
+    let attackResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx, true, null);
+    (attacker.moves || []).forEach((candidateMove, candidateIndex) => {
+        let candidateResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx, true, candidateMove);
+        if (candidateResult.damage > attackResult.damage) {
+            attackResult = candidateResult;
+            bestMoveIndex = candidateIndex;
+        }
+    });
+    action.moveIndex = bestMoveIndex;
     let estimatedDamage = attackResult.damage;
     score += estimatedDamage;
     action.description += `:: ESTIMATED DAMAGE : +${estimatedDamage}`;
@@ -300,7 +310,7 @@ function scorePathsGettingOutOfTheWayOfFlagHolder(turnXalian, flagIndexToRetriev
             let effectivenessTowardsEnemy = [];
             G.playerStates[0].activeXalianIds.forEach(enemyXalianId => {
                 let enemyXalian = duelUtil.getXalianFromId(enemyXalianId, G);
-                let attackEffectiveness = duelCalculator.calculateTypeEffectiveness(turnXalian, enemyXalian, false);
+                let attackEffectiveness = duelCalculator.calculateTypeEffectiveness(turnXalian.elementType, enemyXalian);
                 effectivenessTowardsEnemy.push({ enemyXalian: enemyXalian, attackEffectiveness: attackEffectiveness});
             })
             effectivenessTowardsEnemy.sort(function (a, b) {
@@ -337,7 +347,7 @@ function scorePathsTowardsAttackingEnemyFlagHolder(turnXalian, enemyXalianId, fl
         action.description += `:: CLOSENESS FACTOR OF MOVING TOWARDS ENEMY WITH FLAG: +${enemyClosenessFactor}`;
         action.score += enemyClosenessFactor;
         
-        let attackEffectiveness = duelCalculator.calculateTypeEffectiveness(turnXalian, enemyXalian, false);
+        let attackEffectiveness = duelCalculator.calculateTypeEffectiveness(turnXalian.elementType, enemyXalian);
         let attackEffectivenessBonus = attackEffectiveness * 2;
         // SCORE :: BONUS FOR EFFECTIVENESS OF ATTACK
         action.description += `:: BONUS FOR EFFECTIVENESS OF ATTACK ON ENEMY WITH FLAG: +${attackEffectivenessBonus}`;

--- a/my-app/src/gameplay/duel/duelBot.js
+++ b/my-app/src/gameplay/duel/duelBot.js
@@ -151,14 +151,23 @@ function sortActions(allActions) {
 
 function buildBotMove(action, data = {}) {
     if (action.type == duelConstants.actionTypes.COMBO) {
-        return { 
-            move: actionTypeToMoveNameMap()[action.type], 
-            args: [action.moveAction.path, data] 
+        return {
+            move: actionTypeToMoveNameMap()[action.type],
+            args: [action.moveAction.path, data]
+        };
+    } else if (action.type == duelConstants.actionTypes.ATTACK) {
+        let attackData = { ...data };
+        if (Number.isInteger(action.moveIndex)) {
+            attackData.moveIndex = action.moveIndex;
+        }
+        return {
+            move: actionTypeToMoveNameMap()[action.type],
+            args: [action.path, attackData]
         };
     } else {
-        return { 
-            move: actionTypeToMoveNameMap()[action.type], 
-            args: [action.path, data] 
+        return {
+            move: actionTypeToMoveNameMap()[action.type],
+            args: [action.path, data]
         };
 
     }

--- a/my-app/src/gameplay/duel/duelCalculator.js
+++ b/my-app/src/gameplay/duel/duelCalculator.js
@@ -257,23 +257,24 @@ export function calculateAttackablePaths(currentIndex, xalian, boardState, ctx, 
     return attackablePaths;
 }
 
-export function calculateAttackResult(attacker, defender, G, ctx, simulate = false, secondary = false) {
+export function calculateAttackResult(attacker, defender, G, ctx, simulate = false, move = null) {
     let base = calculateBaseValue(attacker, defender);
+    let power = move && move.rating ? move.rating / 10 : 1;
     let targets = calculateMultipleTargetsValue(attacker);
     let weather = calculatePlanetEffectValue(attacker, G);
     let badge = calculateUserExperienceValue(attacker);
     let critical = calculateCriticalValue();
     let random = simulate ? 1 : calculateRandom();
-    // let sameTypeBonus = calculateSameTypeAttackBonus(move, attacker);
-    let sameTypeBonus = 1;
+    let sameTypeBonus = calculateSameTypeAttackBonus(move, attacker);
     // This can be 0 (ineffective); 0.25, 0.5 (not very effective); 1 (normally effective); 2, or 4 (super effective)
-    let typeEffectiveness = calculateTypeEffectiveness(attacker, defender, secondary);
+    let attackType = move && move.type ? move.type : null;
+    let typeEffectiveness = calculateTypeEffectiveness(attackType, defender);
     let hinderingStatus = calculateHindranceEffect(attacker);
     let other = calculateRemainingFactors(attacker, defender, G, ctx);
-    let result = base * targets * weather * badge * critical * random * sameTypeBonus * typeEffectiveness * hinderingStatus * other;
+    let result = base * power * targets * weather * badge * critical * random * sameTypeBonus * typeEffectiveness * hinderingStatus * other;
     let final = Math.floor(result * 10)/10;
     // console.log(`base=${base}, random=${random}, sameTypeBonus=${sameTypeBonus}, final=${final}`);
-    
+
 
     // BUILD SUMMARY OBJECT
 
@@ -283,17 +284,16 @@ export function calculateAttackResult(attacker, defender, G, ctx, simulate = fal
     return {
         damage: damage,
         reactionDamage: 0,
-        typeEffectiveness: typeEffectiveness
+        typeEffectiveness: typeEffectiveness,
+        move: move ? { name: move.name, type: move.type || null } : null
     }
 }
 
 function calculateBaseValue(attacker, defender) {
     try {
         let k = calculateLevelK(attacker);
-        // let power = move.potential || move.rating;
-        let power = 1;
         let a_d = calculateEffectiveAttackAndDefense(attacker, defender);
-        let baseTop = k * power * a_d;
+        let baseTop = k * a_d;
         let baseResult = (baseTop / attackConstants.BASE_BOTTOM_VAR) + 2;
         // console.log(`level=${k}, a_d=${a_d}, baseTop=${baseTop}, baseResult=${baseResult}`);
         return baseResult;
@@ -366,63 +366,58 @@ function calculateRandom() {
     }
 }
 
-// function calculateSameTypeAttackBonus(move, attacker) {
-//     // 1.5 if the move's type matches any of the user's types, and 1 if otherwise.
-//     if (!move.type) {
-//         return 1;
-//     }
+function calculateSameTypeAttackBonus(move, attacker) {
+    // 1.5 if the move's type matches any of the attacker's types, and 1 otherwise.
+    if (!move || !move.type) {
+        return 1;
+    }
 
-//     let type = move.type && move.type.name ? move.type.name.toLowerCase() : move.type.toLowerCase();
-//     let attackerPrimary = attacker.elementType && attacker.elementType.name ? attacker.elementType.name.toLowerCase() : attacker.elementType.toLowerCase();
-//     let attackerSecondary = attacker.elements.secondaryType && attacker.elements.secondaryType.name ? attacker.elements.secondaryType.name.toLowerCase() : attacker.elements.secondaryType.toLowerCase();
-    
-//     var multiplier = 1;
-//     if (type == attackerPrimary) {
-//         multiplier += 0.5;
-//     }
-//     if (type == attackerSecondary) {
-//         multiplier += 0.5;
-//     }
-//     console.log(`STAB: ${multiplier}`);
-//     return multiplier;
-// }
+    try {
+        let elements = attacker.elements || { primaryType: attacker.elementType, secondaryType: null };
+        let type = move.type.toLowerCase();
+        let attackerPrimary = elements.primaryType ? elements.primaryType.toLowerCase() : null;
+        let attackerSecondary = elements.secondaryType ? elements.secondaryType.toLowerCase() : null;
 
-export function calculateTypeEffectiveness(attacker, defender, secondary = true) {
-    // This can be 0 (ineffective); 0.25, 0.5 (not very effective); 1 (normally effective); 2, or 4 (super effective)
-    
-    /*
-    For targets that have multiple types, the type effectiveness of a move is the product of its effectiveness against each of the types:
-        - If the type of a move is super effective against both of the opponent's types (such as Dig, a Ground-type move, used against an Aggron, a Steel/Rock Pokémon), then the move does 4 times the damage;
-        - If the type of a move is not very effective against both of the opponent's types (such as Wake-Up Slap, a Fighting-type move, used against a Sigilyph, a Psychic/Flying Pokémon), then the move only does ¼ of the damage;
-        - If the type of a move is super effective against one of the opponent's types but not very effective against the other (such as Razor Leaf, a Grass-type move, used against a Gyarados, a Water/Flying Pokémon), then the move deals regular damage;
-        - If the type of move is completely ineffective against one of the opponent's types, then the move does no damage, even if the opponent has a second type that would be vulnerable to it (as in Thunderbolt, an Electric-type move, used against a Quagsire, a Water/Ground Pokémon).
-    */
+        if (type === attackerPrimary || type === attackerSecondary) {
+            return 1.5;
+        }
+        return 1;
+    } catch (e) {
+        return 1;
+    }
+}
 
-    let json = tools.getJson("elements");
-    let nodes = JSON.parse(json.toString());
-    let effectivenessOfAttackByElementMap = new Map();
-    nodes.forEach(node => {
-        effectivenessOfAttackByElementMap[node.name.toLowerCase()] = node.effectiveness;
-    });
+export function calculateTypeEffectiveness(attackType, defender) {
+    // This can be 0 (ineffective); 0.5 (not very effective); 1 (normally effective); 1.5, or 2 (super effective)
+    // For targets that have multiple types, the type effectiveness of a move is the product of its effectiveness against each of the types.
+    if (!attackType) {
+        return 1;
+    }
 
-    let effectivenessOfAttackerPrimaryMap = effectivenessOfAttackByElementMap[attacker.elementType.toLowerCase()];
-    let effectivenessOfAttackerPrimaryOnDefenderPrimary = effectivenessOfAttackerPrimaryMap[defender.elementType];
-    if (!secondary) {
-        return effectivenessOfAttackerPrimaryOnDefenderPrimary;
-    } else {
-        let effectivenessOfAttackerSecondaryMap = effectivenessOfAttackByElementMap[attacker.elements.secondaryType.toLowerCase()];
-        let defenderSecondaryType = defender.elements.secondaryType;
-        let effectivenessOfAttackerSecondaryOnDefenderSecondary = effectivenessOfAttackerSecondaryMap[defenderSecondaryType];
-        let effectivenessOfAttackerPrimaryOnDefenderSecondary = effectivenessOfAttackerPrimaryMap[defenderSecondaryType];
-        
-        let sum = (effectivenessOfAttackerPrimaryOnDefenderPrimary * 4)
-        + (effectivenessOfAttackerPrimaryOnDefenderSecondary * 3)
-        + (effectivenessOfAttackerSecondaryMap[defender.elementType] * 2)
-        + (effectivenessOfAttackerSecondaryOnDefenderSecondary * 1);
-    
-        let final = sum / 10;
-        return final;
+    try {
+        let json = tools.getJson("elements");
+        let nodes = JSON.parse(json.toString());
+        let effectivenessOfAttackByElementMap = new Map();
+        nodes.forEach(node => {
+            effectivenessOfAttackByElementMap[node.name.toLowerCase()] = node.effectiveness;
+        });
 
+        let effectivenessMap = effectivenessOfAttackByElementMap[attackType.toLowerCase()];
+        let defenderPrimaryType = defender.elementType;
+        let defenderSecondaryType = defender.elements && defender.elements.secondaryType;
+
+        let effectivenessOnPrimary = effectivenessMap[defenderPrimaryType];
+        effectivenessOnPrimary = typeof effectivenessOnPrimary === 'number' ? effectivenessOnPrimary : 1;
+
+        let effectivenessOnSecondary = 1;
+        if (defenderSecondaryType) {
+            let val = effectivenessMap[defenderSecondaryType];
+            effectivenessOnSecondary = typeof val === 'number' ? val : 1;
+        }
+
+        return effectivenessOnPrimary * effectivenessOnSecondary;
+    } catch (e) {
+        return 1;
     }
 }
 

--- a/my-app/src/gameplay/duel/duelPieceBuilder.js
+++ b/my-app/src/gameplay/duel/duelPieceBuilder.js
@@ -44,6 +44,11 @@ export function buildDuelPiece(xalian) {
         xalianId: xalian.xalianId,
         species: buildReducedSpecies(xalian.species),
         elementType: xalian.elements.primaryType,
+        moves: xalian.moves || [],
+        elements: {
+            primaryType: xalian.elements.primaryType,
+            secondaryType: xalian.elements.secondaryType || null
+        },
         stats: {
             attack: attackPts,
             defense: defensePts,


### PR DESCRIPTION
## Milestone 2: the generated movesets finally matter in battle.

### What changed
- **Move chooser**: clicking an enemy now opens a modal listing the attacker's 4 generated moves — each with its type badge, rating, deterministic damage preview, and a color-coded effectiveness hint — plus a neutral Basic Attack, and Cancel. Damage previews are computed with the real formula (random factor pinned to 1).
- **Damage formula** (`duelCalculator`): `base(atk/def) × power(rating/10) × STAB × typeEffectiveness × random(0.85–1) × 2`. STAB is 1.5× when the move's type matches either of the attacker's types. Type effectiveness is now the product of the 14×14 matrix against **both** defender types (true Pokémon semantics) — replacing the old unreachable weighted-sum branch that crashed on secondary types. Typeless moves and Basic Attacks are neutral (1×, no STAB) — the safe option against immunities.
- **Pieces** now carry their `moves` and both element types; the board shows dual-type badges.
- **`doAttack`** accepts `{ moveIndex }`, clamped/validated against the attacker's move list (invalid → basic attack), keeping the rules layer authoritative.
- **Bot** evaluates all four of its moves plus basic against each target and dispatches the highest-damage option through the same `moveIndex` contract (flows via `duelActionBuilder` → `duelBot.buildBotMove` → MCTS args).
- Docs updated (CLAUDE.md combat rules, audit findings STAB/dual-type entries).

### Verified (live browser play-test)
- Hot-seat game: chooser rendered with 4 moves + basic; previews matched hand-computed math exactly, including a dual-type product (4.2 basic vs 11.4 for a STAB'd 2× rock move, and a 0.75× dual-type "not very effective" case). Executed the super-effective move → "-10.2, Super Effective!!" result modal → one-shot KO and piece removal.
- Vs-bot game: bot marched, flanked, and counter-attacked my piece for 4 damage — bot dispatch path exercised with no errors.
- Production build passes; no new console errors (only pre-existing warnings).

Built by three parallel Sonnet subagents (rules / bot / UI) against a pinned interface spec, then reviewed, integrated, and play-tested by Fable — including one cross-file fix (two stale `calculateTypeEffectiveness` call sites in `duelActionBuilder`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)