### PR TITLE
Duel: rules hardening (M3)

### DIFF
--- a/my-app/src/components/games/duel/board/attackActionModal.js
+++ b/my-app/src/components/games/duel/board/attackActionModal.js
@@ -30,11 +30,17 @@ class AttackActionModal extends React.Component {
         // if (this.props.animationTl) {
         //     this.props.animationTl.play();
         // }
-        gsap.to('#attack-action-modal', {autoAlpha: 0, duration: 0.35}).then(() => {
+        let modalElem = document.getElementById('attack-action-modal');
+        if (!modalElem) {
+            // element missing — nothing to animate, but the shared timeline MUST still resume
+            this.props.onHide();
+            return;
+        }
+        gsap.to(modalElem, {autoAlpha: 0, duration: 0.35}).then(() => {
             this.props.onHide();
         }
         );
-        
+
     }
 
     onAnimationComplete = () => {
@@ -42,75 +48,96 @@ class AttackActionModal extends React.Component {
     }
 
     componentDidMount() {
-        // calculate variables
-        let attackerElem = document.getElementById('duel-attack-action-' + this.props.attacker.xalianId + '-animation');
-        let defenderElem = document.getElementById('duel-attack-action-' + this.props.defender.xalianId + '-animation');
-        let attackerRect = attackerElem.getBoundingClientRect();
-        let defenderRect = defenderElem.getBoundingClientRect();
+        try {
+            // calculate variables
+            let attackerElem = document.getElementById('duel-attack-action-' + this.props.attacker.xalianId + '-animation');
+            let defenderElem = document.getElementById('duel-attack-action-' + this.props.defender.xalianId + '-animation');
 
-        let attackerBadge = document.getElementById("duel-attack-action-attacker-type-icon");
-        let defenderBadge = document.getElementById("duel-attack-action-defender-type-icon");
-        let badgeWidthOffset = attackerBadge.clientWidth/2;
-        let xOffset = badgeWidthOffset;
+            let attackerBadge = document.getElementById("duel-attack-action-attacker-type-icon");
+            let defenderBadge = document.getElementById("duel-attack-action-defender-type-icon");
 
-        // init modal-global timeline
-        let modalTl = gsap.timeline({ onComplete: this.onAnimationComplete });
+            if (!attackerElem || !defenderElem || !attackerBadge || !defenderBadge) {
+                // required element missing — skip the fancy animation and fail safe so the
+                // shared timeline (paused elsewhere for the duration of the attack) still resumes
+                throw new Error('attackActionModal: required animation element missing');
+            }
 
-        // fade in entire modal
-        modalTl.to('#attack-action-modal', {autoAlpha: 1, duration: 0.25});
-        
-        // fade in pieces
-        // modalTl.from(attackerElem, { ease: "expo.in", opacity: 0}, "<");
-        // modalTl.from(defenderElem, { ease: "expo.in", delay: 0.2, opacity: 0}, "<");
+            let attackerRect = attackerElem.getBoundingClientRect();
+            let defenderRect = defenderElem.getBoundingClientRect();
+            let badgeWidthOffset = attackerBadge.clientWidth/2;
+            let xOffset = badgeWidthOffset;
 
-        if (this.props.attackerStartRect && this.props.defenderStartRect) { // move pieces in from location on board if provided
-            modalTl.from(attackerElem, {x: this.props.attackerStartRect.x - attackerRect.x, y: this.props.attackerStartRect.y - attackerRect.y, ease: "expo.in"}, "<");
-            modalTl.from(defenderElem, {x: this.props.defenderStartRect.x - defenderRect.x, y: this.props.defenderStartRect.y - defenderRect.y, ease: "expo.in"}, "<");
-        } else { // otherwise fade in from the side
-            modalTl.from(attackerElem, {xPercent: -200, opacity: 0, ease: "expo.in"}, "<");
-            // modalTl.from(attackerElem, {xPercent: -200, ease: "expo.in"}, "<");
-            modalTl.from(defenderElem, {xPercent: 200, opacity: 0, ease: "expo.in", delay: 0.2}, "<");
-            // modalTl.from(defenderElem, {xPercent: 200, ease: "expo.in", delay: 0.2}, "<");
+            // init modal-global timeline
+            let modalTl = gsap.timeline({ onComplete: this.onAnimationComplete });
+
+            // fade in entire modal
+            modalTl.to('#attack-action-modal', {autoAlpha: 1, duration: 0.25});
+
+            // fade in pieces
+            // modalTl.from(attackerElem, { ease: "expo.in", opacity: 0}, "<");
+            // modalTl.from(defenderElem, { ease: "expo.in", delay: 0.2, opacity: 0}, "<");
+
+            if (this.props.attackerStartRect && this.props.defenderStartRect) { // move pieces in from location on board if provided
+                modalTl.from(attackerElem, {x: this.props.attackerStartRect.x - attackerRect.x, y: this.props.attackerStartRect.y - attackerRect.y, ease: "expo.in"}, "<");
+                modalTl.from(defenderElem, {x: this.props.defenderStartRect.x - defenderRect.x, y: this.props.defenderStartRect.y - defenderRect.y, ease: "expo.in"}, "<");
+            } else { // otherwise fade in from the side
+                modalTl.from(attackerElem, {xPercent: -200, opacity: 0, ease: "expo.in"}, "<");
+                // modalTl.from(attackerElem, {xPercent: -200, ease: "expo.in"}, "<");
+                modalTl.from(defenderElem, {xPercent: 200, opacity: 0, ease: "expo.in", delay: 0.2}, "<");
+                // modalTl.from(defenderElem, {xPercent: 200, ease: "expo.in", delay: 0.2}, "<");
+            }
+
+
+            let attackerBadgeTl = gsap.timeline();
+            attackerBadgeTl.fromTo(attackerBadge, {opacity: 0}, {opacity: 1, duration: 0.2});
+            attackerBadgeTl.to(attackerBadge, {x: xOffset, scale: 1.5, ease: "expo.in"}, "<");
+
+            let defenderBadgeTl = gsap.timeline();
+            defenderBadgeTl.fromTo(defenderBadge, {opacity: 0}, {opacity: 1, duration: 0.2});
+            defenderBadgeTl.to(defenderBadge, {x: -xOffset, scale: 1.5, ease: "expo.in"}, "<");
+
+            // bounce to type badge based on effectiveness
+            let effectivenessScore = this.props.result && this.props.result.typeEffectiveness ? this.props.result.typeEffectiveness : 0;
+            let effectiveness = duelValueTranslator.effectivenessScoreToText(effectivenessScore);
+            this.addBounceAnimation(effectiveness, attackerBadgeTl, attackerBadge, defenderBadgeTl, defenderBadge, xOffset);
+
+            modalTl.add(attackerBadgeTl).add(defenderBadgeTl, "<");
+
+            let effectivenessTextElem = document.getElementById('duel-attack-action-effectiveness-text');
+            modalTl.fromTo(effectivenessTextElem, {opacity: 0}, {opacity: 1});
+
+            let defenderHealthDelta = this.buildXalianHealthDelta(this.props.defender.state.health, this.props.result.damage);
+            let attackerHealthDelta = this.buildXalianHealthDelta(this.props.attacker.state.health, this.props.result.reactionDamage);
+
+            let defenderDropShadowBlur = Math.min(4, defenderHealthDelta.end.percent);
+            let attackerDropShadowBlur = Math.min(4, attackerHealthDelta.end.percent);
+
+
+            modalTl.fromTo('#duel-attack-action-attacker-health-bar-wrapper, #duel-attack-action-defender-health-bar-wrapper', {autoAlpha: 0}, {autoAlpha: 1, duration: 0.15}, "<");
+            modalTl.to('#duel-attack-action-defender-health-bar', {width: `${defenderHealthDelta.end.percent}%`, backgroundColor: defenderHealthDelta.end.color, boxShadow: `0px 0px ${defenderDropShadowBlur}px ${defenderDropShadowBlur}px ${defenderHealthDelta.end.color}`, duration: 0.5});
+            modalTl.to('#duel-attack-action-attacker-health-bar', {width: `${attackerHealthDelta.end.percent}%`, backgroundColor: attackerHealthDelta.end.color, boxShadow: `0px 0px ${attackerDropShadowBlur}px ${attackerDropShadowBlur}px ${attackerHealthDelta.end.color}`, duration: 0.5}, "<");
+            modalTl.fromTo('#duel-attack-action-attacker-result-damage, #duel-attack-action-defender-result-damage', {autoAlpha: 0}, {autoAlpha: 1, duration: 0.5}, "<");
+            if (defenderDropShadowBlur == 0) {
+                modalTl.to(defenderElem, {opacity: 0.25, duration: 0.25});
+            }
+            if (attackerDropShadowBlur == 0) {
+                modalTl.to(attackerElem, {opacity: 0.25, duration: 0.25});
+            }
+
+            let fits = fitty('.fit-text'); // fitting title to modal
+        } catch (err) {
+            // fail safe: something required for the fancy animation was missing or threw.
+            // We must not deadlock the board — make the modal visible if possible (so the
+            // damage text can still flash) and force the completion/close path to run so the
+            // shared, paused gsap timeline resumes.
+            console.error('attackActionModal: animation setup failed, falling back to safe close', err);
+            try {
+                gsap.set('#attack-action-modal', { autoAlpha: 1 });
+            } catch (setErr) {
+                // ignore — modal element may not exist either
+            }
+            this.onAnimationComplete();
         }
-
-        
-        let attackerBadgeTl = gsap.timeline();
-        attackerBadgeTl.fromTo(attackerBadge, {opacity: 0}, {opacity: 1, duration: 0.2});
-        attackerBadgeTl.to(attackerBadge, {x: xOffset, scale: 1.5, ease: "expo.in"}, "<");
-        
-        let defenderBadgeTl = gsap.timeline();
-        defenderBadgeTl.fromTo(defenderBadge, {opacity: 0}, {opacity: 1, duration: 0.2});
-        defenderBadgeTl.to(defenderBadge, {x: -xOffset, scale: 1.5, ease: "expo.in"}, "<");
-        
-        // bounce to type badge based on effectiveness
-        let effectivenessScore = this.props.result && this.props.result.typeEffectiveness ? this.props.result.typeEffectiveness : 0;
-        let effectiveness = duelValueTranslator.effectivenessScoreToText(effectivenessScore);
-        this.addBounceAnimation(effectiveness, attackerBadgeTl, attackerBadge, defenderBadgeTl, defenderBadge, xOffset);
-
-        modalTl.add(attackerBadgeTl).add(defenderBadgeTl, "<");
-        
-        let effectivenessTextElem = document.getElementById('duel-attack-action-effectiveness-text');
-        modalTl.fromTo(effectivenessTextElem, {opacity: 0}, {opacity: 1});
-
-        let defenderHealthDelta = this.buildXalianHealthDelta(this.props.defender.state.health, this.props.result.damage);
-        let attackerHealthDelta = this.buildXalianHealthDelta(this.props.attacker.state.health, this.props.result.reactionDamage);
-
-        let defenderDropShadowBlur = Math.min(4, defenderHealthDelta.end.percent);
-        let attackerDropShadowBlur = Math.min(4, attackerHealthDelta.end.percent);
-        
-
-        modalTl.fromTo('#duel-attack-action-attacker-health-bar-wrapper, #duel-attack-action-defender-health-bar-wrapper', {autoAlpha: 0}, {autoAlpha: 1, duration: 0.15}, "<");
-        modalTl.to('#duel-attack-action-defender-health-bar', {width: `${defenderHealthDelta.end.percent}%`, backgroundColor: defenderHealthDelta.end.color, boxShadow: `0px 0px ${defenderDropShadowBlur}px ${defenderDropShadowBlur}px ${defenderHealthDelta.end.color}`, duration: 0.5});
-        modalTl.to('#duel-attack-action-attacker-health-bar', {width: `${attackerHealthDelta.end.percent}%`, backgroundColor: attackerHealthDelta.end.color, boxShadow: `0px 0px ${attackerDropShadowBlur}px ${attackerDropShadowBlur}px ${attackerHealthDelta.end.color}`, duration: 0.5}, "<");
-        modalTl.fromTo('#duel-attack-action-attacker-result-damage, #duel-attack-action-defender-result-damage', {autoAlpha: 0}, {autoAlpha: 1, duration: 0.5}, "<");
-        if (defenderDropShadowBlur == 0) {
-            modalTl.to(defenderElem, {opacity: 0.25, duration: 0.25});
-        }
-        if (attackerDropShadowBlur == 0) {
-            modalTl.to(attackerElem, {opacity: 0.25, duration: 0.25});
-        }
-
-        let fits = fitty('.fit-text'); // fitting title to modal
     }
 
     addBounceAnimation = (effectiveness, attackerBadgeTl, attackerBadge, defenderBadgeTl, defenderBadge, xOffset) => {

--- a/my-app/src/components/games/duel/board/duelBoardCell.js
+++ b/my-app/src/components/games/duel/board/duelBoardCell.js
@@ -33,6 +33,8 @@ class DuelBoardCell extends React.Component {
 		contentLoaded: false,
 	};
 
+	draggableInstances = [];
+
 	componentDidMount() {
 		// document.addEventListener('DOMContentLoaded', this.setAsDraggable);
 		// this.setDraggables();
@@ -43,6 +45,15 @@ class DuelBoardCell extends React.Component {
 		// if (this.props.ctx.turn < 3 && this.props.isActive && (prevProps.ctx.turn < this.props.ctx.turn)) {
 		// 	this.doFadesAfterMove();
 		// }
+	}
+
+	componentWillUnmount() {
+		this.killDraggables();
+	}
+
+	killDraggables = () => {
+		(this.draggableInstances || []).forEach(d => d.kill());
+		this.draggableInstances = [];
 	}
 
 	doFadesAfterMove = () => {
@@ -103,7 +114,8 @@ class DuelBoardCell extends React.Component {
 				})
 			}
 			console.log("DRAGGABLES CREATED");
-			Draggable.create(elemId, {
+			this.killDraggables();
+			this.draggableInstances = Draggable.create(elemId, {
 				type: "x,y",
 				edgeResistance: 1,
 				bounds: ".duel-board-wrapper",
@@ -296,6 +308,7 @@ class DuelBoardCell extends React.Component {
 
 			});
 		} else {
+			this.killDraggables();
 			console.log();
 		}
 	}

--- a/my-app/src/components/games/duel/duel.js
+++ b/my-app/src/components/games/duel/duel.js
@@ -435,14 +435,46 @@ function moveXalianToActive(id, unset, active, ctx, endTurnAfterMove = false) {
 
 // function movePiece(G, ctx, startIndex, endIndex, data = {}) {
 function movePiece(G, ctx, path, data = {}) {
+	// sanity-check the client-submitted path shape before trusting any of it
+	if (!path
+		|| !Number.isInteger(path.startIndex) || !Number.isInteger(path.endIndex)
+		|| path.startIndex < 0 || path.startIndex > 63
+		|| path.endIndex < 0 || path.endIndex > 63) {
+		return INVALID_MOVE;
+	}
+
+	if (ctx.phase !== 'play') {
+		return INVALID_MOVE;
+	}
+
 	let xalianIdToMove = G.cells[path.startIndex];
+	if (!xalianIdToMove || !duelUtil.isCurrentTurnsXalian(xalianIdToMove, G, ctx)) {
+		return INVALID_MOVE;
+	}
+
 	let xalian = duelUtil.getXalianFromId(xalianIdToMove, G);
-	
+	if (!xalian) {
+		return INVALID_MOVE;
+	}
+
+	// recompute the valid destinations for this piece server-side; never trust the client's endIndex/spacesMoved
+	let validPaths = duelCalculator.calculateMovablePaths(path.startIndex, xalian, G, ctx);
+	let serverPath = validPaths && validPaths.find(p => p.endIndex === path.endIndex);
+	if (!serverPath) {
+		return INVALID_MOVE;
+	}
+
+	let xalianStatus = duelUtil.getXalianCurrentTurnStatus(xalian, G, ctx);
+	let turnState = boardStateManager.currentTurnState(G, ctx);
+	if (xalianStatus.remainingSpacesXalianCanMove < serverPath.spacesMoved
+		|| turnState.remainingSpacesToMove < serverPath.spacesMoved) {
+		return INVALID_MOVE;
+	}
 
 	let targetFlagIndex = duelUtil.getCurrentTurnTargetFlagIndex(G, ctx);
 	let opponentFlagState = G.flags[parseInt(ctx.currentPlayer === '0' ? 1 : 0)];
 	// set flag holder
-	if (path.endIndex == targetFlagIndex) {
+	if (serverPath.endIndex == targetFlagIndex) {
 		let flag = G.flags[parseInt(ctx.currentPlayer)];
 		if (flag) {
 			flag.index = null;
@@ -452,19 +484,19 @@ function movePiece(G, ctx, path, data = {}) {
 	}
 
 	// move flag back to start if recaptured
-	if (path.endIndex == opponentFlagState.index) {
+	if (serverPath.endIndex == opponentFlagState.index) {
 		opponentFlagState.index = opponentFlagState.startIndex;
 	}
 
-	G.cells[path.startIndex] = null;
-	G.cells[path.endIndex] = xalianIdToMove;
-	xalian.state.stamina = xalian.state.stamina - path.spacesMoved;
+	G.cells[serverPath.startIndex] = null;
+	G.cells[serverPath.endIndex] = xalianIdToMove;
+	xalian.state.stamina = xalian.state.stamina - serverPath.spacesMoved;
 
 	let action = {
 		type: duelConstants.actionTypes.MOVE,
 		move: {
 			moverId: xalianIdToMove,
-			path: path
+			path: serverPath
 		}
 	};
 	// G.currentTurnState.actions.push(action);
@@ -474,76 +506,105 @@ function movePiece(G, ctx, path, data = {}) {
 
 
 function doAttack(G, ctx, path, data = {}) {
+	// sanity-check the client-submitted path shape before trusting any of it
+	if (!path
+		|| !Number.isInteger(path.startIndex) || !Number.isInteger(path.endIndex)
+		|| path.startIndex < 0 || path.startIndex > 63
+		|| path.endIndex < 0 || path.endIndex > 63) {
+		return INVALID_MOVE;
+	}
+
+	if (ctx.phase !== 'play') {
+		return INVALID_MOVE;
+	}
+
 	let attackerIndex = path.startIndex;
 	let defenderIndex = path.endIndex;
 	let attackerId = G.cells[attackerIndex];
 	let attacker = G.xalians.filter((x) => x.xalianId === attackerId)[0];
 	let defenderId = G.cells[defenderIndex];
 	let defender = G.xalians.filter((x) => x.xalianId === defenderId)[0];
-	if (attacker && defender) {
-		// attacker.state.stamina = attacker.state.stamina - duelConstants.ATTACK_STAMINA_COST;
-		attacker.state.stamina = attacker.state.stamina - path.spacesMoved;
-		// console.log('xalian ' + attacker.species.name + ' from square ' + attackerIndex + ' is attacking xalian ' + defender.species.name + ' on square ' + defenderIndex);
-		var existingDefenderHealth = parseInt(defender.state.health);
-		let moveIndex = Number.isInteger(data.moveIndex) && attacker.moves && data.moveIndex >= 0 && data.moveIndex < attacker.moves.length ? data.moveIndex : null;
-		let move = moveIndex != null ? attacker.moves[moveIndex] : null;
-		let attackResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx, false, move);
-		let damage = attackResult.damage;
-		defender.state.health = Math.max(0, existingDefenderHealth - damage);
-		// console.log('resulting health = ' + defender.state.health);
-		if (defender.state.health <= 0) {
-			if (duelUtil.isPlayerPiece(defenderId, G)) {
-				removeItemFromList(defenderId, G.playerStates[0].activeXalianIds);
-				G.playerStates[0].inactiveXalianIds.push(defenderId);
-				let flag = duelUtil.getPlayerFlagState(G);
-				if (flag.holder && flag.holder === defenderId) {
-					flag.holder = null;
-					flag.index = defenderIndex;
-				}
-			} else if (duelUtil.isOpponentPiece(defenderId, G)) {
-				removeItemFromList(defenderId, G.playerStates[1].activeXalianIds);
-				G.playerStates[1].inactiveXalianIds.push(defenderId);
-				let flag = duelUtil.getOpponentFlagState(G);
-				if (flag.holder && flag.holder === defenderId) {
-					flag.holder = null;
-					flag.index = defenderIndex;
-				}
-			}
-			G.cells[defenderIndex] = null;
 
-		}
-
-		// if (ctx.currentPlayer == 0) {
-		// 	Hub.dispatch("duel-animation-event", { event: "attack", data: 
-		let attackActionResult = {
-			attackerIndex: attackerIndex,
-			attackerId: attackerId,
-			attackerType: attacker.elementType,
-			defenderIndex: defenderIndex,
-			defenderId: defenderId,
-			defenderType: defender.elementType,
-			moveName: move ? move.name : null,
-			moveType: move && move.type ? move.type : null,
-			typeEffectiveness: attackResult.typeEffectiveness,
-			attackResult: attackResult
-
-		};
-
-		let action = {
-			type: duelConstants.actionTypes.ATTACK,
-			attack: {
-				attackerId: attackerId,
-				defenderId: defenderId,
-				path: path,
-				result: attackActionResult
-			}
-		};
-		G.currentTurnActions.push(action);
-	} else {
-		console.error(`ERROR :: DID NOT FIND ONE OF ATTACKER [${attacker}] OR DEFENDER [${defender}] DURING ATTACK ACTION`);
+	if (!attacker || !attackerId || !duelUtil.isCurrentTurnsXalian(attackerId, G, ctx)) {
+		return INVALID_MOVE;
 	}
 
+	if (!defender || !defenderId || duelUtil.xaliansAreOnSameTeam(attackerId, defenderId, G)) {
+		return INVALID_MOVE;
+	}
 
+	// only one attack per team per turn, and this attacker must not have already attacked this turn
+	let turnState = boardStateManager.currentTurnState(G, ctx);
+	let attackerStatus = duelUtil.getXalianCurrentTurnStatus(attacker, G, ctx);
+	if (turnState.hasAttacked || attackerStatus.xalianHasAttacked) {
+		return INVALID_MOVE;
+	}
+
+	// recompute the valid attack targets for this piece server-side; never trust the client's endIndex/spacesMoved
+	let validPaths = duelCalculator.calculateAttackablePaths(attackerIndex, attacker, G, ctx);
+	let serverPath = validPaths && validPaths.find(p => p.endIndex === defenderIndex);
+	if (!serverPath) {
+		return INVALID_MOVE;
+	}
+
+	// attacker.state.stamina = attacker.state.stamina - duelConstants.ATTACK_STAMINA_COST;
+	attacker.state.stamina = attacker.state.stamina - serverPath.spacesMoved;
+	// console.log('xalian ' + attacker.species.name + ' from square ' + attackerIndex + ' is attacking xalian ' + defender.species.name + ' on square ' + defenderIndex);
+	var existingDefenderHealth = parseInt(defender.state.health);
+	let moveIndex = Number.isInteger(data.moveIndex) && attacker.moves && data.moveIndex >= 0 && data.moveIndex < attacker.moves.length ? data.moveIndex : null;
+	let move = moveIndex != null ? attacker.moves[moveIndex] : null;
+	let attackResult = duelCalculator.calculateAttackResult(attacker, defender, G, ctx, false, move);
+	let damage = attackResult.damage;
+	defender.state.health = Math.max(0, existingDefenderHealth - damage);
+	// console.log('resulting health = ' + defender.state.health);
+	if (defender.state.health <= 0) {
+		if (duelUtil.isPlayerPiece(defenderId, G)) {
+			removeItemFromList(defenderId, G.playerStates[0].activeXalianIds);
+			G.playerStates[0].inactiveXalianIds.push(defenderId);
+			let flag = duelUtil.getPlayerFlagState(G);
+			if (flag.holder && flag.holder === defenderId) {
+				flag.holder = null;
+				flag.index = defenderIndex;
+			}
+		} else if (duelUtil.isOpponentPiece(defenderId, G)) {
+			removeItemFromList(defenderId, G.playerStates[1].activeXalianIds);
+			G.playerStates[1].inactiveXalianIds.push(defenderId);
+			let flag = duelUtil.getOpponentFlagState(G);
+			if (flag.holder && flag.holder === defenderId) {
+				flag.holder = null;
+				flag.index = defenderIndex;
+			}
+		}
+		G.cells[defenderIndex] = null;
+
+	}
+
+	// if (ctx.currentPlayer == 0) {
+	// 	Hub.dispatch("duel-animation-event", { event: "attack", data:
+	let attackActionResult = {
+		attackerIndex: attackerIndex,
+		attackerId: attackerId,
+		attackerType: attacker.elementType,
+		defenderIndex: defenderIndex,
+		defenderId: defenderId,
+		defenderType: defender.elementType,
+		moveName: move ? move.name : null,
+		moveType: move && move.type ? move.type : null,
+		typeEffectiveness: attackResult.typeEffectiveness,
+		attackResult: attackResult
+
+	};
+
+	let action = {
+		type: duelConstants.actionTypes.ATTACK,
+		attack: {
+			attackerId: attackerId,
+			defenderId: defenderId,
+			path: serverPath,
+			result: attackActionResult
+		}
+	};
+	G.currentTurnActions.push(action);
 }
 
 function removeItemFromList(item, list) {

--- a/my-app/src/utils/duelUtil.js
+++ b/my-app/src/utils/duelUtil.js
@@ -250,6 +250,7 @@ export function getXalianCurrentTurnStatus(xalian, boardState, ctx) {
         }
     });
     remainingSpacesXalianCanMove = Math.min(remainingSpacesXalianCanMove, remainingSpacesToMoveForTurn);
+    remainingSpacesXalianCanMove = Math.min(remainingSpacesXalianCanMove, xalian.state && Number.isFinite(xalian.state.stamina) ? xalian.state.stamina : remainingSpacesXalianCanMove);
     remainingSpacesXalianCanMove = Math.max(remainingSpacesXalianCanMove, 0);
 
     return {


### PR DESCRIPTION
## Milestone 3: the rules layer no longer trusts the client.

Fixes #1, Fixes #3, Fixes #4, Fixes #8

### What changed
- **`movePiece`/`doAttack` validation** (`duel.js`): path shape + bounds, `play`-phase guard, piece ownership (`isCurrentTurnsXalian`), per-piece budget (`getXalianCurrentTurnStatus`) and team pool (`currentTurnState`), and — the core of it — a **server-side recompute** of legal destinations (`calculateMovablePaths`) / attack targets (`calculateAttackablePaths`): the client's `endIndex` must be in the recomputed set, and the server's path (its `spacesMoved`) drives stamina deduction, flag pickup, and the action log. Anything else returns `INVALID_MOVE` and leaves `G` untouched. Attacks also enforce once-per-team and once-per-piece per turn. This is the multiplayer seam: rules are now server-authoritative-shaped.
- **#8**: `getXalianCurrentTurnStatus` caps per-piece movement by remaining stamina (was ignoring it).
- **#3**: `DuelBoardCell` stores its `Draggable.create` instances, kills them before re-creating, on turn-state flips, and on unmount — a drop now fires exactly one `onDragEnd`.
- **#4**: `AttackActionModal` wraps its animation setup in try/catch with explicit element checks; any failure still shows the modal best-effort and runs the close path so the shared paused timeline always resumes. `closeModal` falls back to `onHide()` if the modal element is missing. Happy path unchanged.
- Issue #2 (stale-state input) is deliberately rescoped to P2: with validation in place, stale-derived input is rejected instead of corrupting the board (comment on the issue).

### Verified (live browser play-test, hot-seat + vs bot)
- Legal play unaffected: moves, flag cells, the move-chooser attack (5.8 preview → 44% defender health remaining — exact), turn transitions.
- Per-piece move caps and the one-attack-per-turn rule now actually refuse repeat attempts (observed clean rejections, no state corruption, no freezes).
- The chooser also surfaced a 0× immunity preview ("no effect", ~0 dmg) working correctly.
- Bot plays normally under validation (moved across multiple turns; its paths come from the same calculator functions the validator recomputes with — the `isBot` flag was traced and is a dead parameter). The `NO ACTIONS BUILT FOR ANY BOT` console line seen during stamina-exhaustion stalls is pre-existing master behavior (`duelBot.js:60`), tracked in #9.
- Production build passes; no new console errors.

Implemented by two parallel Sonnet subagents against a pinned spec; reviewed, integrated, and play-tested by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)