### PR TITLE
Add a how-to-play panel to the duel

### DIFF
--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -276,6 +276,16 @@ body { width: 100%; max-width: 100%; height: auto;
   z-index: 99999 !important;
 }
 
+/* the navbar above sits at 99999, which would otherwise cover the top of any
+   modal (bootstrap's own modal layer is only 1055). modals must outrank it. */
+.modal-backdrop {
+  z-index: 99999;
+}
+
+.modal {
+  z-index: 100000 !important;
+}
+
 .navbar {
   padding: 0;
 }

--- a/my-app/src/components/games/duel/board/duelBoard.js
+++ b/my-app/src/components/games/duel/board/duelBoard.js
@@ -23,6 +23,7 @@ import XalianDuelStatBadge from './xalianDuelStatBadge';
 import DuelBoardCell from './duelBoardCell';
 import AttackActionModal from './attackActionModal';
 import AttackMoveChooserModal from './attackMoveChooserModal';
+import HowToPlayModal from '../howToPlayModal';
 import { useSelector, useDispatch } from 'react-redux'
 import { addAnimationToQueue } from '../../../../store/duelAnimationQueueSlice';
 import { AnimationHub } from '../../../../store/AnimationHub';
@@ -53,7 +54,8 @@ class DuelBoard extends React.Component {
 		animationTl: gsap.timeline(),
 		logIndex: 0,
 		showXalianDetails: false,
-		animationIndex: -1
+		animationIndex: -1,
+		showHowToPlay: false
 	};
 
 	static propTypes = {
@@ -80,9 +82,20 @@ class DuelBoard extends React.Component {
 		document.addEventListener('DOMContentLoaded', this.updateSize);
 		window.addEventListener('resize', this.updateSize);
 		this.updateSize();
-		// alert("READ THIS FIRST! (DEBUG MODE: after you tap ok, tap the white-boxed arrow to hide the debug menu) READ THIS NEXT PART THEN TAP OK! =====> GOAL OF GAME ==> grab your blue flag and move it to your side's first row (bottom of board), OR defeat all enemies :::::::: HOW TO PLAY: (you are blue) ==> you can move any of your pieces on your turn, up to 3 spaces per turn :: the 3 spaces do not have to be moved by the same piece :: you are allowed one attack per turn :: you can move and attack in any order :: once a piece's health reaches 0, it is eliminated :: you can move more than once per turn, as long as your total spaces moved and your active pieces' range allows it :: when a piece is selected, the red X's indicate how effective your selected piece's attack would be against the opponent, the red-striped circles indicate attack range, the green dots indicate viable moves :: a piece cannot move through another piece :: bot goes first :: have fun!");
+		this.showHowToPlayOnFirstVisit();
 		this.transitionClientViewForActivePlayer();
 		
+	}
+
+	showHowToPlayOnFirstVisit = () => {
+		if (!LocalDuelStorage.hasSeenHowToPlay()) {
+			this.setState({ showHowToPlay: true });
+		}
+	}
+
+	onHideHowToPlay = () => {
+		LocalDuelStorage.setHowToPlaySeen();
+		this.setState({ showHowToPlay: false });
 	}
 
 	isAnimationHappening = () => {
@@ -532,6 +545,12 @@ class DuelBoard extends React.Component {
 		}
 
 		userActionButtons.push(
+			<Col key="duel-action-how-to-play" xs="auto" style={{ display: 'flex', justifyContent: 'center' }}>
+				<Button variant='xalianGray' title='How to play' aria-label='How to play' onClick={() => this.setState({ showHowToPlay: true })} style={{ margin: 'auto', marginBottom: '10px', marginTop: '10px' }} ><i className="bi bi-question-lg" /></Button>
+			</Col>
+		)
+
+		userActionButtons.push(
 			<Col key="duel-action-end-turn" style={{ display: 'flex', justifyContent: 'center' }}>
 				<Button variant='xalianGray' disabled={!showEndTurnButton} onClick={this.endPlayerTurn} style={{ margin: 'auto', marginBottom: '10px', marginTop: '10px' }} >End turn</Button>
 			</Col>
@@ -703,6 +722,8 @@ class DuelBoard extends React.Component {
 									}
 
 									<FadeAlert />
+
+								<HowToPlayModal show={this.state.showHowToPlay} onHide={this.onHideHowToPlay} />
 
 									{this.state.pendingAttack &&
 										<AttackMoveChooserModal

--- a/my-app/src/components/games/duel/howToPlayModal.js
+++ b/my-app/src/components/games/duel/howToPlayModal.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+import * as duelConstants from '../../../gameplay/duel/duelGameConstants';
+
+// The rules text is derived from constants rather than hardcoded so it cannot
+// drift away from the actual game as tunables change.
+const MAX_HIT_PERCENT = Math.round(duelConstants.MAX_SINGLE_HIT_HEALTH_FRACTION * 100);
+const MAX_EVASION_PERCENT = Math.round(duelConstants.MAX_EVASION_DAMAGE_REDUCTION * 100);
+
+const SECTIONS = [
+    {
+        title: 'The goal',
+        icon: 'bi-flag-fill',
+        lines: [
+            'Two flags sit on the board — one on each side. Carry the enemy flag back to your home row (your back row) and you win instantly.',
+            'Eliminating every enemy piece also wins the duel.',
+        ],
+    },
+    {
+        title: 'Setting up',
+        icon: 'bi-grid-3x3-gap-fill',
+        lines: [
+            'Before play begins, place each of your pieces on any open square of your home row. Tap a piece below the board, then tap the square you want it on.',
+        ],
+    },
+    {
+        title: 'Your turn',
+        icon: 'bi-hourglass-split',
+        lines: [
+            `Each turn your team gets ${duelConstants.MAX_SPACES_MOVED_PER_TURN} squares of movement to spend and exactly one attack.`,
+            'The movement is a shared pool — spend it all on one piece, or split it between several. You can move and attack in any order.',
+            'End your turn early at any time with the End turn button.',
+        ],
+    },
+    {
+        title: 'Moving',
+        icon: 'bi-arrows-move',
+        lines: [
+            'Tap a piece to select it, then tap a highlighted square to move there. Movement is orthogonal — no diagonals.',
+            'Each piece also has its own range limit of 1 to 3 squares per turn, no matter how much team movement is left.',
+            'Pieces block movement, so you have to path around a crowd — unless the piece can fly, in which case it moves over other pieces (it still cannot land on an occupied square).',
+            `A piece carrying a flag is slowed to ${duelConstants.FLAG_CARRIER_MAX_SPACES_PER_TURN} squares per turn, so a fast grab still has to survive the walk home.`,
+        ],
+    },
+    {
+        title: 'Attacking',
+        icon: 'bi-lightning-charge-fill',
+        lines: [
+            'Select a piece and tap an enemy in range to attack. Each species has its own reach of 1 to 3 squares, and attacks ignore blockers — there is no line of sight.',
+            'You then choose which of that piece\'s four moves to use, or a plain Basic Attack. Every option shows its estimated damage and how effective it will be before you commit.',
+            'Damage depends on the attacker\'s attack stat against the defender\'s defense, the move\'s rating, and elemental matchups. A move matching the attacker\'s own element hits 50% harder.',
+            `Elemental matchups swing hard: a move can be resisted, doubled, or blocked outright. No single hit can take more than ${MAX_HIT_PERCENT}% of a full health bar, so nothing is ever a one-shot.`,
+            `A high evasion stat blunts incoming damage by up to ${MAX_EVASION_PERCENT}%.`,
+        ],
+    },
+    {
+        title: 'Stamina',
+        icon: 'bi-battery-half',
+        lines: [
+            `Every piece has up to ${duelConstants.MAX_STAMINA_POINTS} stamina. Moving costs 1 per square and attacking costs more the further away the target is.`,
+            'Pieces recover 1 stamina each turn, so a piece that has been working hard needs a turn to breathe.',
+        ],
+    },
+    {
+        title: 'Flags',
+        icon: 'bi-flag',
+        lines: [
+            'Knock out a flag carrier and the flag drops on the square where they fell — anyone can pick it up from there.',
+            'Step your own piece onto your dropped flag to return it to its starting square.',
+        ],
+    },
+    {
+        title: 'Reading the board',
+        icon: 'bi-eye-fill',
+        lines: [
+            'Green dots are squares your selected piece can move to.',
+            'Red striped circles show how far that piece can attack.',
+            'A red X marks an enemy you can hit right now — the bigger and brighter it is, the better the matchup.',
+        ],
+    },
+];
+
+class HowToPlayModal extends React.Component {
+
+    renderSection = (section) => {
+        return (
+            <div key={`duel-how-to-${section.title}`} style={{ marginBottom: '22px' }}>
+                <h6 style={{ color: '#3ddc5b', marginBottom: '8px', textTransform: 'uppercase', letterSpacing: '0.05em', fontSize: '0.8em' }}>
+                    <i className={`bi ${section.icon}`} style={{ marginRight: '8px' }} />
+                    {section.title}
+                </h6>
+                {section.lines.map((line, i) => (
+                    <p key={`duel-how-to-${section.title}-${i}`} style={{ color: '#d8d8d8', fontSize: '0.9em', marginBottom: '6px', lineHeight: '1.45' }}>
+                        {line}
+                    </p>
+                ))}
+            </div>
+        );
+    }
+
+    render() {
+        return (
+            <Modal
+                show={this.props.show}
+                onHide={this.props.onHide}
+                size="lg"
+                centered
+                scrollable
+                className="themed-modal dark-themed-modal"
+            >
+                <Modal.Header closeButton closeVariant="white" style={{ borderBottom: '1px solid #444', backgroundColor: '#1a1a1a' }}>
+                    <Modal.Title style={{ color: 'white', fontSize: '1.2em' }}>How to play Duel</Modal.Title>
+                </Modal.Header>
+                <Modal.Body style={{ backgroundColor: '#1a1a1a' }}>
+                    <p style={{ color: '#a0a0a0', fontSize: '0.9em', marginBottom: '20px' }}>
+                        Duel is a squad tactics game: capture the flag on a chess-sized board, with elemental creatures instead of chess pieces.
+                    </p>
+                    {SECTIONS.map(this.renderSection)}
+                </Modal.Body>
+                <Modal.Footer style={{ borderTop: '1px solid #444', backgroundColor: '#1a1a1a' }}>
+                    <Button variant="xalianGreen" onClick={this.props.onHide}>Got it</Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+
+}
+
+export default HowToPlayModal;

--- a/my-app/src/pages/games/duelStartPage.js
+++ b/my-app/src/pages/games/duelStartPage.js
@@ -24,13 +24,16 @@ import * as duelConstants from '../../gameplay/duel/duelGameConstants';
 import * as duelPieceBuilder from '../../gameplay/duel/duelPieceBuilder';
 import gsap from 'gsap';
 import DuelPage from './duelPage';
+import HowToPlayModal from '../../components/games/duel/howToPlayModal';
+import LocalDuelStorage from '../../store/LocalStorage';
 
 class DuelStartPage extends React.Component {
 
     state = {
         randomizeStartingPositions: true,
         debugMode: process.env.NODE_ENV !== 'production',
-        selectedXalianIds: []
+        selectedXalianIds: [],
+        showHowToPlay: false
     }
 
     // componentDidUpdate(prevProps, prevState) {
@@ -61,6 +64,13 @@ class DuelStartPage extends React.Component {
             .catch(() => {
                 // signed out or API unavailable — duel falls back to random squads
             });
+    }
+
+    // reading the rules here counts as having seen them, so the board does not
+    // pop the same modal again the moment the duel starts
+    onHideHowToPlay = () => {
+        LocalDuelStorage.setHowToPlaySeen();
+        this.setState({ showHowToPlay: false });
     }
 
     handleStartClicked = () => {
@@ -202,6 +212,7 @@ class DuelStartPage extends React.Component {
 
                                 </div>
 
+                                {process.env.NODE_ENV !== 'production' &&
                                 <div style={{ height: '100%', display: 'flex', justifyContent: 'space-evenly', alignItems: 'stretch', alignContent: 'center', marginTop: '50px'}}>
                                     <h4 style={{ marginTop: 'auto', marginBottom: 'auto', alignSelf: 'center', textAlign: 'center', width: 'fit-content' }}>Debug Mode:</h4>
                                     <ToggleButtonGroup style={{ textAlign: 'center', width: '35px' }} type='checkbox' onChange={(e) =>
@@ -214,10 +225,17 @@ class DuelStartPage extends React.Component {
                                     </ToggleButtonGroup>
 
                                 </div>
+                                }
 
-                                <Button onClick={this.handleStartClicked}
-                                size='lg' disabled={!this.state.players  || !this.state.numberOfPieces} variant='xalianGreen' style={{ width: 'fit-content', margin: 'auto', marginTop: '50px'}}>Start Duel!</Button>
+                                <div style={{ display: 'flex', justifyContent: 'center', gap: '15px', flexWrap: 'wrap', marginTop: '50px' }}>
+                                    <Button onClick={() => this.setState({ showHowToPlay: true })}
+                                    size='lg' variant='xalianGray' style={{ width: 'fit-content' }}>How to Play</Button>
+                                    <Button onClick={this.handleStartClicked}
+                                    size='lg' disabled={!this.state.players  || !this.state.numberOfPieces} variant='xalianGreen' style={{ width: 'fit-content' }}>Start Duel!</Button>
+                                </div>
                             </div>
+
+                            <HowToPlayModal show={this.state.showHowToPlay} onHide={this.onHideHowToPlay} />
 
                         {/* </GameContainer> */}
 

--- a/my-app/src/store/LocalStorage.js
+++ b/my-app/src/store/LocalStorage.js
@@ -64,7 +64,31 @@ var LocalDuelStorage = (function () {
     };
     
 
+    // unlike the rest of this module, "have they read the rules?" should outlive the
+    // browser session - so it uses localStorage, guarded because private-mode browsers
+    // can throw on access rather than simply returning nothing.
+    var HOW_TO_PLAY_SEEN_KEY = 'duel_how_to_play_seen';
+
+    var hasSeenHowToPlay = function () {
+        try {
+            return window.localStorage.getItem(HOW_TO_PLAY_SEEN_KEY) === 'true';
+        } catch (e) {
+            return true; // can't remember the dismissal, so don't nag on every visit
+        }
+    };
+
+    var setHowToPlaySeen = function () {
+        try {
+            window.localStorage.setItem(HOW_TO_PLAY_SEEN_KEY, 'true');
+        } catch (e) {
+            // nothing to do - the modal is still reachable from the ? button
+        }
+    };
+
+
     return {
+        hasSeenHowToPlay: hasSeenHowToPlay,
+        setHowToPlaySeen: setHowToPlaySeen,
         getBoardSize: getBoardSize,
         setBoardSize: setBoardSize,
         getSelectedXalianId: getSelectedXalianId,


### PR DESCRIPTION
Fixes #49.

Visitors could reach the duel from the navbar with no idea how to play — no rules text, tooltip, or onboarding anywhere. The only written explanation was a commented-out `alert()` in `duelBoard.js`.

That copy is now a real `HowToPlayModal`, updated for the rules added since it was written: per-move attack selection, type effectiveness and STAB, the 75% damage ceiling, flying pieces pathing over others, and the 2-square flag-carrier cap. Every number in the text is read from `duelGameConstants`, so the rules can't drift from the game when tunables change. I verified each claim against the implementation rather than trusting the old copy — including that `PF.AStarFinder()` defaults to non-diagonal, and that attack stamina cost is distance-to-target.

**Entry points:** a `How to Play` button on the start screen, a `?` button beside `End turn` on the board, and an automatic first-visit open. Dismissing it anywhere sets a `localStorage` flag (guarded with try/catch — private-mode browsers throw rather than no-op) so it auto-opens only once.

### Two things found while verifying

- **`.xalian-navbar` has `z-index: 99999 !important`**, which put *every* bootstrap modal in the app (layer 1055) underneath it. The existing attack chooser is `size="sm"` and centered, so it happened to sit clear of the navbar and nobody noticed. This one didn't — its header and close button were covered. Modals now outrank the navbar globally.
- **The `Debug Mode` toggle on the start screen was rendering in production**, alongside the DEBUG button hidden in #48. Now dev-only.

### Verification

Driven in a real browser against a production build at 390×844: modal opens from both entry points, auto-opens on first visit, doesn't re-open after dismissal, and the seen flag persists. Screenshots confirm the header is no longer clipped. 15/15 duel rules tests pass; production build compiles.