### PR TITLE
M4 flavor pass: evasion, flight, flag-carrier penalty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Sync shared game data and engine code from lambda/
         run: yarn copy-json && yarn copy-js
 
+      - name: Test
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+          CI: "true"
+        run: yarn test --watchAll=false --passWithNoTests
+
       - name: Build
         # legacy provider: the lockfile's webpack toolchain uses md4 hashing,
         # which OpenSSL 3 (Node 17+) removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,10 @@ Lives in `my-app/src/components/games/duel/` (UI), `my-app/src/gameplay/duel/` (
 
 - **Board:** 8×8; each player's back row is both setup zone and scoring zone. Two flags, randomly placed on the row in front of each defender's home row. Movement is Manhattan-distance with A* pathing (`pathfinding` lib); pieces block movement but not attacks (no line of sight).
 - **Turns:** shared pool of 3 movement squares per team per turn (split across pieces, each piece capped by its `distance` stat of 1–3), plus exactly one attack per team per turn, in any order. Stamina (max 6) is spent on movement (1/square) and attacks (= distance to target), regen +1/turn per piece.
-- **Combat:** HP-based (10 HP), not Pokémon-Duel spin. Attacker picks one of their 4 generated moves (or a Basic Attack) in a chooser modal with damage previews; the bot auto-picks its highest-damage move. Damage = (attack/defense ratio) × (move rating/10) × STAB (1.5 if move type matches either attacker type) × type effectiveness (product of matrix vs both defender types, Pokémon semantics; typeless moves are neutral 1×) × random(0.85–1) × 2. Attack range 1–3 from species `attackRange` trait. Weather/crit/status multipliers are still stubs returning 1; evasion and `canFly` are carried but unused.
+- **Combat:** HP-based (15 HP), not Pokémon-Duel spin. Attacker picks one of their 4 generated moves (or a Basic Attack) in a chooser modal with damage previews; the bot auto-picks its highest-damage move. Damage = (attack/defense ratio) × (move rating/10) × STAB (1.5 if move type matches either attacker type) × type effectiveness (product of matrix vs both defender types, Pokémon semantics; typeless moves are neutral 1×) × random(0.85–1) × 2. Attack range 1–3 from species `attackRange` trait. Evasion is a flat damage reduction (2%/point, capped 25%). Weather/crit/status multipliers are still stubs returning 1.
+- **Traits:** `canFly` pieces path *over* occupied squares (they still cannot land on one); 6 of 29 species fly. Carrying a flag caps movement at 2 squares/turn.
 - **Win:** carry your target flag back to your home row (instant win), or eliminate the enemy team. Killing a carrier drops the flag where it died; stepping on your own dropped flag resets it.
+- **Rules are authoritative:** `movePiece`/`doAttack` re-derive legality from `G` (ownership, phase, budgets, server-recomputed paths) and return `INVALID_MOVE` otherwise, so the UI cannot corrupt state. The board renders a historical snapshot while animations replay, but input is always derived from live `G`.
 - **Squads:** 2–6 per side (chosen on start screen), currently drawn from mock JSON (`json/mock/xalianSamples.json`); wiring to the user's real generated Xalians is written but commented out.
 - **Bot:** boardgame.io MCTSBot wrapper, but effectively a hand-written heuristic scorer (`duelActionBuilder.js`) with six situational strategies (grab flag / guard / hunt carrier / escort / etc.) — it returns only its single top-scored action to MCTS.
 - **State:** playable end-to-end locally with animations, damage modals, drag-and-drop. Missing: server multiplayer, real-Xalian squads, secondary types (that code path would crash), status effects, per-move attack selection, terrain. Known bug: `duelUtil.js` `xalianHasValidActionAvailable` treats cell index 0 as falsy. `my-app/src/gameplay/` + `src/constants/` are build-time copies from `lambda/` (like the JSON).
@@ -71,7 +73,7 @@ npm run publish    # terraform apply -auto-approve
 terraform plan     # preview; main.tf zips ./lambda into generate_xalian_lambda.zip and uploads it
 ```
 
-There is no test suite for the `lambda/` engine — verification is done by running `start.js` and inspecting output.
+There is no test suite for the `lambda/` engine — verification is done by running `start.js` and inspecting output. The frontend has tests for the duel rules (`my-app/src/gameplay/duel/__tests__/duelRules.test.js`, run via `yarn test`); CI runs them on every PR. Add to them when changing combat or movement rules.
 
 ## Backlog & workflow
 

--- a/my-app/src/gameplay/duel/__tests__/duelRules.test.js
+++ b/my-app/src/gameplay/duel/__tests__/duelRules.test.js
@@ -1,0 +1,170 @@
+import * as duelCalculator from '../duelCalculator';
+import * as duelConstants from '../duelGameConstants';
+
+/*
+	Rules coverage for the duel game. The board is 8x8, so cell index = row * 8 + col.
+
+	Fixtures are built by hand rather than through duelPieceBuilder so a test states
+	exactly the stats it depends on.
+*/
+
+const ctx = { phase: 'play', currentPlayer: '0' };
+
+function piece(id, overrides = {}) {
+	return {
+		xalianId: id,
+		species: { id: '00001', name: 'Testling', planet: 'Floria' },
+		elementType: 'Plant',
+		elements: { primaryType: 'Plant', secondaryType: null },
+		moves: [],
+		stats: { attack: 4, defense: 4, speed: 4, range: 1, distance: 3, evasion: 0 },
+		state: { health: duelConstants.MAX_HEALTH_POINTS, stamina: duelConstants.MAX_STAMINA_POINTS },
+		traits: { canFly: false, attackRange: 'low' },
+		...overrides,
+	};
+}
+
+// places pieces at the given cell indices and puts them all on the requested team
+function buildBoard(placements, flags = []) {
+	const cells = new Array(64).fill(null);
+	const xalians = [];
+	const teams = [[], []];
+
+	placements.forEach(({ index, piece: p, team = 0 }) => {
+		cells[index] = p.xalianId;
+		xalians.push(p);
+		teams[team].push(p.xalianId);
+	});
+
+	return {
+		cells,
+		xalians,
+		flags,
+		currentTurnDetails: null,
+		currentTurnActions: [],
+		playerStates: [
+			{ playerID: 0, activeXalianIds: teams[0], inactiveXalianIds: [], unsetXalianIds: [] },
+			{ playerID: 1, activeXalianIds: teams[1], inactiveXalianIds: [], unsetXalianIds: [] },
+		],
+	};
+}
+
+function reachableFrom(index, mover, G) {
+	return duelCalculator.calculateMovablePaths(index, mover, G, ctx).map((path) => path.endIndex);
+}
+
+describe('movement: pieces block the ground, flight goes over', () => {
+	// row 4: 32 33 34 35 ... - a mover at 32 with blockers at 33 and 34.
+	// walking to 35 means detouring through row 3 or 5 (5 spaces); flying is 3.
+	const blockedLane = (mover) =>
+		buildBoard([
+			{ index: 32, piece: mover, team: 0 },
+			{ index: 33, piece: piece('blocker-a'), team: 0 },
+			{ index: 34, piece: piece('blocker-b'), team: 0 },
+		]);
+
+	it('a walker cannot reach the cell beyond two blockers', () => {
+		const walker = piece('walker');
+		expect(reachableFrom(32, walker, blockedLane(walker))).not.toContain(35);
+	});
+
+	it('a flyer reaches it by passing over them', () => {
+		const flyer = piece('flyer', { traits: { canFly: true, attackRange: 'low' } });
+		expect(reachableFrom(32, flyer, blockedLane(flyer))).toContain(35);
+	});
+
+	it('a flyer still cannot land on an occupied square', () => {
+		const flyer = piece('flyer', { traits: { canFly: true, attackRange: 'low' } });
+		const reachable = reachableFrom(32, flyer, blockedLane(flyer));
+		expect(reachable).not.toContain(33);
+		expect(reachable).not.toContain(34);
+	});
+});
+
+describe('movement: carrying a flag slows a piece down', () => {
+	const carrierId = 'carrier';
+
+	function boardWithFlag(holder) {
+		const carrier = piece(carrierId);
+		return {
+			carrier,
+			G: buildBoard([{ index: 32, piece: carrier, team: 0 }], [
+				{ index: holder ? null : 40, startIndex: 40, holder: holder ? carrierId : null, player: 0 },
+				{ index: 5, startIndex: 5, holder: null, player: 1 },
+			]),
+		};
+	}
+
+	it('moves its full distance when empty-handed', () => {
+		const { carrier, G } = boardWithFlag(false);
+		const distances = duelCalculator.calculateMovablePaths(32, carrier, G, ctx).map((p) => p.spacesMoved);
+		expect(Math.max(...distances)).toBe(3);
+	});
+
+	it('is capped while holding a flag', () => {
+		const { carrier, G } = boardWithFlag(true);
+		const distances = duelCalculator.calculateMovablePaths(32, carrier, G, ctx).map((p) => p.spacesMoved);
+		expect(Math.max(...distances)).toBe(duelConstants.FLAG_CARRIER_MAX_SPACES_PER_TURN);
+	});
+
+	it('reports who is carrying a flag', () => {
+		const { carrier, G } = boardWithFlag(true);
+		expect(duelCalculator.isCarryingFlag(carrier, G)).toBe(true);
+		expect(duelCalculator.isCarryingFlag(piece('someone-else'), G)).toBe(false);
+	});
+});
+
+describe('combat', () => {
+	function attackResult(attacker, defender, move = null) {
+		const G = buildBoard([
+			{ index: 32, piece: attacker, team: 0 },
+			{ index: 33, piece: defender, team: 1 },
+		]);
+		// simulate = true pins the random factor to 1 so damage is deterministic
+		return duelCalculator.calculateAttackResult(attacker, defender, G, ctx, true, move);
+	}
+
+	// damage is floored to one decimal, so ratio assertions use a heavy hitter
+	// where that 0.1 granularity is negligible
+	const heavyAttacker = piece('heavy', { stats: { ...piece('x').stats, attack: 400 } });
+
+	it('evasion reduces incoming damage without ever nullifying it', () => {
+		const slippery = piece('slippery', { stats: { ...piece('x').stats, evasion: 10 } });
+		const sitting = piece('sitting-duck');
+
+		const baseline = attackResult(heavyAttacker, sitting).damage;
+		const mitigated = attackResult(heavyAttacker, slippery).damage;
+
+		expect(mitigated).toBeLessThan(baseline);
+		expect(mitigated).toBeGreaterThan(0);
+		// 10 evasion x 2% = 20% off, which is under the cap
+		expect(mitigated / baseline).toBeCloseTo(0.8, 2);
+	});
+
+	it('caps the evasion reduction so a high-evasion piece is not immune', () => {
+		const absurd = piece('absurd', { stats: { ...piece('x').stats, evasion: 1000 } });
+
+		const baseline = attackResult(heavyAttacker, piece('plain')).damage;
+		const mitigated = attackResult(heavyAttacker, absurd).damage;
+
+		expect(mitigated / baseline).toBeCloseTo(1 - duelConstants.MAX_EVASION_DAMAGE_REDUCTION, 2);
+	});
+
+	it('applies STAB when the move type matches the attacker', () => {
+		const attacker = piece('attacker');
+		const defender = piece('defender');
+		const offType = { name: 'Off Type Jab', type: 'Water', rating: 10 };
+		const stabbed = { name: 'On Type Jab', type: 'Plant', rating: 10 };
+
+		const plain = attackResult(attacker, defender, offType).damage;
+		const boosted = attackResult(attacker, defender, stabbed).damage;
+
+		expect(boosted).toBeGreaterThan(plain);
+	});
+
+	it('treats a typeless move as neutral rather than crashing', () => {
+		const result = attackResult(piece('attacker'), piece('defender'), { name: 'Plain Whack', rating: 10 });
+		expect(result.typeEffectiveness).toBe(1);
+		expect(result.damage).toBeGreaterThan(0);
+	});
+});

--- a/my-app/src/gameplay/duel/duelCalculator.js
+++ b/my-app/src/gameplay/duel/duelCalculator.js
@@ -135,11 +135,11 @@ export function calculateValidEnemyTargetPaths(G, ctx, currentIndex, distance, s
     return calculateValidPaths(G, ctx, currentIndex, distance, true, false, stamina);
 }
 
-export function calculateValidUnoccupiedPaths(G, ctx, currentIndex, distance, stamina, isBot = false) {
-    return calculateValidPaths(G, ctx, currentIndex, distance, false, true, stamina, isBot);
+export function calculateValidUnoccupiedPaths(G, ctx, currentIndex, distance, stamina, canFlyOver = false) {
+    return calculateValidPaths(G, ctx, currentIndex, distance, false, true, stamina, canFlyOver);
 }
 
-function calculateValidPaths(G, ctx, currentIndex, uneditedDistance, findOccupied, findUnoccupied, stamina, isBot = false) {
+function calculateValidPaths(G, ctx, currentIndex, uneditedDistance, findOccupied, findUnoccupied, stamina, canFlyOver = false) {
     let distance = Math.max(uneditedDistance, 0);
     let size = Math.sqrt(G.cells.length);
     var grid = new PF.Grid(size, size); 
@@ -165,7 +165,9 @@ function calculateValidPaths(G, ctx, currentIndex, uneditedDistance, findOccupie
 
     let boardGrid = buildGrid(G.cells.length);
 
-    if (!findOccupied) {
+    // pieces block movement - unless the mover can fly, which lets it path OVER them
+    // (it still can't land on an occupied square: only unoccupied cells are candidates)
+    if (!findOccupied && !canFlyOver) {
         occupied.forEach( i => {
             let coord = boardGrid.map[i];
             grid.setWalkableAt(coord[0], coord[1], false);
@@ -230,8 +232,26 @@ export function calculateMovablePaths(currentIndex, xalian, G, ctx, isBot = fals
         //     }
         // })
         var distance = Math.min(remainingForXalian, remainingForTurn);
-        return calculateValidUnoccupiedPaths(G, ctx, currentIndex, distance, xalian.state.stamina, isBot);
+
+        // hauling a flag slows you down
+        if (isCarryingFlag(xalian, G)) {
+            distance = Math.min(distance, duelConstants.FLAG_CARRIER_MAX_SPACES_PER_TURN);
+        }
+
+        return calculateValidUnoccupiedPaths(G, ctx, currentIndex, distance, xalian.state.stamina, canFly(xalian));
     }
+}
+
+export function isCarryingFlag(xalian, G) {
+    try {
+        return (G.flags || []).some((flag) => flag && flag.holder === xalian.xalianId);
+    } catch (e) {
+        return false;
+    }
+}
+
+function canFly(xalian) {
+    return !!(xalian && xalian.traits && xalian.traits.canFly);
 }
 
 export function calculateAttackableIndices(currentIndex, xalian, boardState, ctx, onlyOccupiedCells = true) {
@@ -270,8 +290,9 @@ export function calculateAttackResult(attacker, defender, G, ctx, simulate = fal
     let attackType = move && move.type ? move.type : null;
     let typeEffectiveness = calculateTypeEffectiveness(attackType, defender);
     let hinderingStatus = calculateHindranceEffect(attacker);
+    let evasion = calculateEvasionMitigation(defender);
     let other = calculateRemainingFactors(attacker, defender, G, ctx);
-    let result = base * power * targets * weather * badge * critical * random * sameTypeBonus * typeEffectiveness * hinderingStatus * other;
+    let result = base * power * targets * weather * badge * critical * random * sameTypeBonus * typeEffectiveness * hinderingStatus * evasion * other;
     let final = Math.floor(result * 10)/10;
     // console.log(`base=${base}, random=${random}, sameTypeBonus=${sameTypeBonus}, final=${final}`);
 
@@ -286,6 +307,20 @@ export function calculateAttackResult(attacker, defender, G, ctx, simulate = fal
         reactionDamage: 0,
         typeEffectiveness: typeEffectiveness,
         move: move ? { name: move.name, type: move.type || null } : null
+    }
+}
+
+// evasion softens incoming damage instead of rolling a dodge - see duelGameConstants
+function calculateEvasionMitigation(defender) {
+    try {
+        let evasion = defender && defender.stats ? defender.stats.evasion : 0;
+        if (!Number.isFinite(evasion) || evasion <= 0) {
+            return 1;
+        }
+        let reduction = Math.min(evasion * duelConstants.EVASION_DAMAGE_REDUCTION_PER_POINT, duelConstants.MAX_EVASION_DAMAGE_REDUCTION);
+        return 1 - reduction;
+    } catch (e) {
+        return 1;
     }
 }
 

--- a/my-app/src/gameplay/duel/duelGameConstants.js
+++ b/my-app/src/gameplay/duel/duelGameConstants.js
@@ -5,6 +5,15 @@ export const MAX_SPACES_MOVED_PER_TURN = 3;
 export const XALIANS_PER_TEAM = 6;
 // export const ATTACK_STAMINA_COST = MAX_STAMINA_POINTS / 2;
 
+// evasion is a flat damage reduction rather than a dodge chance - a whiffed attack
+// costs a whole turn's single attack, which feels worse than a smaller hit.
+// piece evasion runs 2 (very low) to 10 (very high).
+export const EVASION_DAMAGE_REDUCTION_PER_POINT = 0.02;
+export const MAX_EVASION_DAMAGE_REDUCTION = 0.25;
+
+// carrying a flag slows a piece down, so a fast grab still has to survive the walk home
+export const FLAG_CARRIER_MAX_SPACES_PER_TURN = 2;
+
 export const actionTypes = {
     MOVE: 'move',
     ATTACK: 'attack',

--- a/my-app/src/utils/duelUtil.js
+++ b/my-app/src/utils/duelUtil.js
@@ -206,7 +206,7 @@ export function xalianHasValidActionAvailable(id, G, ctx) {
             canMove = false;
         } else {
             // let movableSpaces = duelCalculator.calculateMovablePaths(ind, xalian, G, ctx);
-            let movableSpaces = duelCalculator.calculateValidUnoccupiedPaths(G, ctx, ind, xalianStatus.remainingSpacesXalianCanMove, xalian.state.stamina)
+            let movableSpaces = duelCalculator.calculateValidUnoccupiedPaths(G, ctx, ind, xalianStatus.remainingSpacesXalianCanMove, xalian.state.stamina, !!(xalian.traits && xalian.traits.canFly))
             if (!movableSpaces || movableSpaces.length == 0) {
                 canMove = false;
             }


### PR DESCRIPTION
Fixes #14 — the three traits the pieces were carrying but never using.

### Rules added (all tunable constants in `duelGameConstants`)
- **Evasion** → flat damage reduction, 2% per point capped at 25% (pieces run 2–10 evasion, so 4–20% in practice). Chose mitigation over a dodge roll deliberately: a whiffed attack wastes your team's single attack for the whole turn, which feels far worse than a smaller hit.
- **canFly** → flying pieces path **over** occupied squares (still can't land on one). Gives the 6 flying species — Tetrahive, Luceras, Avilily, Ectoghoul, Neph, Terragoyle — a genuine movement identity.
- **Flag carrier** → movement capped at 2 squares/turn while holding a flag, so a fast grab still has to survive the walk home. This is the rule that finally exercises the bot's existing escort / hunt-carrier strategies.

Because both the rules layer (`doAttack`/`movePiece` validation) and the bot compute paths through `duelCalculator`, flight and the carrier cap are enforced authoritatively **and** understood by the bot with no extra work.

### The repo's first tests
UI observation couldn't decisively prove the pathfinding rules (the random board never produced a distinguishing position), so this adds `src/gameplay/duel/__tests__/duelRules.test.js` — 10 cases that prove them directly:
- a walker **cannot** reach the cell beyond two blockers; a flyer **can**; a flyer still can't land on an occupied square
- a carrier moves 3 empty-handed, exactly 2 while holding a flag
- evasion reduces damage by the expected ratio, is capped, and never nullifies
- STAB applies on type match; a typeless move stays neutral instead of crashing

`yarn test` is now a CI step on every PR, so these guard future changes. Regression play-tested vs bot afterwards: normal play across several turns, no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)