### PR TITLE
Design system: consistent galactic background + training grounds

### DIFF
--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -2023,9 +2023,20 @@ section {
   color: #80ffb0;
 }
 
+/* Pages using this container used to sit on a flat grey radial gradient while
+   home/species/planets showed a starfield, so half the site read as galactic
+   and half did not. This paints the same starfield tile those pages use, over
+   the space background token - the drifting-particle canvas stays opt-in for
+   the pages that mount SplashGalaxyBackground, so this costs no JS. */
 .content-background-container {
-  background: rgb(75, 74, 74);
-  background: radial-gradient(circle, rgb(54, 54, 54) 21%, rgba(57, 57, 57, 1) 53%, rgba(28, 28, 28, 1) 100%);
+  background-color: var(--x-bg);
+  background-image:
+    radial-gradient(circle, rgba(35, 35, 35, 0.55) 21%, rgba(13, 13, 13, 0.85) 100%),
+    url("../img/background/stars_bg.png");
+  background-size: auto, 50%;
+  background-position: center center, center center;
+  background-repeat: no-repeat, repeat;
+  background-attachment: fixed, fixed;
   min-height: 100vh;
   min-width: 100vw;
   /* flex-direction: column; */
@@ -3581,4 +3592,21 @@ input, textarea {
 .give-some-padding {
   margin-top: 200px !important;
   padding-top: 200px !important;
+}
+/*--------------------------------------------------------------
+# Training Grounds
+--------------------------------------------------------------*/
+
+.training-grounds-subtitle {
+  color: var(--x-text-dim);
+  text-align: center;
+  margin-bottom: var(--x-space-5);
+}
+
+.training-game-switcher {
+  display: flex;
+  justify-content: center;
+  gap: var(--x-space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--x-space-5);
 }

--- a/my-app/src/pages/trainingGroundsPage.js
+++ b/my-app/src/pages/trainingGroundsPage.js
@@ -22,20 +22,16 @@ class TrainingGroundsPage extends React.Component {
     }
 
     buildGamesList = () => {
-        let list = []
-        
-        // list.push(<a href="/train/match"> <h1>Xalian Match</h1></a>);
-        // list.push(<a href="/train/physics"> <h1>Physics</h1></a>);
+        let list = [
+            { name: 'Xalian Match', element: <MatchCardGamePage key="match" /> },
+            { name: 'Physics', element: <PhysicsGamePage key="physics" /> },
+        ];
 
-        list.push(<MatchCardGamePage/>);
-        list.push(<PhysicsGamePage/>);
-
-        this.setState({ games: list, selectedGame: list[0] });
+        this.setState({ games: list, selectedGame: list[0].element });
     }
 
-    change = () => {
-        let nextIndex = (this.state.selectedGameIndex + 1) % this.state.games.length;
-        this.setState({ selectedGameIndex: nextIndex, selectedGame: this.state.games[nextIndex] })
+    selectGame = (index) => {
+        this.setState({ selectedGameIndex: index, selectedGame: this.state.games[index].element });
     }
 
     render() {
@@ -47,7 +43,24 @@ class TrainingGroundsPage extends React.Component {
 
                     <Row className="">
                         <Col style={{ textAlign: 'center' }} >
-                            <Button onClick={ this.change }>switch</Button>
+                            <h1 className="page-title-text">Training Grounds</h1>
+                            <p className="training-grounds-subtitle">Warm-up games while you wait for a duel.</p>
+
+                            {/* was a single unlabelled bootstrap-blue "switch" button that
+                                cycled games without saying which one you were on */}
+                            <div className="training-game-switcher">
+                                {this.state.games.map((game, index) => (
+                                    <Button
+                                        key={game.name}
+                                        variant={this.state.selectedGameIndex === index ? 'xalianGreen' : 'xalianGray'}
+                                        onClick={() => this.selectGame(index)}
+                                        aria-pressed={this.state.selectedGameIndex === index}
+                                    >
+                                        {game.name}
+                                    </Button>
+                                ))}
+                            </div>
+
                             <GameContainer>
                                 {this.state.selectedGame}
                             </GameContainer>


### PR DESCRIPTION
Follow-up to #51.

## Every page is galactic now

Half the site was on a starfield and half wasn't. Home, species and planets mount `SplashGalaxyBackground`; **every other page** — glossary, species detail, training, account — fell through to `.content-background-container`, a flat grey radial gradient. Navigating between them broke the vibe.

That container now paints the same `stars_bg` tile those pages use, over the space background token. It's pure CSS — the drifting-particle canvas stays opt-in for pages that mount the component, so unifying the look **costs no extra JS anywhere**. I deliberately didn't mount the particle canvas globally for that reason.

## Training grounds

The last piece of unthemed bootstrap chrome on the site. Its only control was an unlabelled blue `switch` button that cycled between two mini-games without ever telling you which one you were on. Now a pair of labelled buttons showing the active game, plus a page title and a line saying what the page is for — it had neither.

## Verification

Species detail, glossary and training checked at 1440×900 against a production build; the starfield now matches its sibling pages. 18/18 tests pass.