### PR TITLE
Design system: token layer + first applications

### DIFF
--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -273,17 +273,18 @@ body { width: 100%; max-width: 100%; height: auto;
   /* border-radius: 6px; */
   width: 100%;
   opacity: 1;
-  z-index: 99999 !important;
+  z-index: var(--x-layer-navbar) !important;
 }
 
-/* the navbar above sits at 99999, which would otherwise cover the top of any
-   modal (bootstrap's own modal layer is only 1055). modals must outrank it. */
+/* the navbar above sits at --x-layer-navbar, which would otherwise cover the
+   top of any modal (bootstrap's own modal layer is only 1055). Modals must
+   outrank it. Both live in the layer scale in tokens.css. */
 .modal-backdrop {
-  z-index: 99999;
+  z-index: var(--x-layer-navbar);
 }
 
 .modal {
-  z-index: 100000 !important;
+  z-index: var(--x-layer-modal) !important;
 }
 
 .navbar {
@@ -1500,18 +1501,33 @@ section {
 --------------------------------------------------------------*/
 
 
+/* The panel itself carries the measure, rather than each child centring its own
+   copy - the heading and the prose sit in different containers, so centring
+   them separately left the heading floating off to one side. */
 .story-splash-section {
   background: radial-gradient(circle, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%);
-  border: 5px outset #80ffb183;
-  border-radius: 10px;
-  padding: 10px;
+  border: 2px solid var(--x-green-a30);
+  border-radius: var(--x-radius-lg);
+  box-shadow: var(--x-glow-inset) var(--x-green-a15);
+  padding: var(--x-space-6);
+  max-width: calc(var(--x-measure) + (2 * var(--x-space-6)));
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.story-splash-section h3 {
+  margin-bottom: var(--x-space-5);
+  color: var(--x-green);
 }
 
 .story-text {
-  color: whitesmoke;
+  color: var(--x-text-muted);
   font-weight: lighter !important;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  /* font-size: 80%; */
+  /* was a Segoe UI stack, the only place on the site that broke from the
+     body font - the lore read like it came from a different product */
+  font-family: var(--x-font-body);
+  line-height: 1.6;
+  margin-bottom: var(--x-space-4);
 }
 
 
@@ -2323,8 +2339,7 @@ article {
 }
 
 .planet-table tbody * td {
-  /* color: rgb(179, 179, 179); */
-  color: #;
+  color: var(--x-text-muted);
   padding: 3px;
   font-style: italic;
   text-align: left !important;
@@ -2708,24 +2723,85 @@ article {
 */
 
 .glossary-wrapper {
-  padding-top: 25px;
+  padding-top: var(--x-space-5);
+  padding-bottom: var(--x-space-8);
 }
 
+/* each term is its own surface, so 63 entries scan as a list of cards rather
+   than one unbroken wall of prose */
 .glossary-word-row {
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding: var(--x-space-4) var(--x-space-3);
+  margin-bottom: var(--x-space-3);
+  border: 1px solid var(--x-border);
+  border-left: 3px solid var(--x-green-a60);
+  border-radius: var(--x-radius-md);
+  background-color: rgba(0, 0, 0, 0.35);
+  transition: border-color var(--x-transition-fast), background-color var(--x-transition-fast);
 }
 
-.glossary-word-row h3 {
-  font-weight: bolder;
+.glossary-word-row:hover {
+  border-color: var(--x-green-a30);
+  border-left-color: var(--x-green);
+  background-color: var(--x-surface-1);
 }
 
-.glossary-word-row h5 {
-  color: white;
+.glossary-list {
+  margin-bottom: 0;
 }
 
 .glossary-title {
   text-align: right;
+  font-weight: bolder;
+  font-size: var(--x-text-lg);
+  color: var(--x-green);
+  margin-bottom: 0;
+}
+
+.glossary-definition {
+  color: var(--x-text-muted);
+  line-height: 1.55;
+  margin-bottom: 0;
+}
+
+.glossary-search {
+  margin-top: var(--x-space-3);
+}
+
+/* bootstrap's .input-group-text ships a light background, which reads as a
+   white block against the starfield - hence the overrides */
+.glossary-search-icon.input-group-text {
+  background-color: var(--x-surface-2) !important;
+  border: 1px solid var(--x-border) !important;
+  border-right: none !important;
+  color: var(--x-green) !important;
+}
+
+.glossary-search-input {
+  background-color: var(--x-surface-2) !important;
+  border: 1px solid var(--x-border) !important;
+  color: var(--x-text) !important;
+}
+
+.glossary-search-input::placeholder {
+  color: var(--x-text-dim);
+}
+
+.glossary-search-input:focus {
+  border-color: var(--x-green-a60) !important;
+  box-shadow: 0 0 0 0.2rem var(--x-green-a15) !important;
+}
+
+.glossary-result-count {
+  color: var(--x-text-dim);
+  font-size: var(--x-text-sm);
+  text-align: right;
+  margin: var(--x-space-2) 0 0 0;
+}
+
+.glossary-empty {
+  color: var(--x-text-dim);
+  text-align: center;
+  padding: var(--x-space-7) 0;
 }
 
 /* HAPPENS WHEN SCREEN GOES TO SMALL OR XSMALL I THINK */
@@ -3129,13 +3205,16 @@ input, textarea {
   width: 100%;
 }
 
+/* the label is chrome and the value is the information, so the value gets the
+   emphasis. This was inverted - values were `gray` (~4.0:1 on the page
+   background, under the 4.5:1 minimum) against pure-white labels. */
 .species-detail-chart-header {
-  color: white;
+  color: var(--x-text-dim);
   text-align: right;
 }
 
 .species-detail-chart-text {
-  color: gray;
+  color: var(--x-text);
   text-align: left;
 }
 

--- a/my-app/public/assets/css/tokens.css
+++ b/my-app/public/assets/css/tokens.css
@@ -1,0 +1,203 @@
+/**
+ * Xalians design tokens
+ * -----------------------------------------------------------------------------
+ * The single source of truth for colour, spacing, radius, type scale and glow.
+ *
+ * Before this file the brand palette lived in a COMMENT at the top of style.css
+ * and was then hand-copied as raw hex into ~70 places across the CSS and another
+ * ~67 inline styles in JSX. Anything reused should be added here rather than
+ * pasted as a literal.
+ *
+ * Element/type colours are mirrored in src/constants/colorConstants.js, which is
+ * what the JS side reads. The two are kept honest by a test:
+ * src/__tests__/designTokens.test.js fails if they ever drift apart.
+ */
+
+:root {
+	/* --- brand ------------------------------------------------------------ */
+	--x-green: #80ffb0;
+	--x-green-hover: #b3ffd0;
+	--x-green-active: #57aa77;
+	--x-green-border: #6bd493;
+	/* translucent greens, for borders and focus rings */
+	--x-green-a15: rgba(128, 255, 176, 0.15);
+	--x-green-a30: rgba(128, 255, 176, 0.3);
+	--x-green-a60: rgba(128, 255, 176, 0.6);
+
+	/* --- surfaces --------------------------------------------------------- */
+	/* the galactic backdrop: near-black, never pure #000, so starfields read */
+	--x-bg: #0d0d0d;
+	--x-surface-1: #151515;
+	--x-surface-2: #1a1a1a;
+	--x-surface-3: #232323;
+	--x-surface-overlay: rgba(13, 13, 13, 0.85);
+	--x-border: #333333;
+	--x-border-strong: #4a4a4a;
+
+	/* --- text ------------------------------------------------------------- */
+	--x-text: #ffffff;
+	--x-text-muted: #cccccc;
+	/* --x-text-dim is the lowest step that still clears 4.5:1 on --x-bg;
+	   anything fainter is decorative only and must not carry meaning */
+	--x-text-dim: #949494;
+	--x-text-inverse: #000000;
+
+	/* --- feedback --------------------------------------------------------- */
+	--x-danger: #ff5b5b;
+	--x-warning: #e2bd43;
+	--x-success: var(--x-green);
+
+	/* --- element / type colours ------------------------------------------- */
+	/* mirrored in src/constants/colorConstants.js - see note above */
+	--x-type-fire: #df6d5e;
+	--x-type-water: #60a0c5;
+	--x-type-air: #ffffff;
+	--x-type-electric: #e2bd43;
+	--x-type-rock: #8d7050;
+	--x-type-plant: #708844;
+	--x-type-chemical: #64bd9f;
+	--x-type-light: #ffffc7;
+	--x-type-dark: #57619c;
+	--x-type-metal: #8d8d8d;
+	--x-type-psychic: #d39bcb;
+	--x-type-ghost: #8764a8;
+	--x-type-ice: #85dde4;
+	--x-type-sand: #e6b26f;
+
+	/* --- spacing ---------------------------------------------------------- */
+	--x-space-1: 4px;
+	--x-space-2: 8px;
+	--x-space-3: 12px;
+	--x-space-4: 16px;
+	--x-space-5: 24px;
+	--x-space-6: 32px;
+	--x-space-7: 48px;
+	--x-space-8: 64px;
+
+	/* --- radius ----------------------------------------------------------- */
+	--x-radius-sm: 6px;
+	--x-radius-md: 10px;
+	--x-radius-lg: 16px;
+	--x-radius-xl: 25px;
+	--x-radius-pill: 999px;
+
+	/* --- elevation / glow ------------------------------------------------- */
+	/* glow is this site's depth cue instead of drop shadow - space has no sun */
+	--x-glow-inset: inset 0px 0px 30px;
+	--x-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.5);
+	--x-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.6);
+
+	/* --- typography ------------------------------------------------------- */
+	--x-font-display: 'ProcrastinatingPixie', 'Abel', sans-serif;
+	--x-font-body: 'Abel', 'Open Sans', sans-serif;
+	--x-text-xs: 0.75rem;
+	--x-text-sm: 0.875rem;
+	--x-text-md: 1rem;
+	--x-text-lg: 1.25rem;
+	--x-text-xl: 1.75rem;
+	--x-text-2xl: 2.5rem;
+	/* cap body copy at a readable measure - the lore sections used to run the
+	   full 1400px viewport, roughly 200 characters per line */
+	--x-measure: 70ch;
+
+	/* --- motion ----------------------------------------------------------- */
+	--x-transition-fast: 0.15s ease;
+	--x-transition: 0.3s ease;
+
+	/* --- layers ----------------------------------------------------------- */
+	/* the navbar historically sat at 99999, which put every bootstrap modal
+	   (1055) underneath it. Layers belong in one ordered list, here. */
+	--x-layer-navbar: 99999;
+	--x-layer-modal: 100000;
+}
+
+/*--------------------------------------------------------------
+# Primitives
+# Built from the language already proven on the planets page: a
+# tinted, inset-glowing panel keyed to an element colour.
+--------------------------------------------------------------*/
+
+/* A surface panel. Set --x-panel-tint on it (or use .x-panel--type-* below)
+   to key it to an element colour; it falls back to the brand green. */
+.x-panel {
+	--x-panel-tint: var(--x-green);
+	border: solid 2px color-mix(in srgb, var(--x-panel-tint) 60%, transparent);
+	box-shadow: var(--x-glow-inset) var(--x-panel-tint);
+	background-color: color-mix(in srgb, var(--x-panel-tint) 12%, rgba(0, 0, 0, 0.75));
+	border-radius: var(--x-radius-xl);
+	padding: var(--x-space-5);
+}
+
+/* A quieter panel for dense content (lists, tables) where a full glow is noise */
+.x-panel--flat {
+	box-shadow: none;
+	border-width: 1px;
+	border-radius: var(--x-radius-md);
+	background-color: var(--x-surface-1);
+}
+
+/* Constrain body copy to a readable line length, centred in its column. */
+.x-measure {
+	max-width: var(--x-measure);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+/* Section heading used above panels and page sections. */
+.x-section-title {
+	color: var(--x-green);
+	font-family: var(--x-font-body);
+	margin-bottom: var(--x-space-4);
+}
+
+/* Tabs. Bootstrap's defaults are blue links on a white pill, which is the one
+   piece of unthemed chrome that reads as broken against the starfield. */
+.x-tabs.nav-tabs {
+	border-bottom: 1px solid var(--x-border);
+	gap: var(--x-space-2);
+}
+
+.x-tabs.nav-tabs .nav-link {
+	color: var(--x-text-muted);
+	background-color: transparent;
+	border: 1px solid transparent;
+	border-bottom: none;
+	border-radius: var(--x-radius-md) var(--x-radius-md) 0 0;
+	padding: var(--x-space-2) var(--x-space-4);
+	transition: color var(--x-transition-fast), background-color var(--x-transition-fast);
+}
+
+.x-tabs.nav-tabs .nav-link:hover {
+	color: var(--x-green-hover);
+	background-color: var(--x-green-a15);
+	border-color: transparent;
+}
+
+.x-tabs.nav-tabs .nav-link.active {
+	color: var(--x-green);
+	background-color: var(--x-surface-2);
+	border-color: var(--x-green-a30);
+	border-bottom-color: transparent;
+}
+
+.x-tabs.nav-tabs .nav-link:focus-visible {
+	outline: 2px solid var(--x-green);
+	outline-offset: -2px;
+}
+
+/* Element-keyed panel tints, so JSX can pick a panel colour with a class
+   instead of computing inline styles. */
+.x-panel--type-fire { --x-panel-tint: var(--x-type-fire); }
+.x-panel--type-water { --x-panel-tint: var(--x-type-water); }
+.x-panel--type-air { --x-panel-tint: var(--x-type-air); }
+.x-panel--type-electric { --x-panel-tint: var(--x-type-electric); }
+.x-panel--type-rock { --x-panel-tint: var(--x-type-rock); }
+.x-panel--type-plant { --x-panel-tint: var(--x-type-plant); }
+.x-panel--type-chemical { --x-panel-tint: var(--x-type-chemical); }
+.x-panel--type-light { --x-panel-tint: var(--x-type-light); }
+.x-panel--type-dark { --x-panel-tint: var(--x-type-dark); }
+.x-panel--type-metal { --x-panel-tint: var(--x-type-metal); }
+.x-panel--type-psychic { --x-panel-tint: var(--x-type-psychic); }
+.x-panel--type-ghost { --x-panel-tint: var(--x-type-ghost); }
+.x-panel--type-ice { --x-panel-tint: var(--x-type-ice); }
+.x-panel--type-sand { --x-panel-tint: var(--x-type-sand); }

--- a/my-app/public/assets/css/typeColors.css
+++ b/my-app/public/assets/css/typeColors.css
@@ -1,51 +1,57 @@
-.fire-color {background-color: #df6d5e;}
-.water-color {background-color: #60a0c5;}
-.air-color {background-color: #ffffff;}
-.electric-color {background-color: #e2bd43;}
-.rock-color {background-color: #8d7050;}
-.plant-color {background-color: #708844;}
-.chemical-color {background-color: #64bd9f;}
-.light-color {background-color: #ffffc7;}
-/* .dark-color {background-color: #57619c;} */
+/**
+ * Element colour utilities.
+ *
+ * Every value here comes from the --x-type-* tokens in tokens.css; this file
+ * only maps them onto the three properties the app actually paints with.
+ * Add a new element by adding its token, then one line in each block below.
+ */
 
-.dark-color {background-color: #57619c;}
-.metal-color {background-color: #8d8d8d;}
-.psychic-color {background-color: #d39bcb;}
-.ghost-color {background-color: #8764a8;}
-.ice-color {background-color: #85dde4;}
-.sand-color {background-color: #e6b26f;}
+/* background color */
+.fire-color {background-color: var(--x-type-fire);}
+.water-color {background-color: var(--x-type-water);}
+.air-color {background-color: var(--x-type-air);}
+.electric-color {background-color: var(--x-type-electric);}
+.rock-color {background-color: var(--x-type-rock);}
+.plant-color {background-color: var(--x-type-plant);}
+.chemical-color {background-color: var(--x-type-chemical);}
+.light-color {background-color: var(--x-type-light);}
+.dark-color {background-color: var(--x-type-dark);}
+.metal-color {background-color: var(--x-type-metal);}
+.psychic-color {background-color: var(--x-type-psychic);}
+.ghost-color {background-color: var(--x-type-ghost);}
+.ice-color {background-color: var(--x-type-ice);}
+.sand-color {background-color: var(--x-type-sand);}
 
 
 /* text color */
-.fire-text-color {color: #df6d5e;}
-.water-text-color {color: #60a0c5;}
-.air-text-color {color: #ffffff;}
-.electric-text-color {color: #e2bd43;}
-.rock-text-color {color: #8d7050;}
-.plant-text-color {color: #708844;}
-.chemical-text-color {color: #64bd9f;}
-.light-text-color {color: #ffffc7;}
-.dark-text-color {color: #57619c;}
-.metal-text-color {color: #8d8d8d;}
-.psychic-text-color {color: #d39bcb;}
-.ghost-text-color {color: #8764a8;}
-.ice-text-color {color: #85dde4;}
-.sand-text-color {color: #e6b26f;}
-
+.fire-text-color {color: var(--x-type-fire);}
+.water-text-color {color: var(--x-type-water);}
+.air-text-color {color: var(--x-type-air);}
+.electric-text-color {color: var(--x-type-electric);}
+.rock-text-color {color: var(--x-type-rock);}
+.plant-text-color {color: var(--x-type-plant);}
+.chemical-text-color {color: var(--x-type-chemical);}
+.light-text-color {color: var(--x-type-light);}
+.dark-text-color {color: var(--x-type-dark);}
+.metal-text-color {color: var(--x-type-metal);}
+.psychic-text-color {color: var(--x-type-psychic);}
+.ghost-text-color {color: var(--x-type-ghost);}
+.ice-text-color {color: var(--x-type-ice);}
+.sand-text-color {color: var(--x-type-sand);}
 
 
 /* border color */
-.fire-border-color {border-color: #df6d5e;}
-.water-border-color {border-color: #60a0c5;}
-.air-border-color {border-color: #ffffff;}
-.electric-border-color {border-color: #e2bd43;}
-.rock-border-color {border-color: #8d7050;}
-.plant-border-color {border-color: #708844;}
-.chemical-border-color {border-color: #64bd9f;}
-.light-border-color {border-color: #ffffc7;}
-.dark-border-color {border-color: #57619c;}
-.metal-border-color {border-color: #8d8d8d;}
-.psychic-border-color {border-color: #d39bcb;}
-.ghost-border-color {border-color: #8764a8;}
-.ice-border-color {border-color: #85dde4;}
-.sand-border-color {border-color: #e6b26f;}
+.fire-border-color {border-color: var(--x-type-fire);}
+.water-border-color {border-color: var(--x-type-water);}
+.air-border-color {border-color: var(--x-type-air);}
+.electric-border-color {border-color: var(--x-type-electric);}
+.rock-border-color {border-color: var(--x-type-rock);}
+.plant-border-color {border-color: var(--x-type-plant);}
+.chemical-border-color {border-color: var(--x-type-chemical);}
+.light-border-color {border-color: var(--x-type-light);}
+.dark-border-color {border-color: var(--x-type-dark);}
+.metal-border-color {border-color: var(--x-type-metal);}
+.psychic-border-color {border-color: var(--x-type-psychic);}
+.ghost-border-color {border-color: var(--x-type-ghost);}
+.ice-border-color {border-color: var(--x-type-ice);}
+.sand-border-color {border-color: var(--x-type-sand);}

--- a/my-app/public/index.html
+++ b/my-app/public/index.html
@@ -40,6 +40,9 @@
   
   <script src="https://unpkg.com/react-bootstrap@next/dist/react-bootstrap.min.js" crossorigin></script> -->
 
+  <!-- Design tokens - must load first, everything below consumes them -->
+  <link href="/assets/css/tokens.css" rel="stylesheet">
+
   <!-- Template Main CSS File -->
   <link href="/assets/css/style.css" rel="stylesheet">
   <link href="/assets/css/duel.css" rel="stylesheet">

--- a/my-app/src/__tests__/designTokens.test.js
+++ b/my-app/src/__tests__/designTokens.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const colorConstants = require('../constants/colorConstants');
+
+// Element colours exist twice by necessity: CSS classes paint with them, and the
+// JS side (charts, SVG, inline glow styles) reads them from colorConstants.
+// Nothing enforces that at runtime, so this test does - a palette edit made in
+// only one of the two places fails here rather than silently splitting the
+// site's colours in half.
+
+const TOKENS_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'css', 'tokens.css');
+const TYPE_COLORS_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'css', 'typeColors.css');
+
+const readTokens = () => {
+	const css = fs.readFileSync(TOKENS_PATH, 'utf8');
+	const tokens = {};
+	const re = /--x-type-([a-z]+):\s*([^;]+);/g;
+	let match;
+	while ((match = re.exec(css)) !== null) {
+		tokens[match[1]] = match[2].trim().toLowerCase();
+	}
+	return tokens;
+};
+
+describe('design tokens', () => {
+	const tokens = readTokens();
+
+	it('defines a --x-type-* token for every element in colorConstants', () => {
+		expect(Object.keys(tokens).sort()).toEqual(Object.keys(colorConstants.themeColors).sort());
+	});
+
+	it('matches colorConstants exactly, so CSS and JS paint the same colours', () => {
+		Object.entries(colorConstants.themeColors).forEach(([type, hex]) => {
+			expect(`${type}: ${tokens[type]}`).toEqual(`${type}: ${hex.toLowerCase()}`);
+		});
+	});
+
+	it('leaves no raw hex colours in the element colour utilities', () => {
+		const css = fs.readFileSync(TYPE_COLORS_PATH, 'utf8');
+		const strippedComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+		expect(strippedComments.match(/#[0-9a-fA-F]{3,8}\b/g)).toBeNull();
+	});
+});

--- a/my-app/src/pages/glossaryPage.js
+++ b/my-app/src/pages/glossaryPage.js
@@ -1,47 +1,59 @@
 import React from 'react';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
 import XalianNavbar from '../components/navbar';
-import ListGroup from 'react-bootstrap/ListGroup';
 import glossary from '../json/glossary.json';
 
 
 class GlossaryPage extends React.Component {
 
-    buildDictionary() {
-        var list = [];
-        glossary.sort(function(a, b) {
-            var nameA = a.word.toUpperCase(); // ignore upper and lowercase
-            var nameB = b.word.toUpperCase(); // ignore upper and lowercase
-            if (nameA < nameB) {
-              return -1;
-            }
-            if (nameA > nameB) {
-              return 1;
-            }
-          
-            return 0;
-          });
-        glossary.forEach(row => {
-            if (row.word) {
-                list.push(
-                    <Row className="glossary-word-row vertically-center-contents">
-                        <Col sm={4}>
-                            <h3 className="glossary-title">{row.word}</h3>
-                        </Col>
-                        <Col sm={true}>
-                            <h5>{row.definition}</h5>
-                        </Col>
-                    </Row>
-                );
-            }
-        });
-        return list;
+    state = {
+        query: ''
+    }
+
+    // glossary.json is a shared module import - sorting a copy keeps this page
+    // from reordering the array for anything else that imports it
+    getSortedEntries() {
+        return glossary
+            .filter((row) => row.word)
+            .slice()
+            .sort((a, b) => a.word.toUpperCase().localeCompare(b.word.toUpperCase()));
+    }
+
+    getMatchingEntries() {
+        let query = this.state.query.trim().toLowerCase();
+        let entries = this.getSortedEntries();
+        if (!query) {
+            return entries;
+        }
+        return entries.filter((row) =>
+            row.word.toLowerCase().includes(query) ||
+            (row.definition && row.definition.toLowerCase().includes(query))
+        );
+    }
+
+    // a glossary is a description list. This was previously an <h3> per term and
+    // an <h5> per definition, which announced ~130 consecutive headings to a
+    // screen reader and conveyed none of the term-to-definition relationship.
+    buildDictionary(entries) {
+        return entries.map((row) => (
+            <Row className="glossary-word-row vertically-center-contents" key={row.word} as="div">
+                <Col sm={3}>
+                    <dt className="glossary-title">{row.word}</dt>
+                </Col>
+                <Col sm={true}>
+                    <dd className="glossary-definition">{row.definition}</dd>
+                </Col>
+            </Row>
+        ));
     }
 
     render() {
+        let entries = this.getMatchingEntries();
+        let total = this.getSortedEntries().length;
 
         return <React.Fragment>
 
@@ -49,9 +61,37 @@ class GlossaryPage extends React.Component {
                 <XalianNavbar></XalianNavbar>
 
                 <Container>
+                    <h1 className="page-title-text template-col-wrapper" style={{ textAlign: 'center' }}>Glossary</h1>
+
+                    <Row className="justify-content-center">
+                        <Col md={7} lg={6}>
+                            <InputGroup className="glossary-search">
+                                <InputGroup.Text className="glossary-search-icon">
+                                    <i className="bi bi-search" />
+                                </InputGroup.Text>
+                                <Form.Control
+                                    type="search"
+                                    placeholder="Search the galaxy's terms..."
+                                    aria-label="Search glossary terms"
+                                    value={this.state.query}
+                                    onChange={(e) => this.setState({ query: e.target.value })}
+                                    className="glossary-search-input"
+                                />
+                            </InputGroup>
+                            <p className="glossary-result-count">
+                                {this.state.query
+                                    ? `${entries.length} of ${total} terms`
+                                    : `${total} terms`}
+                            </p>
+                        </Col>
+                    </Row>
+
                     <Row className="glossary-wrapper">
                         <Col className="">
-                            {this.buildDictionary()}
+                            {entries.length > 0
+                                ? <dl className="glossary-list">{this.buildDictionary(entries)}</dl>
+                                : <p className="glossary-empty">No terms match “{this.state.query}”.</p>
+                            }
                         </Col>
                     </Row>
                 </Container>

--- a/my-app/src/pages/speciesPage.js
+++ b/my-app/src/pages/speciesPage.js
@@ -144,7 +144,7 @@ class SpeciesPage extends React.Component {
                             <h1 className="page-title-text">Discovered Species</h1>
 
                             {species &&
-                                <Tabs defaultActiveKey="grid" id="tabbs" className="species-tab-group">
+                                <Tabs defaultActiveKey="grid" id="tabbs" className="species-tab-group x-tabs">
                                     <Tab eventKey="grid" title="Grid" className="species-tab">
                                         <Row>
                                             {this.state.gridList}


### PR DESCRIPTION
First step of the design system refactor. This is the foundation plus the handful of fixes that were most visibly wrong.

## The problem

There was no token layer. The brand palette was written as a **comment** at the top of `style.css`, then hand-copied as raw hex into ~70 places across the CSS and another ~67 inline styles in JSX, alongside 266 `!important` declarations. Element colours existed in two places — `colorConstants.js` (what JS reads) and 42 hardcoded hex values in `typeColors.css` — with nothing keeping them in sync.

## Foundation

`public/assets/css/tokens.css` is now the single source of truth for colour, spacing, radius, type scale, glow, motion and layering, loaded before everything else. `typeColors.css` consumes the element tokens instead of repeating hex, and `designTokens.test.js` fails if the CSS palette and `colorConstants.js` drift apart — verified by deliberately changing one value and watching it fail with the offending element named.

The `.x-panel` primitive is lifted from the **planets page**, which was already the best-looking surface on the site: a tinted, inset-glowing card keyed to an element colour, built by `styleUtil.getInsideGlowThemeColor`. That design language already existed — it was just applied to exactly one page.

## Applied

| Page | Before | After |
|---|---|---|
| Species | Tabs were raw bootstrap — blue links on a white pill, the one piece of unthemed chrome on the site | Themed via a reusable `.x-tabs` primitive |
| Home | Lore ran ~200 characters per line at full viewport width, in a Segoe UI stack used nowhere else, inside a `5px outset` border | Capped to a readable measure, on the body font, in a panel that glows |
| Glossary | A flat wall of 67 undifferentiated entries, no title, no way to find anything | Title, search across terms *and* definitions, result count, per-term cards |
| Generator | Attribute **values** were `gray` (~4.0:1, under the 4.5:1 minimum) against pure-white **labels** — emphasis on the chrome, not the information | Inverted |

## Accessibility

The glossary was an `<h3>` per term and an `<h5>` per definition — ~130 consecutive headings announced to a screen reader, conveying none of the term-to-definition relationship. It is now a real `<dl>`/`<dt>`/`<dd>`.

## Incidental fixes

- `color: #;` — an invalid declaration in the planet table styles.
- The glossary was calling `.sort()` on the shared `glossary.json` module import, reordering it for every other consumer. Now sorts a copy.
- Added the React `key` props the glossary rows were missing.
- The navbar/modal z-index numbers from #50 now come from the layer scale rather than being magic numbers in two files.

## Verification

Every page driven in a real browser at 1440×900 and 390×844 against a production build. Search filtering confirmed working (4 of 67 for "plague", matching definition text). 18/18 tests pass.

## Note on scope

I measured the 3504-line BootstrapMade template CSS for dead rules — 115 of 293 class names appear unreferenced — but that count has false positives: `btn-xalianGreen` *is* used, composed by bootstrap from `variant='xalianGreen'`. Bulk-deleting on that signal would break things, so no template CSS was removed here.