### PR TITLE
Duel: production debug default + health balance

### DIFF
--- a/my-app/src/gameplay/duel/duelGameConstants.js
+++ b/my-app/src/gameplay/duel/duelGameConstants.js
@@ -1,5 +1,5 @@
 export const BOARD_COLUMN_SIZE = 8;
-export const MAX_HEALTH_POINTS = 10;
+export const MAX_HEALTH_POINTS = 15;
 export const MAX_STAMINA_POINTS = 6;
 export const MAX_SPACES_MOVED_PER_TURN = 3;
 export const XALIANS_PER_TEAM = 6;

--- a/my-app/src/pages/games/duelStartPage.js
+++ b/my-app/src/pages/games/duelStartPage.js
@@ -29,7 +29,7 @@ class DuelStartPage extends React.Component {
 
     state = {
         randomizeStartingPositions: true,
-        debugMode: true,
+        debugMode: process.env.NODE_ENV !== 'production',
         selectedXalianIds: []
     }
 


### PR DESCRIPTION
Two P1 quick wins from the backlog:

- **Fixes #6** — `debugMode` now defaults to `NODE_ENV !== 'production'`: visitors stop getting the boardgame.io debug panel; dev builds keep it, and the settings toggle still works either way.
- **Fixes #5** — `MAX_HEALTH_POINTS` 10 → 15. With the verified damage numbers (basic ~4.2, STAB+2× ~11.4, dual-weakness ~17–21): basic attacks now take ~4 hits, a STAB'd super-effective hit lands ~75% of a health bar instead of a guaranteed one-shot, and only the rare double-weakness hit still KOs outright — kept as the exciting high-roll. Health bars render off the constant, so UI scales automatically. Trivial to retune after playtesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)