### PR TITLE
P2 sweep: nav links, bot guarding, Hub teardowns, element vocab

### DIFF
--- a/lambda/src/json/elements.json
+++ b/lambda/src/json/elements.json
@@ -320,10 +320,12 @@
       "supernatural",
       "banshee",
       "wraith",
-      "ghost",
       "haunted",
       "genie",
-      "ghost"
+      "spectral",
+      "poltergeist",
+      "seance",
+      "dreadscape"
     ],
     "effectiveness": {
       "Fire": 1.5,
@@ -345,9 +347,7 @@
       "ghost",
       "phantom",
       "supernatural",
-      "wraith",
-      "ghost",
-      "ghost"
+      "wraith"
     ]
   },
   {
@@ -428,7 +428,17 @@
     "name": "Ice",
     "moveTypes": [
       "ice",
-      "frost"
+      "frost",
+      "cryo",
+      "glacial",
+      "arctic",
+      "subzero",
+      "hail",
+      "blizzard",
+      "permafrost",
+      "frostbite",
+      "snowdrift",
+      "freezing"
     ],
     "effectiveness": {
       "Fire": 0,
@@ -447,14 +457,28 @@
       "Sand": 0.5
     },
     "elements": [
-      "ice",
-      "frost"
+      "frost",
+      "cryo",
+      "glacial",
+      "arctic",
+      "blizzard"
     ]
   },
   {
     "name": "Metal",
     "moveTypes": [
-      "metal"
+      "metal",
+      "steel",
+      "iron",
+      "chrome",
+      "alloy",
+      "magnetic",
+      "titanium",
+      "forged",
+      "plated",
+      "gilded",
+      "mechanized",
+      "razorwire"
     ],
     "effectiveness": {
       "Fire": 0.5,
@@ -473,13 +497,28 @@
       "Sand": 1.5
     },
     "elements": [
-      "metal"
+      "steel",
+      "chrome",
+      "alloy",
+      "magnetic",
+      "forged"
     ]
   },
   {
     "name": "Sand",
     "moveTypes": [
-      "sand"
+      "sand",
+      "dune",
+      "dust",
+      "sirocco",
+      "quicksand",
+      "sandstorm",
+      "desert",
+      "eroding",
+      "silica",
+      "mirage",
+      "scouring",
+      "burying"
     ],
     "effectiveness": {
       "Fire": 1.5,
@@ -498,7 +537,11 @@
       "Sand": 1
     },
     "elements": [
-      "sand"
+      "dune",
+      "sirocco",
+      "silica",
+      "mirage",
+      "sandstorm"
     ]
   }
 ]

--- a/my-app/src/components/auth/authButtonGroup.js
+++ b/my-app/src/components/auth/authButtonGroup.js
@@ -38,14 +38,21 @@ class AuthButtonGroup extends React.Component {
             }
         });
 
-        Hub.listen('auth', (data) => {
+        this.authListener = (data) => {
             if (data.payload.event === 'signIn_failure') {
                 if (data.payload.data.code === 'UserNotConfirmedException') {
                     this.setState({ verifyEmailModalShow: true })
                 }
             }
             this.handleAuthEvent(data.payload.event, data.payload.data);
-        })
+        };
+        Hub.listen('auth', this.authListener);
+    }
+
+    componentWillUnmount() {
+        if (this.authListener) {
+            Hub.remove('auth', this.authListener);
+        }
     }
 
     handleAuthEvent = (name, data) => {

--- a/my-app/src/components/auth/signInModal.js
+++ b/my-app/src/components/auth/signInModal.js
@@ -21,7 +21,7 @@ class SignInModal extends React.Component {
     }
 
     componentDidMount() {
-        Hub.listen('auth', (data) => {
+        this.authListener = (data) => {
             if (data.payload.event === 'signIn_failure') {
                 if (data.payload.data.code === 'UserNotConfirmedException') {
                     this.setState({errorMessage: null}, () => {
@@ -34,7 +34,14 @@ class SignInModal extends React.Component {
                 }
                 this.setState({isThinking: false})
             }
-        })
+        };
+        Hub.listen('auth', this.authListener);
+    }
+
+    componentWillUnmount() {
+        if (this.authListener) {
+            Hub.remove('auth', this.authListener);
+        }
     }
 
     handleSubmit = event => {

--- a/my-app/src/components/fadeAlert.js
+++ b/my-app/src/components/fadeAlert.js
@@ -11,7 +11,7 @@ class FadeAlert extends React.Component {
   };
 
   componentDidMount() {
-    Hub.listen("alert", (data) => {
+    this.alertListener = (data) => {
       const type = data.payload.event;
       const req = data.payload.data;
       if (type == "new-alert") {
@@ -33,7 +33,14 @@ class FadeAlert extends React.Component {
       } else if (type == "show-alert") {
         this.setState({ isShowing: true });
       }
-    });
+    };
+    Hub.listen("alert", this.alertListener);
+  }
+
+  componentWillUnmount() {
+    if (this.alertListener) {
+      Hub.remove("alert", this.alertListener);
+    }
   }
 
   render() {

--- a/my-app/src/components/navbar.js
+++ b/my-app/src/components/navbar.js
@@ -104,6 +104,8 @@ class XalianNavbar extends React.Component {
 										<Nav.Link href="/species">Species</Nav.Link>
 										<Nav.Link href="/planets">Planets</Nav.Link>
 										<Nav.Link href="/glossary">Glossary</Nav.Link>
+										<Nav.Link href="/duel">Duel</Nav.Link>
+										<Nav.Link href="/train">Training</Nav.Link>
 										{/* <Nav.Link href="/faq">FAQ</Nav.Link> */}
 										{/* <Nav.Link href="/login">Login</Nav.Link> */}
 										{/* <Nav.Link href="/designer">Designer</Nav.Link> */}

--- a/my-app/src/gameplay/duel/duelBot.js
+++ b/my-app/src/gameplay/duel/duelBot.js
@@ -265,9 +265,25 @@ export function buildBotObjectives() {
             weight: 100,
         },
         'flag-guarded': {
+            // true when the bot has at least one active piece within Manhattan distance 2 of its own (unstolen) flag
             checker: (G, ctx) => {
               let flag = duelUtil.getPlayerFlagState(G);
-              return flag.holder ? true : false;
+              if (flag.holder || flag.index == null) {
+                return false;
+              }
+              let boardSize = duelConstants.BOARD_COLUMN_SIZE;
+              let flagRow = Math.floor(flag.index / boardSize);
+              let flagCol = flag.index % boardSize;
+              return G.playerStates[1].activeXalianIds.some((id) => {
+                let index = duelUtil.getIndexOfXalian(id, G);
+                if (index == null) {
+                  return false;
+                }
+                let row = Math.floor(index / boardSize);
+                let col = index % boardSize;
+                let distance = Math.abs(row - flagRow) + Math.abs(col - flagCol);
+                return distance <= 2;
+              });
             },
             weight: 50,
         },

--- a/my-app/src/json/elements.json
+++ b/my-app/src/json/elements.json
@@ -320,10 +320,12 @@
       "supernatural",
       "banshee",
       "wraith",
-      "ghost",
       "haunted",
       "genie",
-      "ghost"
+      "spectral",
+      "poltergeist",
+      "seance",
+      "dreadscape"
     ],
     "effectiveness": {
       "Fire": 1.5,
@@ -345,9 +347,7 @@
       "ghost",
       "phantom",
       "supernatural",
-      "wraith",
-      "ghost",
-      "ghost"
+      "wraith"
     ]
   },
   {
@@ -428,7 +428,17 @@
     "name": "Ice",
     "moveTypes": [
       "ice",
-      "frost"
+      "frost",
+      "cryo",
+      "glacial",
+      "arctic",
+      "subzero",
+      "hail",
+      "blizzard",
+      "permafrost",
+      "frostbite",
+      "snowdrift",
+      "freezing"
     ],
     "effectiveness": {
       "Fire": 0,
@@ -447,14 +457,28 @@
       "Sand": 0.5
     },
     "elements": [
-      "ice",
-      "frost"
+      "frost",
+      "cryo",
+      "glacial",
+      "arctic",
+      "blizzard"
     ]
   },
   {
     "name": "Metal",
     "moveTypes": [
-      "metal"
+      "metal",
+      "steel",
+      "iron",
+      "chrome",
+      "alloy",
+      "magnetic",
+      "titanium",
+      "forged",
+      "plated",
+      "gilded",
+      "mechanized",
+      "razorwire"
     ],
     "effectiveness": {
       "Fire": 0.5,
@@ -473,13 +497,28 @@
       "Sand": 1.5
     },
     "elements": [
-      "metal"
+      "steel",
+      "chrome",
+      "alloy",
+      "magnetic",
+      "forged"
     ]
   },
   {
     "name": "Sand",
     "moveTypes": [
-      "sand"
+      "sand",
+      "dune",
+      "dust",
+      "sirocco",
+      "quicksand",
+      "sandstorm",
+      "desert",
+      "eroding",
+      "silica",
+      "mirage",
+      "scouring",
+      "burying"
     ],
     "effectiveness": {
       "Fire": 1.5,
@@ -498,7 +537,11 @@
       "Sand": 1
     },
     "elements": [
-      "sand"
+      "dune",
+      "sirocco",
+      "silica",
+      "mirage",
+      "sandstorm"
     ]
   }
 ]

--- a/my-app/src/utils/timerUtil.js
+++ b/my-app/src/utils/timerUtil.js
@@ -1,15 +1,4 @@
-import { Hub } from 'aws-amplify';
-
-Hub.listen('game-timer', (data) => {
-	const type = data.payload.event;
-	const req = data.payload.data;
-	if (type === 'start-timer') {
-	} else if (type === 'stop-timer') {
-		this.setState({ isShowing: false });
-	} else if (type === 'show-alert') {
-		this.setState({ isShowing: true });
-	}
-});
+// timer Hub wiring removed — was module-level Hub.listen with this.setState (broken); re-add inside a component if ever needed
 
 // export const start = () => {
 //     let startTime = performance.now();
@@ -46,4 +35,3 @@ Hub.listen('game-timer', (data) => {
 // export const convertMillisToSeconds = (ms) => {
 //     return Math.round(ms / 1000 * 100)/100;
 // }
-


### PR DESCRIPTION
Four backlog P2s in one file-disjoint sweep:

- **Fixes #21** — navbar gains "Duel" and "Training" links (same `Nav.Link` pattern as the existing links; the single responsive `Navbar.Collapse` covers mobile).
- **Fixes #16** — the bot's `flag-guarded` MCTS objective now returns true when a bot piece stands within Manhattan distance 2 of its own unstolen flag, instead of being a polarity-flipped copy of `enemy-flag-not-held-by-enemy` that partially cancelled it.
- **Fixes #23** — `Hub.listen` teardowns in `authButtonGroup`, `signInModal`, `fadeAlert` following the navbar's stored-listener + `Hub.remove` convention; `timerUtil`'s broken module-level `Hub.listen` (referenced `this.setState` at module scope, imported nowhere) removed.
- **Fixes #31** — `elements.json` word lists: Ice/Metal/Sand each go from 1–2 words to 12 lore-flavored ones (Krystos cryo/glacial/permafrost, Veridium steel/chrome/forged, Endessa dune/sirocco/mirage), Ghost's triple-"ghost" deduped and expanded (spectral/poltergeist/seance/dreadscape); `elements` sublists (used for primary/secondary element naming) curated to match. Verified against the live generator: moves like "Silica Flush", "Titanium Shove", "Poltergeist Thrust", "Desert Slash" now generate. Frontend JSON copy re-synced.

Production build passes. Bot fix + teardowns implemented by parallel Sonnet subagents; vocab written and generator-verified by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)