### PR TITLE
Frontend polish bundle

### DIFF
--- a/my-app/src/components/auth/signInModal.js
+++ b/my-app/src/components/auth/signInModal.js
@@ -10,8 +10,8 @@ import { Hub } from 'aws-amplify';
 class SignInModal extends React.Component {
 
     state = {
-        username: null,
-        password: null,
+        username: '',
+        password: '',
         isThinking: false,
         errors: {}
     }

--- a/my-app/src/components/auth/signUpModal.js
+++ b/my-app/src/components/auth/signUpModal.js
@@ -12,10 +12,10 @@ class SignUpModal extends React.Component {
     state = {
         errorMessage: null,
         validated: false,
-        username: null,
-        email: null,
-        firstPassword: null,
-        secondPassword: null,
+        username: '',
+        email: '',
+        firstPassword: '',
+        secondPassword: '',
         errors: {}
     }
 

--- a/my-app/src/components/auth/verifyEmailModal.js
+++ b/my-app/src/components/auth/verifyEmailModal.js
@@ -9,8 +9,8 @@ import Spinner from 'react-bootstrap/Spinner';
 class VerifyEmailModal extends React.Component {
 
     state = {
-        username: null,
-        code: null,
+        username: '',
+        code: '',
         errorMessage: null,
         verificationMessage: null
     }

--- a/my-app/src/components/games/duel/board/attackableMoveBadge.js
+++ b/my-app/src/components/games/duel/board/attackableMoveBadge.js
@@ -18,10 +18,10 @@ class AttackableMoveBadge extends React.Component {
 
 			let icons = [];
 			for (var i = 0; i < effectivenessIconCount; i++) {
-				icons.push(<AttackIcon className="" style={{ fill: 'rgb(255, 0, 0)',stroke: 'black', strokeWidth: '2px', filter: `drop-shadow( 0px 0px 1px black)`, height: `25%`, width: '25%' }} />);
+				icons.push(<AttackIcon key={`effective-icon-${i}`} className="" style={{ fill: 'rgb(255, 0, 0)',stroke: 'black', strokeWidth: '2px', filter: `drop-shadow( 0px 0px 1px black)`, height: `25%`, width: '25%' }} />);
 			}
 			while (icons.length < 4) {
-				icons.push(<AttackIcon className="" style={{ fill: 'black', stroke: 'white', strokeWidth: '2px', filter: `drop-shadow( 0px 0px 1px white)`, height: `25%`, width: '25%' }} />);
+				icons.push(<AttackIcon key={`empty-icon-${icons.length}`} className="" style={{ fill: 'black', stroke: 'white', strokeWidth: '2px', filter: `drop-shadow( 0px 0px 1px white)`, height: `25%`, width: '25%' }} />);
 			}
 			return (
 			// <React.Fragment>

--- a/my-app/src/components/games/duel/board/duelBoard.js
+++ b/my-app/src/components/games/duel/board/duelBoard.js
@@ -483,7 +483,7 @@ class DuelBoard extends React.Component {
 		let cellSizeText = this.determineCellSizeText();
 
 		return (
-				<Col style={{ maxWidth: cellSizeText, maxHeight: cellSizeText, opacity: opac }} className='duel-unset-piece-wrapper' onClick={() => this.handleInitialPieceSelection(x, boardState)}>
+				<Col key={x.xalianId} style={{ maxWidth: cellSizeText, maxHeight: cellSizeText, opacity: opac }} className='duel-unset-piece-wrapper' onClick={() => this.handleInitialPieceSelection(x, boardState)}>
 					<XalianImage padding='2%' colored rounded shadowed selected={isSelected} speciesName={x.species.name} primaryType={x.elementType} moreClasses="duel-xalian-unselected" />
 						{/* <div style={{ padding: '0px', height: '100%', width: '100%', margin: 'auto' }}>
 							<h6 className="fit-xalian-name-text" style={{ textAlign: 'center', margin: 'auto', height: '100%', width: '100%', color: 'white', opacity: 0.5 }}>
@@ -523,13 +523,13 @@ class DuelBoard extends React.Component {
 		let userActionButtons = [];
 
 		userActionButtons.push(
-			<Col style={{ display: 'flex', justifyContent: 'center' }}>
+			<Col key="duel-action-debug" style={{ display: 'flex', justifyContent: 'center' }}>
 				<Button variant='xalianGray' onClick={ this.doDebugAction } style={{ margin: 'auto', marginBottom: '10px', marginTop: '10px' }} >DEBUG</Button>
 			</Col>
 		)
 
 		userActionButtons.push(
-			<Col style={{ display: 'flex', justifyContent: 'center' }}>
+			<Col key="duel-action-end-turn" style={{ display: 'flex', justifyContent: 'center' }}>
 				<Button variant='xalianGray' disabled={!showEndTurnButton} onClick={this.endPlayerTurn} style={{ margin: 'auto', marginBottom: '10px', marginTop: '10px' }} >End turn</Button>
 			</Col>
 		)

--- a/my-app/src/components/games/duel/board/duelBoardCell.js
+++ b/my-app/src/components/games/duel/board/duelBoardCell.js
@@ -560,23 +560,23 @@ class DuelBoardCell extends React.Component {
 
 		if (leftIndex != undefined && !this.cellIsOccupied(leftIndex)) {
 			cellConnectors.push(
-				<div className="duel-board-cell-connector occupied-connector" style={{ width: '100%', height: '5px', top: '50%', left: '0' }} />
+				<div key={`connector-${index}-left`} className="duel-board-cell-connector occupied-connector" style={{ width: '100%', height: '5px', top: '50%', left: '0' }} />
 			)
 		}
 		if (topIndex != undefined && !this.cellIsOccupied(topIndex)) {
 			cellConnectors.push(
-				<div className="duel-board-cell-connector occupied-connector" style={{ width: '5px', height: '100%', top: '0', left: '50%' }} />
+				<div key={`connector-${index}-top`} className="duel-board-cell-connector occupied-connector" style={{ width: '5px', height: '100%', top: '0', left: '50%' }} />
 			)
 		}
 
 		if (rightIndex != undefined && !this.cellIsOccupied(rightIndex)) {
 			cellConnectors.push(
-				<div className="duel-board-cell-connector occupied-connector" style={{ width: '100%', height: '5px', top: '50%', left: '100%' }} />
+				<div key={`connector-${index}-right`} className="duel-board-cell-connector occupied-connector" style={{ width: '100%', height: '5px', top: '50%', left: '100%' }} />
 			)
 		}
 		if (bottomIndex != undefined && !this.cellIsOccupied(bottomIndex)) {
 			cellConnectors.push(
-				<div className="duel-board-cell-connector occupied-connector" style={{ width: '5px', height: '100%', top: '100%', left: '50%' }} />
+				<div key={`connector-${index}-bottom`} className="duel-board-cell-connector occupied-connector" style={{ width: '5px', height: '100%', top: '100%', left: '50%' }} />
 			)
 		}
 

--- a/my-app/src/components/games/duel/board/xalianTypeEffectivenessSummary.js
+++ b/my-app/src/components/games/duel/board/xalianTypeEffectivenessSummary.js
@@ -32,7 +32,7 @@ class XalianTypeEffectivenessSummary extends React.Component {
         if (map) {
             Object.keys(map).forEach(key => {
                 let val = map[key];
-                let badge = <XalianSpeciesBadge hideName type={key.toLowerCase()} />;
+                let badge = <XalianSpeciesBadge key={key.toLowerCase()} hideName type={key.toLowerCase()} />;
                 if (val == 0) { noEffectTypes.push(badge); }
                 if (val == 0.5) { lowEffectTypes.push(badge); }
                 if (val == 1) { mediumEffectTypes.push(badge); }

--- a/my-app/src/components/views/xalianSpeciesSizeComparisonView.js
+++ b/my-app/src/components/views/xalianSpeciesSizeComparisonView.js
@@ -32,11 +32,27 @@ class XalianSpeciesSizeComparisonView extends React.Component {
         // })
 
         let scrollContainer = document.getElementById("species-compare-box");
-        scrollContainer.addEventListener("wheel", (event) => {
+        this.onWheelScroll = (event) => {
             event.preventDefault();
             scrollContainer.scrollLeft += event.deltaY;
-         });
+         };
+        scrollContainer.addEventListener("wheel", this.onWheelScroll);
+
+        this.onWindowResize = () => {
+            this.setSpeciesContent();
+        };
+        window.addEventListener("resize", this.onWindowResize);
 	}
+
+    componentWillUnmount() {
+        let scrollContainer = document.getElementById("species-compare-box");
+        if (scrollContainer && this.onWheelScroll) {
+            scrollContainer.removeEventListener("wheel", this.onWheelScroll);
+        }
+        if (this.onWindowResize) {
+            window.removeEventListener("resize", this.onWindowResize);
+        }
+    }
 
     componentDidUpdate() {
         // fitty.fitAll();
@@ -45,7 +61,9 @@ class XalianSpeciesSizeComparisonView extends React.Component {
 
 
     setSpeciesContent = () => {
-        let s = species;
+        // copy the elements too, not just the array: species.json is a shared module
+        // import and this writes size/heightString onto each entry
+        let s = species.map((element) => ({ ...element }));
         s.forEach(element => {
             element.size = this.getHeight(element);
             element.heightString = translater.translateHeightString(element.height);
@@ -99,7 +117,7 @@ class XalianSpeciesSizeComparisonView extends React.Component {
         let minSizeForWholeWrapper = 150;
 
 		return (
-			<React.Fragment>
+			<React.Fragment key={`species-compare-${x.id}`}>
 				<div className="species-compare-whole-wrapper" style={{ width: x.size * sizeRatio, height: x.size * sizeRatio + spaceToLeaveForSpeciesText, minWidth: Math.max(minSizeForWholeWrapper, x.size * sizeRatio) }}>
 					<div className="species-compare-image-wrapper" style={{ width: x.size * sizeRatio, height: x.size * sizeRatio }}>
 						<a href={'/species/' + x.id}>

--- a/my-app/src/components/xalianStatRatingChart.js
+++ b/my-app/src/components/xalianStatRatingChart.js
@@ -9,12 +9,6 @@ import Table from 'react-bootstrap/Table';
 import * as valueTranslator from '../utils/valueTranslator';
 
 class XalianStatRatingChart extends React.Component {
-	state = {};
-
-	componentDidMount() {
-		this.setState({ data: this.setupData(this.props.stats) });
-	}
-
 	setupData = (stats) => {
 		if (!stats) {
 			return [];
@@ -56,17 +50,18 @@ class XalianStatRatingChart extends React.Component {
 	};
 
 	render() {
+		let data = this.setupData(this.props.stats);
 		return (
 			<div className={(this.props.moreClasses || '') + " centered-view"}>
 				{this.props.stats && (
 					<ResponsiveContainer className="chart-container centered-view">
-						<BarChart data={this.state.data} layout="vertical" maxBarSize={this.props.barSize || 35}>
+						<BarChart data={data} layout="vertical" maxBarSize={this.props.barSize || 35}>
 							<XAxis type="number" hide />
 							<YAxis width={60} type="category" dataKey="statLabel" stroke={this.props.axisLabelColor || '#ffffff'} interval={0} />
 
 								<Bar radius={[10, 10, 10, 10]} isAnimationActive={false} animationBegin={50} dataKey="rangeNumber" fill="#ecff8234">
 									{this.props.includeLabel && <LabelList dataKey="rangeName" position={this.props.labelPosition || 'center'} fill="white" style={{ fontSize: this.props.labelFontSize || '12pt' }} className="chart-bar-label" />}
-									{this.state.data && this.state.data.map((val, index) => <Cell key={`cell-${index}`} fill={valueTranslator.statFieldToBarColor(val.statName)} />)}
+									{data && data.map((val, index) => <Cell key={`cell-${index}`} fill={valueTranslator.statFieldToBarColor(val.statName)} />)}
 								</Bar>
 						</BarChart>
 					</ResponsiveContainer>

--- a/my-app/src/pages/games/duelStartPage.js
+++ b/my-app/src/pages/games/duelStartPage.js
@@ -162,14 +162,14 @@ class DuelStartPage extends React.Component {
                                     value={1}
                                     checked={this.state.players == 1}
                                 >
-                                    <i class="bi bi-person-fill" style={{ paddingRight: '10px', fontSize: '24pt' }}></i> vs. <i class="bi bi-robot" style={{ paddingLeft: '10px', fontSize: '24pt' }}></i>
+                                    <i className="bi bi-person-fill" style={{ paddingRight: '10px', fontSize: '24pt' }}></i> vs. <i className="bi bi-robot" style={{ paddingLeft: '10px', fontSize: '24pt' }}></i>
                                 </ToggleButton>
 
                                 <ToggleButton key={`players-radio-${1}`} id={`players-radio-${1}`} type="radio" variant='xalianGray' name="radio" style={{ width: 'fit-content', margin: 'auto' }}
                                     value={2}
                                     checked={this.state.players == 2}
                                 >
-                                    <i class="bi bi-person-fill" style={{ paddingRight: '10px', fontSize: '24pt' }}></i> vs. <i class="bi bi-person-fill" style={{ paddingLeft: '10px', fontSize: '24pt' }}></i>
+                                    <i className="bi bi-person-fill" style={{ paddingRight: '10px', fontSize: '24pt' }}></i> vs. <i className="bi bi-person-fill" style={{ paddingLeft: '10px', fontSize: '24pt' }}></i>
                                 </ToggleButton>
                                 </ToggleButtonGroup>
 
@@ -197,7 +197,7 @@ class DuelStartPage extends React.Component {
                                         <ToggleButton key={`randomize-positions-1`} id={`randomize-positions-1`} type="checkbox" name="randomize-checkbox" variant={this.state.randomizeStartingPositions ? 'xalianGreen' : 'xalianGray'} style={{ padding: '0px', margin: 'auto', height: '35px', width: '35px' }}
                                             value={true}
                                             checked={this.state.randomizeStartingPositions}
-                                        >{this.state.randomizeStartingPositions && <i class="bi bi-check" style={{ fontSize: '35px', lineHeight: '35px' }} />}</ToggleButton>
+                                        >{this.state.randomizeStartingPositions && <i className="bi bi-check" style={{ fontSize: '35px', lineHeight: '35px' }} />}</ToggleButton>
                                     </ToggleButtonGroup>
 
                                 </div>
@@ -210,7 +210,7 @@ class DuelStartPage extends React.Component {
                                         <ToggleButton key={`debugMode-1`} id={`debugMode-1`} type="checkbox" name="debugMode-checkbox" variant={this.state.debugMode ? 'xalianGreen' : 'xalianGray'} style={{ padding: '0px', margin: 'auto', height: '35px', width: '35px' }}
                                             value={true}
                                             checked={this.state.debugMode}
-                                        >{this.state.debugMode && <i class="bi bi-check" style={{ fontSize: '35px', lineHeight: '35px' }} />}</ToggleButton>
+                                        >{this.state.debugMode && <i className="bi bi-check" style={{ fontSize: '35px', lineHeight: '35px' }} />}</ToggleButton>
                                     </ToggleButtonGroup>
 
                                 </div>

--- a/my-app/src/pages/speciesPage.js
+++ b/my-app/src/pages/speciesPage.js
@@ -65,22 +65,23 @@ class SpeciesPage extends React.Component {
     // }
 
     buildSpeciesGridList() {
-        species.sort((a, b) => a.id - b.id);
+        // copy before sorting: species.json is a shared module import
+        let sorted = [...species].sort((a, b) => a.id - b.id);
         var list = [];
-        for (let ind in species) {
+        for (let ind in sorted) {
             list.push(
-                this.buildSpeciesIcon(species[ind])
+                this.buildSpeciesIcon(sorted[ind])
             );
         }
         return list;
     }
 
     buildStatRows() {
-        species.sort((a, b) => a.id - b.id);
+        let sorted = [...species].sort((a, b) => a.id - b.id);
         var list = [];
-        for (let ind in species) {
+        for (let ind in sorted) {
             list.push(
-                this.buildStatRow(species[ind])
+                this.buildStatRow(sorted[ind])
             );
         }
         return list;
@@ -99,7 +100,7 @@ class SpeciesPage extends React.Component {
 
     buildSpeciesIcon(x) {
         return (
-			<Col md={2} sm={3} xs={6} className="species-col">
+			<Col key={`species-icon-${x.id}`} md={2} sm={3} xs={6} className="species-col">
 				<a href={'/species/' + x.id}>
 					<XalianImage colored bordered speciesName={x.name} primaryType={x.type} moreClasses="xalian-image-grid" />
 					<Row style={{ width: '100%', margin: '0px', padding: '0px' }}>
@@ -121,7 +122,7 @@ class SpeciesPage extends React.Component {
     }
 
     buildStatRow(x) {
-        return <a href={"/species/" + x.id}><XalianSpeciesRowView species={x} /></a>;
+        return <a key={`species-stat-row-${x.id}`} href={"/species/" + x.id}><XalianSpeciesRowView species={x} /></a>;
     }
 
     getTypeColorClassName(x) {

--- a/my-app/src/svg/species/xalianSvg.js
+++ b/my-app/src/svg/species/xalianSvg.js
@@ -78,7 +78,13 @@ class XalianSVG extends React.Component {
         if (speciesName == 'hypnopet') { return <HypnopetSVG style={this.props.style} className={this.props.className} /> }
         if (speciesName == 'drilltail') { return <DrilltailSVG style={this.props.style} className={this.props.className} /> }
         else {
-            const elem = require(`./${this.props.name}.svg`).default;
+            let elem = null;
+            try {
+                elem = require(`./${this.props.name}.svg`).default;
+            } catch (error) {
+                console.log(`No SVG found for species "${this.props.name}"`, error.message);
+                return null;
+            }
                     return (<React.Fragment>
             {elem &&
                 <SVG src={elem} onError={(error) => console.log(error.message)} style={this.props.style} className={this.props.className}/>

--- a/my-app/src/utils/animationUtil.js
+++ b/my-app/src/utils/animationUtil.js
@@ -1,7 +1,6 @@
 import { gsap } from 'gsap';
 import * as constants from '../constants/colorConstants';
 import SmokeEmitter from '../components/animations/smokeEmitter';
-import { ReactDOM } from 'react';
 import ScrambleTextPlugin from 'gsap/ScrambleTextPlugin';
 import TextPlugin from 'gsap/TextPlugin';
 
@@ -12,11 +11,8 @@ export function addShuffleSpeciesColorAnimation(id, delay = 0) {
 	let colors = constants.themeColors;
 	gsap.set(id, { stroke: '#FFFFFF', strokeWidth: '2px', filter: 'drop-shadow(0px 0px 10px #FFFFFF)' });
 	var t = gsap.timeline({ repeat: -1, delay: delay, repeatDelay: 0 });
-  var keys = [];
-  shuffleArray(colors);
-  for (const item in colors) {
-    keys.push(item);
-  }
+  var keys = Object.keys(colors);
+  shuffleArray(keys);
   for (var i = 0; i<10; i++) {
     let randomIndex = Math.floor(Math.random() * keys.length);
     let randomKey = keys[randomIndex];


### PR DESCRIPTION
Fixes #26 — the verified small-fix bundle from the audit, plus three more issues found while checking the result in a browser.

### From the ticket
- **`xalianSpeciesSizeComparisonView`**: wheel listener is removed on unmount; a resize listener now rebuilds sizing; and the shared `species.json` import is no longer sorted **or written to** in place (elements are copied, not just the array — the shallow copy alone still leaked `size`/`heightString` onto shared objects).
- **`xalianStatRatingChart`**: derives chart data in `render()` instead of snapshotting the prop at mount, so it no longer goes stale.
- **Auth modals**: form fields initialise to `''` instead of `null` (uncontrolled→controlled warnings gone).
- **`xalianSvg`**: a species with no matching SVG now degrades to `null` instead of throwing — this previously hard-crashed the duel board.
- **Duplicate keys**: `DuelBoard`, `DuelBoardCell`, `AttackableMoveBadge`, `XalianTypeEffectivenessSummary`.
- **`class` → `className`** on the duel start page icons.
- **`animationUtil`**: removed a nonexistent `ReactDOM` named import from `'react'`; the colour shuffle now operates on a real array instead of silently no-opping on an object.

### Found while verifying in the browser
- `SpeciesPage` and `XalianSpeciesSizeComparisonView` had their own unkeyed lists (not in the ticket) — keyed.
- `speciesPage` was **also** sorting the shared `species.json` import in place, reordering it for every other page — now copies first.
- The duel's action buttons were unkeyed — keyed.

### Verified
- Species page and duel page now log **zero React warnings** (only the expected "no current user" notice when logged out).
- Investigated a `width(0) height(0)` chart warning firing 29× on the species page: benign — the charts mount inside a hidden tab and render correctly (58 bars) once the Stats tab is shown. No fix needed; the Stats tab reads well as a "notable stats" summary.
- 13 tests pass; production build passes with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)