### PR TITLE
Normalize xalian batch response shape

### DIFF
--- a/lambda/src/database/xalianTableCRUDLambdas.js
+++ b/lambda/src/database/xalianTableCRUDLambdas.js
@@ -54,7 +54,9 @@ module.exports.retrieveXalian = (event, context, callback) => {
 		delegate.getXalianBatch(
 			xalianIds,
 			function onSuccess(xalians) {
-				let response = builder.buildResponse(200, xalians);
+				// return bare xalians like the single-id path does, not raw table items
+				let unwrapped = xalians.map((x) => (x && x.attributes ? x.attributes : x));
+				let response = builder.buildResponse(200, unwrapped);
 				console.log(`SUCCESS :: returning response:\n${JSON.stringify(response, null, 2)}`);
 				callback(undefined, response);
 			},

--- a/my-app/src/utils/dbApi.js
+++ b/my-app/src/utils/dbApi.js
@@ -55,7 +55,11 @@ export const callGetXalianBatch = (ids) => {
     qString = qString + id + ",";
   });
   qString = qString.slice(0, qString.length - 1);
-  return callGet("https://api.xalians.com/prod/db/xalian?xalianId=" + encodeURIComponent(qString));
+  // the API returns a bare xalian object for a single id and an array for 2+;
+  // normalize so callers always get an array of bare xalians
+  return callGet("https://api.xalians.com/prod/db/xalian?xalianId=" + encodeURIComponent(qString)).then((result) =>
+    Array.isArray(result) ? result : [result]
+  );
 };
 
 export const callCreateXalian = (xalian) => {


### PR DESCRIPTION
Fixes #22 — `GET /db/xalian` returned a bare xalian for one id but raw DynamoDB table items (`{speciesId, xalianId, attributes}`) for 2+ ids. Now:

- **Server**: the batch branch unwraps to bare xalians (`x.attributes`), matching the single-id path's shape per element.
- **Client**: `dbApi.callGetXalianBatch` wraps the single-id bare-object case so its callers always receive an array of bare xalians regardless of id count.

No current frontend callers of the batch path exist (it's one of the audit's hidden features), so this is shape-hardening before anything starts depending on the inconsistency. The `populateXalians` user path intentionally keeps its wrapper-item shape (`user.xalians[].attributes`) — the account page depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)