### PR TITLE
Duel: endIf phase guard and symmetric flag rows

### DIFF
--- a/my-app/src/components/games/duel/duel.js
+++ b/my-app/src/components/games/duel/duel.js
@@ -59,11 +59,12 @@ export const Duel = (data) => {
 			let totalSquares = gameConstants.BOARD_COLUMN_SIZE * gameConstants.BOARD_COLUMN_SIZE;
 
 			let grid = duelCalculator.buildGrid(totalSquares);
-			let playerFlagOptions = grid.rows[gameConstants.BOARD_COLUMN_SIZE - 2];
-			let randomPlayerInd = Math.round(Math.random()*(gameConstants.BOARD_COLUMN_SIZE-1));
+			let flagRows = duelCalculator.getFlagRowIndices(gameConstants.BOARD_COLUMN_SIZE);
+			let playerFlagOptions = grid.rows[flagRows.playerFlagRow];
+			let randomPlayerInd = Math.floor(Math.random()*gameConstants.BOARD_COLUMN_SIZE);
 			let opponentTargetFlagIndex = playerFlagOptions[randomPlayerInd];
-			let opponentFlagOptions = grid.rows[1];
-			let randomOpponentInd = Math.round(Math.random()*(gameConstants.BOARD_COLUMN_SIZE-1));
+			let opponentFlagOptions = grid.rows[flagRows.opponentFlagRow];
+			let randomOpponentInd = Math.floor(Math.random()*gameConstants.BOARD_COLUMN_SIZE);
 			let playerTargetFlagIndex = opponentFlagOptions[randomOpponentInd];
 
 			if (playerTargetFlagIndex == undefined || opponentTargetFlagIndex == undefined) {
@@ -267,6 +268,9 @@ export const Duel = (data) => {
 			// 	return { draw: true };
 			// }
 
+			if (ctx.phase !== 'play') {
+				return undefined;
+			}
 
 			if (duelUtil.getOpponentStartingIndices(G).includes(duelUtil.getOpponentFlagIndex(G))) {
 				return { winner: 1 };

--- a/my-app/src/gameplay/duel/__tests__/duelRules.test.js
+++ b/my-app/src/gameplay/duel/__tests__/duelRules.test.js
@@ -114,6 +114,19 @@ describe('movement: carrying a flag slows a piece down', () => {
 	});
 });
 
+describe('setup: flag row placement', () => {
+	it('gives both sides a flag row that is symmetric on an 8x8 board', () => {
+		const { playerFlagRow, opponentFlagRow } = duelCalculator.getFlagRowIndices(duelConstants.BOARD_COLUMN_SIZE);
+		expect(playerFlagRow).toBe(6);
+		expect(opponentFlagRow).toBe(1);
+	});
+
+	it('stays symmetric (equidistant from each side\'s home row) for other board sizes', () => {
+		expect(duelCalculator.getFlagRowIndices(10)).toEqual({ playerFlagRow: 8, opponentFlagRow: 1 });
+		expect(duelCalculator.getFlagRowIndices(6)).toEqual({ playerFlagRow: 4, opponentFlagRow: 1 });
+	});
+});
+
 describe('combat', () => {
 	const CEILING = duelConstants.MAX_SINGLE_HIT_HEALTH_FRACTION * duelConstants.MAX_HEALTH_POINTS;
 

--- a/my-app/src/gameplay/duel/duelCalculator.js
+++ b/my-app/src/gameplay/duel/duelCalculator.js
@@ -42,6 +42,16 @@ export function buildGrid(totalSquares = 0) {
     }
 }
 
+// each side's flag row is the second row in from that side's home row (home rows are the first and last rows of the board)
+export function getFlagRowIndices(boardSize = duelConstants.BOARD_COLUMN_SIZE) {
+    let playerHomeRow = boardSize - 1;
+    let opponentHomeRow = 0;
+    return {
+        playerFlagRow: playerHomeRow - 1,
+        opponentFlagRow: opponentHomeRow + 1
+    };
+}
+
 export function calculateIndicesWithinDistance(currentIndex, distance, G, ctx) {
     let boardSize = duelConstants.BOARD_COLUMN_SIZE;
 


### PR DESCRIPTION
Closes #18.

- **`endIf` now returns early unless `ctx.phase === 'play'`.** It's defined at the game level, so boardgame.io was evaluating win conditions during `setup` too — while pieces were still being placed and `activeXalianIds` could legitimately be empty, which risked declaring a bogus winner before the game began.
- **Both flag rows are derived** via a new pure helper `duelCalculator.getFlagRowIndices(boardSize)`, replacing "one side derived, the other hardcoded to `grid.rows[1]`". Values are identical for the current 8×8 board (rows 6 and 1) but a different board size now stays symmetric.
- **Uniform flag column pick**: `Math.floor(random * size)` instead of `Math.round(random * (size - 1))`, which made the first and last columns half as likely as every other column.

Tests: 2 new cases for the flag-row helper (8×8, plus 10 and 6 to prove symmetry holds), 15 passing total. The `endIf` guard is deliberately untested — it lives inside the boardgame.io game object and covering it would mean restructuring that object for a one-line phase guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)