### PR TITLE
Glossary: four missing lore terms

### DIFF
--- a/lambda/src/json/glossary.json
+++ b/lambda/src/json/glossary.json
@@ -250,5 +250,21 @@
     {
         "word": "QED",
         "definition": "Quantum Entanglement Device. A specially engineered computer chip exposed to a Bloodstorm on Zolton, which can be used to link communications equipment across the galaxy."
+    },
+    {
+        "word": "Leviticus Overdrive",
+        "definition": "The name given to the Phantiri Generator's unprecedented act of re-writing its own code after centuries of watching its creations die on arrival. Under this new programming it abandoned organic life entirely, learning instead to produce ghost-like Xalians formed of spectral energy with no corporeal bodies at all."
+    },
+    {
+        "word": "Dreadscape",
+        "definition": "The vast wasteland blanketing Phantiri, formed from the piled remains of the countless Xalians its Generator produced only for them to die on sight. Their bodies have compressed into islands of corpses crowned with macabre forests of splayed limbs, divided by deep, tarry oceans of the fluids that seep from a planetwide mass grave."
+    },
+    {
+        "word": "Veridians",
+        "definition": "The people of Veridium. During the End Wars, APEX drove the planet's ancient drones and robotic servants as a single hive mind and corralled the Veridians into a formidable fighting force, supplied by starship foundries large enough to spread its menace across the galaxy."
+    },
+    {
+        "word": "Battle Fee",
+        "definition": "A value assigned to each Xalian based on the strength of its stats, used to keep King Kozrak's tournaments competitive. A faction may only enter a team whose combined battle fee falls within the imposed battle fee limit."
     }
 ]

--- a/my-app/src/json/glossary.json
+++ b/my-app/src/json/glossary.json
@@ -250,5 +250,21 @@
     {
         "word": "QED",
         "definition": "Quantum Entanglement Device. A specially engineered computer chip exposed to a Bloodstorm on Zolton, which can be used to link communications equipment across the galaxy."
+    },
+    {
+        "word": "Leviticus Overdrive",
+        "definition": "The name given to the Phantiri Generator's unprecedented act of re-writing its own code after centuries of watching its creations die on arrival. Under this new programming it abandoned organic life entirely, learning instead to produce ghost-like Xalians formed of spectral energy with no corporeal bodies at all."
+    },
+    {
+        "word": "Dreadscape",
+        "definition": "The vast wasteland blanketing Phantiri, formed from the piled remains of the countless Xalians its Generator produced only for them to die on sight. Their bodies have compressed into islands of corpses crowned with macabre forests of splayed limbs, divided by deep, tarry oceans of the fluids that seep from a planetwide mass grave."
+    },
+    {
+        "word": "Veridians",
+        "definition": "The people of Veridium. During the End Wars, APEX drove the planet's ancient drones and robotic servants as a single hive mind and corralled the Veridians into a formidable fighting force, supplied by starship foundries large enough to spread its menace across the galaxy."
+    },
+    {
+        "word": "Battle Fee",
+        "definition": "A value assigned to each Xalian based on the strength of its stats, used to keep King Kozrak's tournaments competitive. A faction may only enter a team whose combined battle fee falls within the imposed battle fee limit."
     }
 ]


### PR DESCRIPTION
Closes #33.

Audited all 63 existing entries against the planet histories rather than assuming. **Coverage was much better than the ticket suggested** — 28 of 33 key lore terms were already defined (End Wars, Scrambler Token, Source Code 606, Nemesis Plague, Terracannon, Deepwater Black, Thousand Families, ECHELON, Bloodstorm, QED, Algael, Benthane, Nightcap and more).

Four genuine gaps, each written from the source text in `planets.json`:

- **Leviticus Overdrive** — the Phantiri Generator re-writing its own code to produce non-corporeal Xalians. Named in Phantiri's history but never defined.
- **Dreadscape** — the wasteland of piled Xalian corpses covering Phantiri. Same situation.
- **Veridians** — the demonym was missing even though Magmuthites and Zolto both have entries.
- **Battle Fee** — canon on the home page and central to the tournament economy, but undefined anywhere. Also directly relevant to the progression/tokenomics discussion.

Two things I nearly got wrong and caught while verifying:
- The file looks alphabetical but **isn't** — the first ~45 entries are alphabetical and the tail is thematically grouped by planet (Poseidas → Death Tide → Algael → Saiphus → Benthane). An alphabetical re-sort would have destroyed that deliberate structure, so the new entries are appended.
- Re-serialising with 2-space indentation rewrote all 500 lines; matching the file's existing 4-space style keeps the diff to the 17 lines actually added (plus the missing trailing newline).

Frontend copy re-synced via `copy-json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)