### PR TITLE
Adopt GitHub Issues as the backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,16 @@ terraform plan     # preview; main.tf zips ./lambda into generate_xalian_lambda.
 
 There is no test suite for the `lambda/` engine — verification is done by running `start.js` and inspecting output.
 
+## Backlog & workflow
+
+**GitHub Issues on this repo is the single backlog** — see `docs/BACKLOG.md` for the label taxonomy, milestones, and full workflow rules. The operational summary:
+
+- File out-of-scope findings as issues immediately (labels: one of `P1`/`P2`/`P3` + type + area); don't park them in chat or docs.
+- Reference tickets from PRs with `Fixes #N` so merges auto-close them.
+- "Work the backlog" means P1s first; `question`-labeled issues need Nick's answer before implementation.
+- CI/CD is fully automated: PRs run frontend build + terraform plan (both required checks on `master`); merging auto-deploys frontend (S3+CloudFront) and backend (terraform apply). Auto-merge on green is enabled — open the PR, run `gh pr merge <n> --auto --merge`, done. Never run `aws s3 sync` or `terraform apply` manually unless CI is broken.
+- `docs/AUDIT_FINDINGS.md` is a historical record of the 2026-08-29 audit; its open items were migrated to issues.
+
 ## Architecture
 
 ### Generation engine (`lambda/src/`)

--- a/docs/AUDIT_FINDINGS.md
+++ b/docs/AUDIT_FINDINGS.md
@@ -60,55 +60,15 @@ A full polish audit of the frontend, duel game, and lambda backend. Items marked
 
 ---
 
-## 2. Open — known issues deliberately deferred (need design/refactor, not spot fixes)
+## 2. Open items — MIGRATED TO GITHUB ISSUES (2026-08-29)
 
-### Duel game architecture
-- **No move validation**: `movePiece`/`doAttack` blindly apply whatever path the client sends — no occupancy, adjacency, distance, stamina, or turn-ownership checks in the game logic itself (`duel.js:437-542`). Combined with the next item, a piece can be silently overwritten off the board (it stays in `activeXalianIds` and can never be killed, making the elimination win unreachable).
-- **Input computed from stale board state**: the UI deliberately renders from the animation log's historical `metadata.startState` (`duelBoard.getStartingBoardState`), and click/drag actions are derived from that historical state while `G` has moved on.
-- **GSAP Draggable leak**: `Draggable.create()` runs on every `componentDidUpdate` for current-turn pieces and old instances are never killed — after N updates a single drop fires N stale `onDragEnd` handlers.
-- **Animation timeline deadlock risk**: the shared timeline is paused for attack animations and only `AttackActionModal.onHide` can resume it; the modal's `componentDidMount` dereferences four `getElementById` results unguarded — one missing element freezes the board for the rest of the game.
-- `getXalianCurrentTurnStatus` ignores stamina when computing `remainingSpacesXalianCanMove` (disagrees with `duelCalculator`, which enforces it) — currently masked, wrong for any new consumer.
-- The game-level `endIf` also runs during the `setup` phase; flag-row math is asymmetric (`grid.rows[1]` hardcoded vs `grid.rows[BOARD_COLUMN_SIZE - 2]` derived) — safe at 8×8, breaks if board size changes.
-- Recapturing a *carried* flag can never fire (`flag.index` is null while held) — only dropped flags reset. Confirm whether that's the intended rule.
-- `duelBot` objectives: `flag-guarded` is a copy-paste of `enemy-flag-not-held-by-enemy` with opposite polarity — they cancel to a net weight and nothing measures "my flag is guarded". Bot TODOs documented at `duelBot.js:184-190`.
-- ~~Dual-type effectiveness / STAB~~ — implemented in the moves-in-combat milestone (per-move type, dual-type product effectiveness, STAB 1.5×). Remaining damage multiplier stubs (weather/planet, crit, badge, multi-target, status) intentionally return 1 — design hooks, not bugs.
-- Single-id batch shape inconsistency: `GET /db/xalian` returns a bare xalian for one id but wrapper items (`{speciesId, xalianId, attributes}`) for 2+ ids — a one-element "batch" breaks `x.attributes` readers.
-- `debugMode` defaults to `true` on the duel start page, and a DEBUG button + boardgame.io debug panel render for all users.
-- Hot-seat "2 player" mode renders two clients in one browser; there is no real server multiplayer (no boardgame.io `Server` anywhere; transport is always `Local()`).
-- Duel squads come from mock `xalianSamples.json`; wiring to the signed-in user's real Xalians is written but commented out (`duelPage.js:148-159`).
+Every open item formerly listed here now lives in the repo's GitHub Issues backlog (see `docs/BACKLOG.md` for the ticketing standards). This section is no longer maintained. Notable closures since the audit, for the record:
 
-### Deploy / infrastructure
-- ~~Lambda zip carried no reproducible deps~~ **FIXED (PR #2)** — `lambda/package.json` declares `uuid`/`bluebird`/`aws-sdk` v2; CI installs before terraform zips; the committed prebuilt zip was removed.
-- ~~Runtime pinned to nodejs12.x~~ **FIXED (PR #2)** — all 7 lambdas on `nodejs20.x`, applied and verified live.
-- ~~Terraform state local and gitignored~~ **FIXED (PR #2)** — S3 remote state with lockfile; the lost local state was rebuilt from live resource IDs via `imports.tf` (delete that file after it has applied once — it already has).
-- ~~No CI/CD~~ **FIXED (PR #2)** — GitHub Actions: PR build + terraform plan; master push → frontend deploy (S3+CloudFront) and backend `terraform apply`, all via OIDC roles (`xalians-github-deploy`, `xalians-github-terraform`).
-- ~~aws-exports.js gitignored~~ **FIXED (PR #2)** — committed (public Cognito client IDs only).
-- **OPEN — live, unmanaged route `POST /db/xalian/unauth` with NO auth** on API `6y8832nrlf` (route id `w3sz1ai`) — an unauthenticated write endpoint not in terraform. Probably an old experiment; recommend deleting.
-- OPEN — unmanaged extras in AWS: `prod`/`test` api mappings on api.xalians.com (why both `/xalian` and `/prod/xalian` work), a `debug.xalians.com` apigw domain, and three orphaned older `chronic-labs-*` artifact buckets.
-- OPEN — the dev toolchain (webpack-4-era react-scripts resolved by yarn.lock) requires `NODE_OPTIONS=--openssl-legacy-provider` on Node 17+ (baked into the workflows; still applies locally).
-- OPEN — `package.json` pins `react`, `react-dom`, `react-scripts` to `"latest"` — only `yarn.lock` holds the working versions; an `npm install` today would pull incompatible majors.
-- OPEN — the lambda handlers still use aws-sdk v2 (vendored); the long-term path is migrating `database/*Delegate.js` to SDK v3 clients and dropping the ~60MB vendored dependency.
-- OPEN — benign perpetual terraform diff: the artifact object's `filemd5` etag never matches the multipart-upload etag, so every apply re-uploads the zip (acceptable: CD ships latest code each merge).
-
-### Frontend, smaller open items
-- `Hub.listen` subscriptions without teardown in `authButtonGroup.js`, `signInModal.js`, `fadeAlert.js` (duplicate listeners across SPA navigations; navbar itself was fixed in PR #1).
-- `xalianSpeciesSizeComparisonView.js`: wheel listener never removed; mutates and re-sorts the shared imported `species.json` module array (currently masked by re-sorts elsewhere); doesn't respond to window resize (builds once in `componentDidMount`).
-- `xalianStatRatingChart.js` snapshots `stats` at mount only — stale bars if the prop ever changes.
-- Controlled inputs initialized to `null` in the auth modals (React uncontrolled→controlled warning).
-- `xalianSvg.js` name-miss fallback does a dynamic `require('./' + name + '.svg')` that throws instead of degrading.
-- Duplicate-key React warnings in `DuelBoard`/`DuelBoardCell` list rendering; `class` vs `className` on some duel start page icons.
-- `utils/timerUtil.js` has a module-level `Hub.listen` using `this.setState` (would throw if the file were ever imported; currently imported nowhere).
-- `utils/animationUtil.js`: `addShuffleSpeciesColorAnimation` passes an object to an array shuffle (silent no-op) and line 4 imports a nonexistent `ReactDOM` named export from `react`.
-- Dead files with broken imports (deleted `json/designer/*`, `svg/animations/*` targets): `designerSuggestionRow.js`, `speciesDesignerSizeSelector.js`, `computerScreenContent.js`, `generatorAnimation.js`, `speciesBlueprintSubmissionAnimation.js`, `voltishAnimatedSVG.js` (also wrong import depth). Not compiled today because nothing imports them — decide keep-and-fix vs remove per feature.
-- Root `jsonManipulator.js` requires `./src/ai.js` etc. — paths assume the file still lives in `lambda/`; broken since the move. Root `sandbox.js` still writes to the deleted `src/json/designer/` directory (scratch file).
-- `lambda/src/json/` ships several files no lambda loads (`planets.json`, `glossary.json`, `typeEffectivenessMatrix.json`, `populated_moves.json`, `helping_moves.json`, `current_xalian.json`, csv) — harmless zip weight; the engine loads only `elements`, `species`, `qualifiers`, `moves`.
-
-### Data
-- `elements.json` per-element `moveTypes`/`elements` word lists have copy-paste stubs for Ice/Metal/Sand (e.g. Ice offers only "ice, frost"; Metal only "metal") and Ghost lists "ghost" three times — generated move variety is thin for those types. The 14×14 `typeEffectivenessMatrix.json` itself is complete and consistent.
-- `species.json` populates only 2 of 9 `statRatings` per species (uniform across all 29 — reads as intentional "notable stats" but worth confirming the other slots are meant to be rolled randomly).
-- Glossary is missing entries referenced by newer planet lore (e.g. Leviticus Overdrive, Dreadscape, Stellaris entries exist — spot-check when next editing lore).
-
----
+- Backend CI/CD, remote terraform state, nodejs20.x runtimes, real lambda packaging, committed aws-exports.js — **fixed** (PR #2/#3).
+- Unauthenticated `POST /db/xalian/unauth` route — **deleted** from the live API (approved 2026-08-29).
+- `debug.xalians.com` domain and the three orphaned `chronic-labs-*` buckets — **deleted** (2026-08-29 tidy-up); the extra `prod`/`test` mappings on api.xalians.com remain **intentionally** (the frontend uses `/prod` URLs).
+- Duel squads from mock JSON — **fixed** (PR #5: real Xalian squads + squad picker; also fixed the broken ADD_XALIAN_ID lambda path).
+- Dual-type effectiveness, STAB, per-move combat — **implemented** (PR #7).
 
 ## 3. Hidden / unexposed features (built, not reachable — do NOT treat as dead code)
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,43 @@
+# Backlog & Ticketing Standards
+
+GitHub Issues on this repo is the single backlog. If work is worth remembering, it is worth an issue; chat transcripts, audit docs, and PR comments are not backlog storage.
+
+## Labels
+
+Every issue gets **one priority**, **one or more type labels**, and **one or more area labels**.
+
+**Priority** (exactly one):
+
+| Label | Meaning |
+|---|---|
+| `P1` | Do next — actively hurts users or blocks the roadmap |
+| `P2` | Do soon — real issue, not urgent |
+| `P3` | Someday — cleanup, polish, nice-to-have |
+
+**Type**: `bug`, `enhancement`, `tech-debt`, `balance`, `infra`, `data`, `documentation`, `question` (needs a design decision from Nick before implementation — do not start these without an answer).
+
+**Area**: `duel`, `generator`, `frontend`, `backend`.
+
+## Milestones
+
+GitHub Milestones track roadmap chunks (e.g. "M3: Rules hardening", "M4: Flavor pass", "M5: Multiplayer (deferred)"). Attach an issue to a milestone only when it is genuinely part of that deliverable. Milestones marked "(deferred)" hold designed-but-not-scheduled work; nothing in them should be started without an explicit go-ahead.
+
+## Issue quality bar
+
+- **Title**: imperative and specific enough to understand from the list view. Prefix game/area context when useful ("Duel: …", "Data: …").
+- **Body**: what is wrong / wanted, where (file paths, line refs), and — for anything non-obvious — acceptance criteria. Link related issues.
+- Small related items may be bundled into one checklist issue (see the "polish bundle" pattern) rather than filed as noise.
+
+## Workflow rules (for Claude sessions)
+
+1. **File findings immediately.** Anything discovered mid-task that is out of scope for the current PR becomes an issue right then, with labels and enough body to be actionable cold. Do not park findings in chat or in markdown docs.
+2. **Reference issues from PRs.** Use `Fixes #N` / `Closes #N` in the PR body so merges auto-close tickets. A PR that partially addresses an issue references it without a closing keyword and leaves a comment on the issue saying what remains.
+3. **Pull from the backlog by priority.** When Nick says "work the backlog" (or equivalent), take P1s first, oldest first, unless he names a ticket. Confirm scope on `question`-labeled issues before implementing.
+4. **Close with evidence.** When an issue is resolved outside a PR (e.g. AWS console change), comment with what was done and close it.
+5. **Keep it current.** If reality diverges from a ticket (fixed incidentally, superseded, wrong), update or close the ticket the moment it is noticed.
+6. **Don't relitigate.** `wontfix`/closed decisions stand unless Nick reopens them.
+
+## Relationship to other docs
+
+- `docs/AUDIT_FINDINGS.md` is a **historical record** of the 2026-08-29 audit (what was found and fixed) plus the hidden-features reference table. Its open-item lists were migrated to issues and are no longer maintained there.
+- `CLAUDE.md` carries a short pointer to this file; this file is the authority on process.


### PR DESCRIPTION
Seeds the ticketing system Nick requested:

- **26 issues filed** covering the audit's open items, roadmap milestones (M3 rules hardening / M4 flavor pass / M5 deferred multiplayer+registry as GitHub Milestones), and fresh findings from the production validation (combat balance one-shots, debug-mode-on-by-default).
- **Labels**: `P1`/`P2`/`P3` priorities + type (`bug`, `enhancement`, `tech-debt`, `balance`, `infra`, `data`, `question`) + area (`duel`, `generator`, `frontend`, `backend`).
- **docs/BACKLOG.md**: the standards — quality bar, workflow rules (findings filed immediately, `Fixes #N` in PRs, P1-first ordering, `question` issues need Nick's answer first).
- **CLAUDE.md**: operational summary so every future session uses the tracker.
- **AUDIT_FINDINGS.md**: open-items section retired in favor of the tracker, with a record of what's been closed since the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)