### PR TITLE
Design system: full build-out, style guide and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,17 @@ Game data JSON is **duplicated by build step, not imported across packages**: `m
 
 `utils/valueTranslator.js` and `constants/constants.js` (element → theme color map) drive the element-themed styling used throughout charts and SVG rendering.
 
+### Design system
+
+**Read `docs/DESIGN_SYSTEM.md` before changing anything visual.** The short version:
+
+- The palette lives **twice on purpose**: `public/assets/css/tokens.css` (`--x-*` custom properties, the CSS source of truth) and `src/constants/designTokens.js` (the same values for recharts `fill` props, GSAP tweens and SVG attributes, which cannot read a CSS variable). `src/__tests__/designTokens.test.js` fails if the two disagree — **never edit one side alone**.
+- Element/type colours stay in `constants/colorConstants.js` and are re-exported through `designTokens.js` as `themeColors`; they are mirrored as `--x-type-*` and enforced identical by the same test.
+- Reusable classes are prefixed `.x-` and defined in `tokens.css`: `.x-panel` (the tinted inset-glow card, the site's core surface), `.x-page-title`, `.x-detail-label`/`.x-detail-value`, `.x-measure`, `.x-tabs`, `.x-input`, `.x-empty-state`.
+- **No new raw hex** in CSS or JSX. Add a token to both sides plus the test's `PAIRINGS` list instead.
+- `/styleguide` is a living reference page rendering every token and primitive. It is deliberately not linked from the navbar — it is a developer tool.
+- `style.css` is a 3504-line BootstrapMade template. Many class names look unused but that signal has false positives (`btn-xalianGreen` is composed by bootstrap from `variant='xalianGreen'`), so do not bulk-delete it.
+
 ## Conventions and gotchas
 
 - Root-level `sandbox.js`, `jsonManipulator.js`, and the `my-app/src/pages/sandbox*.js` / `testPage.js` files are throwaway experiment scratchpads, not part of the app.

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,75 @@
+# Xalians Design System
+
+The site has one visual language: **dark, galactic, neon-green**, with each of the 14 element types carrying its own colour. This document is the rulebook. The live reference is at **`/styleguide`** — it renders from the same tokens the pages use, so it cannot go stale.
+
+## Where things live
+
+| File | Role |
+|---|---|
+| `my-app/public/assets/css/tokens.css` | **Source of truth for CSS.** All tokens (`--x-*`) plus the primitive classes (`.x-*`). Loaded before everything else. |
+| `my-app/src/constants/designTokens.js` | **Source of truth for JS.** The same palette, for consumers that can't read a CSS variable. |
+| `my-app/src/constants/colorConstants.js` | The 14 element/type colours. Predates the system and is referenced widely, so it stays; `designTokens.js` re-exports it as `themeColors`. |
+| `my-app/src/__tests__/designTokens.test.js` | Fails the build if the CSS and JS palettes disagree. |
+| `my-app/public/assets/css/typeColors.css` | Element colour utility classes, generated from the element tokens. |
+| `my-app/public/assets/css/style.css` | Page- and component-specific styles. Consumes tokens; should not define new raw colours. |
+| `my-app/src/pages/styleGuidePage.js` | The living reference at `/styleguide`. |
+
+## The two-sided palette, and why
+
+Most styling belongs in CSS. But some consumers can only take a JavaScript string:
+
+- **recharts** takes colours as `fill` / `stroke` props
+- **GSAP** takes them as tween values
+- **SVG** components take them as attributes
+
+So the palette exists twice. That is a genuine duplication risk, which is why `designTokens.test.js` asserts every pair matches — change a colour on one side and the test fails naming the token that no longer agrees. **Never edit one side alone.**
+
+## Rules
+
+1. **No new raw hex.** If you're typing `#`, you either want an existing token or you're adding one. Add it to *both* sides and to the pairings list in the test.
+2. **Use the spacing scale.** `--x-space-1` … `--x-space-8` (4px based). Not arbitrary pixel values.
+3. **Cap body copy at `--x-measure`.** Long prose across a 1440px viewport is unreadable — the lore sections used to run ~200 characters per line.
+4. **The value gets the emphasis, not the label.** In label/value pairs use `.x-detail-label` (dim) and `.x-detail-value` (bright). It used to be backwards.
+5. **Contrast floor is 4.5:1** against the page background. `--x-text-dim` is the faintest step that clears it; anything fainter is decorative and must not carry meaning.
+6. **Layering goes through the scale.** `--x-layer-navbar` and `--x-layer-modal`. The navbar sits at 99999, so a modal that doesn't outrank it gets its header covered — this is a real bug that shipped.
+
+## Primitives
+
+Class names are prefixed `.x-`.
+
+| Class | Use |
+|---|---|
+| `.x-panel` | The core surface: a tinted, inset-glowing card. Defaults to brand green. |
+| `.x-panel--type-<element>` | Keys a panel to an element colour (`.x-panel--type-fire`). |
+| `.x-panel--flat` | Quieter panel for dense content, where a glow is noise. |
+| `.x-page-title` / `.x-page-subtitle` | Page headers. Every page used to roll its own. |
+| `.x-section-title` | Heading above a panel or section. |
+| `.x-detail-row` / `.x-detail-label` / `.x-detail-value` | Label/value rows. |
+| `.x-measure` | Caps content to a readable line length. |
+| `.x-tabs` | Themed tabs. Bootstrap's default is blue-on-white and reads as broken here. |
+| `.x-input` / `.x-input-addon` | Themed form controls. Bootstrap's are white-on-white. |
+| `.x-empty-state` | "Nothing here" messaging. |
+
+The panel is lifted from the planets page, which was the best-looking surface on the site before this system existed. `styleUtil.getInsideGlowThemeColor()` builds the same effect from JS where a dynamic element colour is needed.
+
+## Buttons
+
+Two variants, both bootstrap `variant` props: **`xalianGreen`** (primary action) and **`xalianGray`** (secondary). Both carry a green focus ring for keyboard users.
+
+The `!important` flags on these rules are load-bearing — bootstrap's own `.btn` rules are more specific than a single class selector. Don't remove them without checking.
+
+## Backgrounds
+
+`.content-background-container` paints the starfield used site-wide. Pages that want the *drifting* particle field additionally mount `SplashGalaxyBackground` (home, species, planets) — that's a JS animation loop, so it stays opt-in rather than global.
+
+## Adding a colour
+
+1. Add the CSS token to `:root` in `tokens.css`.
+2. Add the matching value to `designTokens.js`.
+3. Add the pair to `PAIRINGS` in `designTokens.test.js`.
+4. Run the tests. If you skipped step 2 or 3, they'll tell you.
+
+## Known debt
+
+- `style.css` is a 3504-line BootstrapMade template ("Gp v4.7.0") with a lot of unused rules. A naive scan says ~115 of 293 class names are unreferenced, **but that count has false positives**: `btn-xalianGreen` *is* used, composed by bootstrap from `variant='xalianGreen'`. Don't bulk-delete on that signal.
+- Plenty of inline `style={{}}` remains, concentrated in the duel board components. Layout inline styles are lower priority; colour ones should move to tokens.

--- a/my-app/public/assets/css/duel.css
+++ b/my-app/public/assets/css/duel.css
@@ -1,5 +1,5 @@
 .xalian-duel-selected-cell {
-  border-color: rgb(255, 255, 255);
+  border-color: var(--x-text);
   border-width: 4px;
   border-radius: 8px;
   border-style: solid;
@@ -14,7 +14,7 @@
 /* } */
 
 .xalian-cell-selected {
-  border: 4px solid rgb(255, 255, 255);
+  border: 4px solid var(--x-text);
 }
 
 .duel-piece-xalian-icon {
@@ -43,7 +43,7 @@
   left: 0;
   height: 100%;
   width: 100%;
-  filter: drop-shadow(0px 0px 5px #000000);
+  filter: drop-shadow(0px 0px 5px var(--x-text-inverse));
   fill: 'gray';
   padding: 5px;
   /* box-shadow: 0px 0px 10px #00000044; */
@@ -51,13 +51,13 @@
 
 .duel-badge-text {
   /* text-shadow: 0px 0px 5px rgb(0, 0, 0); */
-  filter: drop-shadow(0px 0px 5px #000000);
+  filter: drop-shadow(0px 0px 5px var(--x-text-inverse));
   color: white;
 }
 
 
 .duel-badge-text-name {
-  filter: drop-shadow(0px 0px 5px #000000);
+  filter: drop-shadow(0px 0px 5px var(--x-text-inverse));
   color: white;
   opacity: 0.5;
   width: auto;
@@ -68,17 +68,17 @@
   position: relative;
   margin: auto;
   display: flex;
-  box-shadow: 0px 0px 8px #000;
+  box-shadow: 0px 0px 8px var(--x-text-inverse);
   background-color: black;
   text-shadow:
-    -1px -1px 0 #000,
-    1px -1px 0 #000,
-    -1px 1px 0 #000,
-    1px 1px 0 #000,
-    -2px -2px 0 #000,
-    2px -2px 0 #000,
-    -2px 2px 0 #000,
-    2px 2px 0 #000;
+    -1px -1px 0 var(--x-text-inverse),
+    1px -1px 0 var(--x-text-inverse),
+    -1px 1px 0 var(--x-text-inverse),
+    1px 1px 0 var(--x-text-inverse),
+    -2px -2px 0 var(--x-text-inverse),
+    2px -2px 0 var(--x-text-inverse),
+    -2px 2px 0 var(--x-text-inverse),
+    2px 2px 0 var(--x-text-inverse);
 }
 
 .duel-xalian-unselected {
@@ -146,8 +146,8 @@
 .duel-xalian-details-box {
   max-width: 400px;
   background-color: rgba(0, 0, 0, 0.75);
-  filter: drop-shadow(5px 5px 5px #000000);
-  border-radius: 10px;
+  filter: drop-shadow(5px 5px 5px var(--x-text-inverse));
+  border-radius: var(--x-radius-md);
   margin: auto;
   padding: 10px;
 }
@@ -163,9 +163,9 @@
   /* margin-bottom: min(5%, 25px); */
   margin-bottom: min(5%, 5px);
   border-radius: 10%;
-  background-color: rgb(0, 0, 0);
+  background-color: var(--x-text-inverse);
   position: relative;
-  box-shadow: 2px 2px 10px #000000;
+  box-shadow: 2px 2px 10px var(--x-text-inverse);
   border: solid 2px black;
 }
 
@@ -189,7 +189,7 @@
   top: 0;
   left: 0;
   /* background-color: #000; */
-  background: rgb(0, 0, 0);
+  background: var(--x-text-inverse);
   background: radial-gradient(circle, rgba(0, 0, 0, 0.4) 0%, rgba(0, 0, 0, 0.8) 100%);
   /* opacity: 0.75; */
   height: 100%;
@@ -243,14 +243,14 @@
 }
 
 .duel-board-cell-dot-dark {
-  background: radial-gradient(circle, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0.5) 5%, rgba(0, 0, 0, 0.25) 20%, rgba(0, 0, 0, 0) 60%);
+  background: radial-gradient(circle, var(--x-text-inverse) 0%, rgba(0, 0, 0, 0.5) 5%, rgba(0, 0, 0, 0.25) 20%, rgba(0, 0, 0, 0) 60%);
   filter: none;
 }
 
 /* PIECE HOVER */
 .duel-piece-draggable-hovering {
-  background: radial-gradient(circle, #ffffff 0%, #ffffff00 100%);
-  filter: drop-shadow(0px 0px 5px #ffffff);
+  background: radial-gradient(circle, var(--x-text) 0%, #ffffff00 100%);
+  filter: drop-shadow(0px 0px 5px var(--x-text));
 }
 
 .duel-attack-cell-icon {
@@ -269,7 +269,7 @@
   padding: 5%;
   /* border-radius: 50%; */
   overflow: visible;
-  filter: drop-shadow(0px 0px 2px #000000) drop-shadow(0px 0px 6px #000000);
+  filter: drop-shadow(0px 0px 2px var(--x-text-inverse)) drop-shadow(0px 0px 6px var(--x-text-inverse));
 }
 
 .duel-attack-icon-wrapper {
@@ -285,7 +285,7 @@
 
 .duel-attack-icon-wrapper>h6 {
   color: white;
-  text-shadow: 1px 1px 2px rgb(0, 0, 0)
+  text-shadow: 1px 1px 2px var(--x-text-inverse)
 }
 
 .duel-xalian-cell-badge-row {
@@ -303,7 +303,7 @@
   left: 20%;
   opacity: 0.8;
   height: 60%;
-  filter: drop-shadow(0px 0px 2px #000000);
+  filter: drop-shadow(0px 0px 2px var(--x-text-inverse));
 }
 
 .duel-flag-carried {
@@ -311,7 +311,7 @@
   position: absolute;
   opacity: 0.8;
   height: 60%;
-  filter: drop-shadow(0px 0px 2px #000000) drop-shadow(0px 0px 6px #000000);
+  filter: drop-shadow(0px 0px 2px var(--x-text-inverse)) drop-shadow(0px 0px 6px var(--x-text-inverse));
 }
 
 .fit-text {
@@ -325,7 +325,7 @@
   padding: 0;
   justify-content: space-evenly;
   align-items: center;
-  filter: drop-shadow(0px 0px 2px #000000);
+  filter: drop-shadow(0px 0px 2px var(--x-text-inverse));
   margin: auto !important;
 }
 

--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -23,24 +23,29 @@
   font-family: 'ProcrastinatingPixie';
 }
 
+/* Buttons.
+   Two variants: xalianGreen is the primary action, xalianGray the secondary.
+   Both are driven by tokens. The !important flags are load-bearing - bootstrap's
+   own .btn rules are more specific than these class selectors. */
+
 .btn-xalianGreen {
-  color: black !important;
-  background-color: #80ffb0 !important;
-  border-color: #6bd493 !important;
+  color: var(--x-text-inverse) !important;
+  background-color: var(--x-green) !important;
+  border-color: var(--x-green-border) !important;
   font-weight: bold !important;
-  /* text-shadow: 1px 1px 2px rgb(255, 255, 255) !important; */
+  transition: background-color var(--x-transition-fast), border-color var(--x-transition-fast) !important;
 }
 
 .btn-xalianGreen:hover {
-  background-color: #bdffd5 !important;
-  border-color: #ffffff !important;
+  background-color: var(--x-green-hover) !important;
+  border-color: var(--x-text) !important;
 }
 
 .btn-check:focus+.btn-xalianGreen,
 .btn-xalianGreen:focus {
-  background-color: #80ffb0 !important;
-  border-color: #6bd493 !important;
-  box-shadow: 0 0 0 0.25rem #80ffb13d !important;
+  background-color: var(--x-green) !important;
+  border-color: var(--x-green-border) !important;
+  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
 }
 
 .btn-check:checked+.btn-xalianGreen,
@@ -48,8 +53,8 @@
 .btn-xalianGreen:active,
 .btn-xalianGreen.active,
 .show>.btn-xalianGreen.dropdown-toggle {
-  background-color: #57aa77 !important;
-  border-color: #74a587 !important;
+  background-color: var(--x-green-active) !important;
+  border-color: var(--x-green-border) !important;
 }
 
 .btn-check:checked+.btn-xalianGreen:focus,
@@ -57,41 +62,53 @@
 .btn-xalianGreen:active:focus,
 .btn-xalianGreen.active:focus,
 .show>.btn-xalianGreen.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.25rem #80ffb13d !important;
+  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
 }
 
+/* disabled kept black text over a near-transparent green, which disappeared
+   against the dark page. Disabled controls still have to be legible. */
 .btn-xalianGreen:disabled,
 .btn-xalianGreen.disabled {
-  background-color: #62a17a3d !important;
-  border-color: #35473c3d !important;
+  color: var(--x-text-dim) !important;
+  background-color: var(--x-surface-3) !important;
+  border-color: var(--x-border-strong) !important;
+  opacity: 1 !important;
 }
 
 .btn-xalianGray {
-  color: rgb(255, 255, 255) !important;
-  background-color: #525252 !important;
-  border-color: #3a3a3a !important;
-  text-shadow: 1px 1px 2px rgb(0, 0, 0) !important;
+  color: var(--x-text) !important;
+  background-color: var(--x-surface-3) !important;
+  border-color: var(--x-border-strong) !important;
+  text-shadow: 1px 1px 2px var(--x-text-inverse) !important;
+  transition: background-color var(--x-transition-fast), border-color var(--x-transition-fast) !important;
 }
 
+/* the gray button used to go pale green on hover while keeping white text,
+   which landed around 1.3:1 and was effectively unreadable mid-hover. It now
+   lifts a surface step and picks up a green border instead. */
 .btn-xalianGray:hover {
-  background-color: #bdffd5 !important;
-  border-color: #ffffff !important;
+  background-color: var(--x-border-strong) !important;
+  border-color: var(--x-green) !important;
 }
 
 .btn-check:focus+.btn-xalianGray,
 .btn-xalianGray:focus {
-  background-color: #80ffb0 !important;
-  border-color: #6bd493 !important;
-  box-shadow: 0 0 0 0.25rem #80ffb13d !important;
+  background-color: var(--x-surface-3) !important;
+  border-color: var(--x-green-border) !important;
+  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
 }
 
+/* checked/active is a real selected state for the toggle groups, so it keeps
+   the green fill - with dark text, which the plain gray variant does not use */
 .btn-check:checked+.btn-xalianGray,
 .btn-check:active+.btn-xalianGray,
 .btn-xalianGray:active,
 .btn-xalianGray.active,
 .show>.btn-xalianGray.dropdown-toggle {
-  background-color: #57aa77 !important;
-  border-color: #74a587 !important;
+  color: var(--x-text-inverse) !important;
+  background-color: var(--x-green-active) !important;
+  border-color: var(--x-green-border) !important;
+  text-shadow: none !important;
 }
 
 .btn-check:checked+.btn-xalianGray:focus,
@@ -99,13 +116,22 @@
 .btn-xalianGray:active:focus,
 .btn-xalianGray.active:focus,
 .show>.btn-xalianGray.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.25rem #80ffb13d !important;
+  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
 }
 
 .btn-xalianGray:disabled,
 .btn-xalianGray.disabled {
-  background-color: #62a17a3d !important;
-  border-color: #35473c3d !important;
+  color: var(--x-text-dim) !important;
+  background-color: var(--x-surface-3) !important;
+  border-color: var(--x-border-strong) !important;
+  text-shadow: none !important;
+  opacity: 1 !important;
+}
+
+/* keyboard users get a visible ring on every button variant */
+.btn:focus-visible {
+  outline: 2px solid var(--x-green) !important;
+  outline-offset: 2px !important;
 }
 
 hr.xalian-hr {
@@ -158,22 +184,16 @@ a:hover {
   text-decoration: none;
 }
 
+/* Headings default to the brand green site-wide. Anything that needs a white
+   heading (page titles, for instance) opts out explicitly. */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: "Abel", sans-serif;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: #80ffb0;
+  font-family: var(--x-font-body);
+  color: var(--x-green);
 }
 
 
@@ -2357,11 +2377,6 @@ article {
 }
 
 
-.page-title-text {
-  padding-top: 40px;
-  padding-bottom: 20px;
-}
-
 .template-col-wrapper h1 {
   text-align: center;
   color: white;
@@ -2778,30 +2793,6 @@ article {
   margin-top: var(--x-space-3);
 }
 
-/* bootstrap's .input-group-text ships a light background, which reads as a
-   white block against the starfield - hence the overrides */
-.glossary-search-icon.input-group-text {
-  background-color: var(--x-surface-2) !important;
-  border: 1px solid var(--x-border) !important;
-  border-right: none !important;
-  color: var(--x-green) !important;
-}
-
-.glossary-search-input {
-  background-color: var(--x-surface-2) !important;
-  border: 1px solid var(--x-border) !important;
-  color: var(--x-text) !important;
-}
-
-.glossary-search-input::placeholder {
-  color: var(--x-text-dim);
-}
-
-.glossary-search-input:focus {
-  border-color: var(--x-green-a60) !important;
-  box-shadow: 0 0 0 0.2rem var(--x-green-a15) !important;
-}
-
 .glossary-result-count {
   color: var(--x-text-dim);
   font-size: var(--x-text-sm);
@@ -2809,11 +2800,6 @@ article {
   margin: var(--x-space-2) 0 0 0;
 }
 
-.glossary-empty {
-  color: var(--x-text-dim);
-  text-align: center;
-  padding: var(--x-space-7) 0;
-}
 
 /* HAPPENS WHEN SCREEN GOES TO SMALL OR XSMALL I THINK */
 @media (max-width: 575px) {
@@ -3216,19 +3202,6 @@ input, textarea {
   width: 100%;
 }
 
-/* the label is chrome and the value is the information, so the value gets the
-   emphasis. This was inverted - values were `gray` (~4.0:1 on the page
-   background, under the 4.5:1 minimum) against pure-white labels. */
-.species-detail-chart-header {
-  color: var(--x-text-dim);
-  text-align: right;
-}
-
-.species-detail-chart-text {
-  color: var(--x-text);
-  text-align: left;
-}
-
 .species-detail-chart>.row {
   padding-top: 5px;
   padding-bottom: 5px;
@@ -3609,4 +3582,177 @@ input, textarea {
   gap: var(--x-space-3);
   flex-wrap: wrap;
   margin-bottom: var(--x-space-5);
+}
+
+/*--------------------------------------------------------------
+# Style Guide
+# The living design system reference at /styleguide.
+--------------------------------------------------------------*/
+
+.styleguide-container {
+  padding-bottom: var(--x-space-8);
+}
+
+.styleguide-section {
+  margin-bottom: var(--x-space-8);
+}
+
+.styleguide-heading {
+  color: var(--x-green);
+  border-bottom: 1px solid var(--x-border);
+  padding-bottom: var(--x-space-2);
+  margin-bottom: var(--x-space-4);
+}
+
+.styleguide-note {
+  color: var(--x-text-dim);
+  font-size: var(--x-text-sm);
+  max-width: var(--x-measure);
+  margin-bottom: var(--x-space-4);
+}
+
+.styleguide-swatch-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: var(--x-space-4);
+}
+
+.styleguide-swatch-chip {
+  height: 56px;
+  border-radius: var(--x-radius-md);
+  border: 1px solid var(--x-border);
+  margin-bottom: var(--x-space-2);
+}
+
+.styleguide-swatch-name {
+  display: block;
+  color: var(--x-text);
+  font-size: var(--x-text-xs);
+  word-break: break-all;
+}
+
+.styleguide-swatch-value {
+  display: block;
+  color: var(--x-text-dim);
+  font-size: var(--x-text-xs);
+}
+
+.styleguide-space-row {
+  display: flex;
+  align-items: center;
+  gap: var(--x-space-4);
+  margin-bottom: var(--x-space-2);
+}
+
+.styleguide-space-name {
+  color: var(--x-text-dim);
+  font-size: var(--x-text-xs);
+  min-width: 110px;
+}
+
+.styleguide-space-bar {
+  height: 16px;
+  background-color: var(--x-green);
+  border-radius: var(--x-radius-sm);
+}
+
+.styleguide-radius-grid {
+  display: flex;
+  gap: var(--x-space-5);
+  flex-wrap: wrap;
+}
+
+.styleguide-radius-box {
+  width: 80px;
+  height: 80px;
+  background-color: var(--x-surface-3);
+  border: 1px solid var(--x-green-a30);
+  margin-bottom: var(--x-space-2);
+}
+
+.styleguide-panel-col {
+  margin-bottom: var(--x-space-4);
+}
+
+.styleguide-tint-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: var(--x-space-3);
+}
+
+.styleguide-tint {
+  text-align: center;
+  text-transform: capitalize;
+  padding: var(--x-space-4) var(--x-space-2);
+  border-radius: var(--x-radius-md);
+}
+
+.styleguide-button-row {
+  display: flex;
+  gap: var(--x-space-3);
+  flex-wrap: wrap;
+}
+
+.styleguide-measure-demo {
+  color: var(--x-text-muted);
+  border-left: 3px solid var(--x-green-a60);
+  padding-left: var(--x-space-4);
+}
+
+/*--------------------------------------------------------------
+# Generator loading state
+--------------------------------------------------------------*/
+
+.generator-page-gradient-overlay {
+  z-index: -1;
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0) 25%, rgba(20, 23, 23, 1) 100%);
+}
+
+/* sits above the smoke canvas (z-index 999) so the message is readable while
+   the generator is working */
+.generator-loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  text-align: center;
+}
+
+.generator-loading-text {
+  color: var(--x-green);
+  font-size: var(--x-text-xl);
+  text-shadow: 0 0 12px rgba(0, 0, 0, 0.9);
+  animation: generator-loading-pulse 1.6s ease-in-out infinite;
+}
+
+.generator-loading-sub {
+  color: var(--x-text);
+  font-size: var(--x-text-sm);
+  margin-top: var(--x-space-2);
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.9);
+}
+
+@keyframes generator-loading-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+/* respect a reduced-motion preference - the pulse is decorative */
+@media (prefers-reduced-motion: reduce) {
+  .generator-loading-text {
+    animation: none;
+    opacity: 1;
+  }
 }

--- a/my-app/public/assets/css/tokens.css
+++ b/my-app/public/assets/css/tokens.css
@@ -64,6 +64,26 @@
 	--x-type-ice: #85dde4;
 	--x-type-sand: #e6b26f;
 
+	/* --- stat colours ----------------------------------------------------- */
+	/* semantic: attack is red, defense is blue, speed yellow-green, stamina and
+	   recovery green. Each "special" variant is a darker shade of the same hue
+	   so the standard/special pairs read as related. */
+	--x-stat-standard-attack: #a84032;
+	--x-stat-special-attack: #753027;
+	--x-stat-standard-defense: #535dc2;
+	--x-stat-special-defense: #494f8c;
+	--x-stat-speed: #d0d466;
+	--x-stat-evasion: #aaad53;
+	--x-stat-stamina: #4bbf4e;
+	--x-stat-recovery: #479e4a;
+
+	/* --- charts ----------------------------------------------------------- */
+	--x-chart-range-track: #ecff8234;
+	--x-chart-points-fill: #80dbff34;
+	--x-chart-bar-label: #ffffff50;
+	--x-chart-cursor-fill: #ffffff25;
+	--x-chart-axis: #ffffff;
+
 	/* --- spacing ---------------------------------------------------------- */
 	--x-space-1: 4px;
 	--x-space-2: 8px;
@@ -183,6 +203,74 @@
 .x-tabs.nav-tabs .nav-link:focus-visible {
 	outline: 2px solid var(--x-green);
 	outline-offset: -2px;
+}
+
+/* --- page headers -------------------------------------------------------
+   Every page hand-rolled its own title treatment, so "Discovered Species",
+   "Discovered Planets" and "Glossary" were each styled slightly differently. */
+.x-page-title {
+	text-align: center;
+	color: var(--x-text);
+	padding-top: var(--x-space-7);
+	padding-bottom: var(--x-space-3);
+	margin: 0;
+}
+
+.x-page-subtitle {
+	text-align: center;
+	color: var(--x-text-dim);
+	max-width: var(--x-measure);
+	margin: 0 auto var(--x-space-6) auto;
+}
+
+/* --- label / value rows -------------------------------------------------
+   The generator, species detail and planet pages all show rows of
+   "Attribute: value". The value is the information, so it gets the emphasis;
+   the label is chrome and stays dim. */
+.x-detail-row {
+	padding-top: var(--x-space-1);
+	padding-bottom: var(--x-space-1);
+}
+
+.x-detail-label {
+	color: var(--x-text-dim);
+	text-align: right;
+}
+
+.x-detail-value {
+	color: var(--x-text);
+	text-align: left;
+}
+
+/* --- form controls ------------------------------------------------------
+   Bootstrap's inputs are white-on-white, which reads as a hole punched in the
+   starfield. */
+.x-input.form-control {
+	background-color: var(--x-surface-2) !important;
+	border: 1px solid var(--x-border) !important;
+	color: var(--x-text) !important;
+}
+
+.x-input.form-control::placeholder {
+	color: var(--x-text-dim);
+}
+
+.x-input.form-control:focus {
+	border-color: var(--x-green-a60) !important;
+	box-shadow: 0 0 0 0.2rem var(--x-green-a15) !important;
+}
+
+.x-input-addon.input-group-text {
+	background-color: var(--x-surface-2) !important;
+	border: 1px solid var(--x-border) !important;
+	color: var(--x-green) !important;
+}
+
+/* --- empty state -------------------------------------------------------- */
+.x-empty-state {
+	color: var(--x-text-dim);
+	text-align: center;
+	padding: var(--x-space-7) var(--x-space-4);
 }
 
 /* Element-keyed panel tints, so JSX can pick a panel colour with a class

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -47,6 +47,7 @@ const PlanetPage = lazy(() => import('./pages/planetPage'));
 const SpeciesPage = lazy(() => import('./pages/speciesPage'));
 const SpeciesDetailPage = lazy(() => import('./pages/speciesDetailPage'));
 const GlossaryPage = lazy(() => import('./pages/glossaryPage'));
+const StyleGuidePage = lazy(() => import('./pages/styleGuidePage'));
 const GeneratorPage = lazy(() => import('./pages/generatorPage'));
 const UserAccountPage = lazy(() => import('./pages/userAccountPage'));
 const UserDetailsPage = lazy(() => import('./pages/userDetailsPage'));
@@ -81,6 +82,9 @@ class App extends React.Component {
                 />
               <Route exact path="/planets"><PlanetPage /></Route>
               <Route exact path="/glossary"><GlossaryPage /></Route>
+              {/* the design system reference - unlinked from the navbar, it is a
+                  developer tool rather than a page for players */}
+              <Route exact path="/styleguide"><StyleGuidePage /></Route>
               <Route exact path="/duel"><DuelStartPage/></Route>
               <Route exact path="/account"><UserAccountPage /></Route>
               <Route exact path="/train"><TrainingGroundsPage /></Route>

--- a/my-app/src/__tests__/designTokens.test.js
+++ b/my-app/src/__tests__/designTokens.test.js
@@ -1,20 +1,21 @@
 const fs = require('fs');
 const path = require('path');
 const colorConstants = require('../constants/colorConstants');
+const designTokens = require('../constants/designTokens');
 
-// Element colours exist twice by necessity: CSS classes paint with them, and the
-// JS side (charts, SVG, inline glow styles) reads them from colorConstants.
-// Nothing enforces that at runtime, so this test does - a palette edit made in
-// only one of the two places fails here rather than silently splitting the
-// site's colours in half.
+// The palette exists on both sides of the stack by necessity: CSS classes paint
+// with custom properties, while recharts `fill` props, GSAP tweens and SVG
+// attributes can only take a JS string. Nothing enforces that the two agree at
+// runtime, so this test does it at build time - edit a colour in one place and
+// this fails naming the token that no longer matches.
 
 const TOKENS_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'css', 'tokens.css');
 const TYPE_COLORS_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'css', 'typeColors.css');
 
-const readTokens = () => {
+const readAllTokens = () => {
 	const css = fs.readFileSync(TOKENS_PATH, 'utf8');
 	const tokens = {};
-	const re = /--x-type-([a-z]+):\s*([^;]+);/g;
+	const re = /(--x-[a-z0-9-]+):\s*([^;]+);/g;
 	let match;
 	while ((match = re.exec(css)) !== null) {
 		tokens[match[1]] = match[2].trim().toLowerCase();
@@ -22,16 +23,69 @@ const readTokens = () => {
 	return tokens;
 };
 
-describe('design tokens', () => {
-	const tokens = readTokens();
+const tokens = readAllTokens();
 
-	it('defines a --x-type-* token for every element in colorConstants', () => {
-		expect(Object.keys(tokens).sort()).toEqual(Object.keys(colorConstants.themeColors).sort());
+// Each entry maps a JS token to the CSS custom property that must match it.
+const PAIRINGS = [
+	['--x-green', designTokens.brand.green],
+	['--x-green-hover', designTokens.brand.greenHover],
+	['--x-green-active', designTokens.brand.greenActive],
+	['--x-green-border', designTokens.brand.greenBorder],
+
+	['--x-bg', designTokens.surface.bg],
+	['--x-surface-1', designTokens.surface.surface1],
+	['--x-surface-2', designTokens.surface.surface2],
+	['--x-surface-3', designTokens.surface.surface3],
+	['--x-border', designTokens.surface.border],
+	['--x-border-strong', designTokens.surface.borderStrong],
+
+	['--x-text', designTokens.text.primary],
+	['--x-text-muted', designTokens.text.muted],
+	['--x-text-dim', designTokens.text.dim],
+	['--x-text-inverse', designTokens.text.inverse],
+
+	['--x-danger', designTokens.feedback.danger],
+	['--x-warning', designTokens.feedback.warning],
+
+	['--x-stat-standard-attack', designTokens.stat.standardAttack],
+	['--x-stat-special-attack', designTokens.stat.specialAttack],
+	['--x-stat-standard-defense', designTokens.stat.standardDefense],
+	['--x-stat-special-defense', designTokens.stat.specialDefense],
+	['--x-stat-speed', designTokens.stat.speed],
+	['--x-stat-evasion', designTokens.stat.evasion],
+	['--x-stat-stamina', designTokens.stat.stamina],
+	['--x-stat-recovery', designTokens.stat.recovery],
+
+	['--x-chart-range-track', designTokens.chart.rangeTrack],
+	['--x-chart-points-fill', designTokens.chart.pointsFill],
+	['--x-chart-bar-label', designTokens.chart.barLabel],
+	['--x-chart-cursor-fill', designTokens.chart.cursorFill],
+	['--x-chart-axis', designTokens.chart.axis],
+];
+
+describe('design tokens', () => {
+
+	describe('element colours', () => {
+		const typeTokens = Object.fromEntries(
+			Object.entries(tokens)
+				.filter(([name]) => name.startsWith('--x-type-'))
+				.map(([name, value]) => [name.replace('--x-type-', ''), value])
+		);
+
+		it('defines a --x-type-* token for every element in colorConstants', () => {
+			expect(Object.keys(typeTokens).sort()).toEqual(Object.keys(colorConstants.themeColors).sort());
+		});
+
+		it('matches colorConstants exactly, so CSS and JS paint the same colours', () => {
+			Object.entries(colorConstants.themeColors).forEach(([type, hex]) => {
+				expect(`${type}: ${typeTokens[type]}`).toEqual(`${type}: ${hex.toLowerCase()}`);
+			});
+		});
 	});
 
-	it('matches colorConstants exactly, so CSS and JS paint the same colours', () => {
-		Object.entries(colorConstants.themeColors).forEach(([type, hex]) => {
-			expect(`${type}: ${tokens[type]}`).toEqual(`${type}: ${hex.toLowerCase()}`);
+	describe('palette', () => {
+		it.each(PAIRINGS)('%s matches its designTokens.js value', (cssName, jsValue) => {
+			expect(`${cssName}: ${tokens[cssName]}`).toEqual(`${cssName}: ${String(jsValue).toLowerCase()}`);
 		});
 	});
 

--- a/my-app/src/components/characterGeneratedStatChart.js
+++ b/my-app/src/components/characterGeneratedStatChart.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from "react";
 import { LabelList, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import { brand, chart } from "../constants/designTokens";
 
 const d = [];
 
@@ -75,13 +76,14 @@ class CharacterGeneratedStatChart extends React.Component {
           <ResponsiveContainer className="chart-container centered-view">
             <BarChart data={this.setupData(this.props.xalian)} layout="vertical" maxBarSize={35}>
               <XAxis type="number" hide />
-              <YAxis type="category" dataKey="statLabel" stroke="#80ffb1" />
+              {/* was #80ffb1, one digit off the brand green - a typo, not a second colour */}
+              <YAxis type="category" dataKey="statLabel" stroke={brand.green} />
               {/* <Tooltip cursor={false}/> */}
 
-              <Bar isAnimationActive={false} animationBegin={50} dataKey="rangeNumber" fill="#ecff8234">
+              <Bar isAnimationActive={false} animationBegin={50} dataKey="rangeNumber" fill={chart.rangeTrack}>
                 <LabelList dataKey="rangeName" position="center" fill="white" className="chart-bar-label" id="stat-bar-label" />
               </Bar>
-              <Bar isAnimationActive={false} animationBegin={50} dataKey="points" fill="#80dbff34">
+              <Bar isAnimationActive={false} animationBegin={50} dataKey="points" fill={chart.pointsFill}>
                 <LabelList dataKey="percentageText" position="center" fill="white" className="chart-bar-label" id="stat-bar-label" />
               </Bar>
               {/* <Bar dataKey="percentage" fill="#80dbff34" >

--- a/my-app/src/components/games/duel/board/attackMoveChooserModal.js
+++ b/my-app/src/components/games/duel/board/attackMoveChooserModal.js
@@ -6,6 +6,7 @@ import Col from 'react-bootstrap/Col';
 import Stack from 'react-bootstrap/Stack';
 import XalianTypeSymbolBadge from './xalianTypeSymbolBadge';
 import * as duelCalculator from '../../../../gameplay/duel/duelCalculator';
+import { surface } from '../../../../constants/designTokens';
 
 class AttackMoveChooserModal extends React.Component {
 
@@ -98,7 +99,7 @@ class AttackMoveChooserModal extends React.Component {
                         {this.props.attacker.species.name} attacks {this.props.defender.species.name}
                     </Modal.Title>
                 </Modal.Header>
-                <Modal.Body style={{ backgroundColor: '#1a1a1a' }}>
+                <Modal.Body style={{ backgroundColor: surface.surface2 }}>
                     <Stack gap={1}>
                         {moves.map((move, index) => this.renderMoveRow(move, index))}
                         {this.renderBasicAttackRow()}

--- a/my-app/src/components/games/duel/board/duelBoard.js
+++ b/my-app/src/components/games/duel/board/duelBoard.js
@@ -42,6 +42,7 @@ import MotionPathPlugin from 'gsap/MotionPathPlugin';
 import constants from '../../../../constants/constants';
 import * as alertUtil from '../../../../utils/alertUtil';
 import FadeAlert from '../../../fadeAlert';
+import { text } from '../../../../constants/designTokens';
 gsap.registerPlugin(Flip, MotionPathPlugin, Draggable);
 
 
@@ -626,8 +627,8 @@ class DuelBoard extends React.Component {
 		var opponentOutCols = this.buildTeamList(boardState.playerStates[1].inactiveXalianIds, boardState);
 
 		let isPlayersTurn = parseInt(this.props.ctx.currentPlayer) == 0;
-		let glowIfCurrentTurnPlayer = isPlayersTurn ? '0px 0px 5px 5px #ffffff' : 'none';
-		let glowIfCurrentTurnOpponent = !isPlayersTurn ? '0px 0px 5px 5px #ffffff' : 'none';
+		let glowIfCurrentTurnPlayer = isPlayersTurn ? `0px 0px 5px 5px ${text.primary}` : 'none';
+		let glowIfCurrentTurnOpponent = !isPlayersTurn ? `0px 0px 5px 5px ${text.primary}` : 'none';
 
 		let selectedXalian = duelUtil.getXalianFromId(selectedId, boardState);
 		// let referencedXalian = duelUtil.getXalianFromId(this.state.referencedXalianId, boardState);

--- a/my-app/src/components/games/duel/board/xalianPieceStateChart.js
+++ b/my-app/src/components/games/duel/board/xalianPieceStateChart.js
@@ -6,6 +6,7 @@ import * as svgUtil from '../../../../utils/svgUtil';
 import { PieChart, Pie, Sector, Cell, ResponsiveContainer } from 'recharts';
 import * as gameConstants from '../../../../gameplay/duel/duelGameConstants';
 import gsap from 'gsap';
+import { text } from '../../../../constants/designTokens';
 
 const COLORS = ['#0088FE', '#00000000'];
 const STROKES = ['black', '#00000000'];
@@ -41,11 +42,11 @@ class XalianPieceStateChart extends React.Component {
         
         return (
             <div className={classes} style={{ height: 'auto', minWidth: '25px', pointerEvents: 'none', width: '100%', zIndex: '104' }}>
-                <div className={wrapperClasses} style={{display: 'flex', flexDirection: 'column', filter: 'drop-shadow(0px 0px 2px #000000)' }}>
-                    <div style={{ width: '100%', height: '100%', filter: 'drop-shadow(0px 0px 1px #000000) drop-shadow(0px 0px 2px #000000)', border: `1px outset ${healthBarColor}`, borderRadius: '4px'}}>
+                <div className={wrapperClasses} style={{display: 'flex', flexDirection: 'column', filter: `drop-shadow(0px 0px 2px ${text.inverse})` }}>
+                    <div style={{ width: '100%', height: '100%', filter: `drop-shadow(0px 0px 1px ${text.inverse}) drop-shadow(0px 0px 2px ${text.inverse})`, border: `1px outset ${healthBarColor}`, borderRadius: '4px'}}>
                         <div style={{ ...style, width: `${healthBarPercentage}%`, background: this.buildBackgroundGradient(healthBarLighterColor), pointerEvents: 'none', boxShadow: `0px 0px 1px 1px ${healthBarColor}`, borderRadius: '4px' }} />
                     </div>
-                    <div style={{ width: '100%', height: '100%', filter: 'drop-shadow(0px 0px 1px #000000) drop-shadow(0px 0px 2px #000000)', border: `1px outset #4d4bc2`, borderRadius: '4px', marginTop: spacing}}>
+                    <div style={{ width: '100%', height: '100%', filter: `drop-shadow(0px 0px 1px ${text.inverse}) drop-shadow(0px 0px 2px ${text.inverse})`, border: `1px outset #4d4bc2`, borderRadius: '4px', marginTop: spacing}}>
                         <div style={{ ...style, width: `${staminaBarPercentage}%`, background: this.buildBackgroundGradient('#6d8ed9'), pointerEvents: 'none', boxShadow: `0px 0px 1px 1px #4d4bc2`, borderRadius: '4px' }}  />
                     </div>
                 </div>

--- a/my-app/src/components/games/duel/howToPlayModal.js
+++ b/my-app/src/components/games/duel/howToPlayModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 import * as duelConstants from '../../../gameplay/duel/duelGameConstants';
+import { surface } from '../../../constants/designTokens';
 
 // The rules text is derived from constants rather than hardcoded so it cannot
 // drift away from the actual game as tunables change.
@@ -109,16 +110,16 @@ class HowToPlayModal extends React.Component {
                 scrollable
                 className="themed-modal dark-themed-modal"
             >
-                <Modal.Header closeButton closeVariant="white" style={{ borderBottom: '1px solid #444', backgroundColor: '#1a1a1a' }}>
+                <Modal.Header closeButton closeVariant="white" style={{ borderBottom: '1px solid #444', backgroundColor: surface.surface2 }}>
                     <Modal.Title style={{ color: 'white', fontSize: '1.2em' }}>How to play Duel</Modal.Title>
                 </Modal.Header>
-                <Modal.Body style={{ backgroundColor: '#1a1a1a' }}>
+                <Modal.Body style={{ backgroundColor: surface.surface2 }}>
                     <p style={{ color: '#a0a0a0', fontSize: '0.9em', marginBottom: '20px' }}>
                         Duel is a squad tactics game: capture the flag on a chess-sized board, with elemental creatures instead of chess pieces.
                     </p>
                     {SECTIONS.map(this.renderSection)}
                 </Modal.Body>
-                <Modal.Footer style={{ borderTop: '1px solid #444', backgroundColor: '#1a1a1a' }}>
+                <Modal.Footer style={{ borderTop: '1px solid #444', backgroundColor: surface.surface2 }}>
                     <Button variant="xalianGreen" onClick={this.props.onHide}>Got it</Button>
                 </Modal.Footer>
             </Modal>

--- a/my-app/src/components/xalianAttributeChart.js
+++ b/my-app/src/components/xalianAttributeChart.js
@@ -13,14 +13,14 @@ class XalianAttributeChart extends React.Component {
                 {this.props.xalian && this.props.xalian.elements && 
                     <React.Fragment>
                         <Row>
-                            <Col className="species-detail-chart-header">Primary Element:</Col>
-                            <Col className="species-detail-chart-text">
+                            <Col className="x-detail-label">Primary Element:</Col>
+                            <Col className="x-detail-value">
                                 {this.props.xalian.elements.primaryType} [{this.props.xalian.elements.primaryElement}]
                             </Col>
                         </Row>
                         <Row>
-                            <Col className="species-detail-chart-header">Secondary Element:</Col>
-                            <Col className="species-detail-chart-text">
+                            <Col className="x-detail-label">Secondary Element:</Col>
+                            <Col className="x-detail-value">
                                 {this.props.xalian.elements.secondaryType} [{this.props.xalian.elements.secondaryElement}]
                             </Col>
                         </Row>
@@ -29,40 +29,40 @@ class XalianAttributeChart extends React.Component {
                 {this.props.xalian && this.props.xalian.species && 
                     <React.Fragment>
                         <Row>
-                            <Col className="species-detail-chart-header">Generation:</Col>
-                            <Col className='species-detail-chart-text'>{this.props.xalian.species.generation}</Col>
+                            <Col className="x-detail-label">Generation:</Col>
+                            <Col className="x-detail-value">{this.props.xalian.species.generation}</Col>
                         </Row>
                         <Row>
-                            <Col className="species-detail-chart-header">Origin Planet:</Col>
-                            <Col className="species-detail-chart-text">{this.props.xalian.species.planet}</Col>
+                            <Col className="x-detail-label">Origin Planet:</Col>
+                            <Col className="x-detail-value">{this.props.xalian.species.planet}</Col>
                         </Row>
                         <Row>
-                            <Col className="species-detail-chart-header">Avg Height:</Col>
-                            <Col className="species-detail-chart-text">{this.props.xalian.species.height}</Col>
+                            <Col className="x-detail-label">Avg Height:</Col>
+                            <Col className="x-detail-value">{this.props.xalian.species.height}</Col>
                         </Row>
                         <Row>
-                            <Col className="species-detail-chart-header">Avg Weight:</Col>
-                            <Col className="species-detail-chart-text">{this.props.xalian.species.weight}</Col>
+                            <Col className="x-detail-label">Avg Weight:</Col>
+                            <Col className="x-detail-value">{this.props.xalian.species.weight}</Col>
                         </Row>
                     </React.Fragment>
                 }
                 {this.props.species && 
                     <React.Fragment>
                         <Row>
-                            <Col className="species-detail-chart-header">Generation:</Col>
-                            <Col className='species-detail-chart-text'>{this.props.species.generation || '0'}</Col>
+                            <Col className="x-detail-label">Generation:</Col>
+                            <Col className="x-detail-value">{this.props.species.generation || '0'}</Col>
                         </Row>
                         <Row>
-                            <Col className="species-detail-chart-header">Origin Planet:</Col>
-                            <Col className="species-detail-chart-text">{this.props.species.planet}</Col>
+                            <Col className="x-detail-label">Origin Planet:</Col>
+                            <Col className="x-detail-value">{this.props.species.planet}</Col>
                         </Row>
                         <Row>
-                            <Col className="species-detail-chart-header">Avg Height:</Col>
-                            <Col className="species-detail-chart-text">{this.props.species.height}</Col>
+                            <Col className="x-detail-label">Avg Height:</Col>
+                            <Col className="x-detail-value">{this.props.species.height}</Col>
                         </Row>
                         <Row>
-                            <Col className="species-detail-chart-header">Avg Weight:</Col>
-                            <Col className="species-detail-chart-text">{this.props.species.weight}</Col>
+                            <Col className="x-detail-label">Avg Weight:</Col>
+                            <Col className="x-detail-value">{this.props.species.weight}</Col>
                         </Row>
                     </React.Fragment>
                 }
@@ -70,20 +70,20 @@ class XalianAttributeChart extends React.Component {
                     <React.Fragment>
 
                     {/* <Row>
-                        <Col className="species-detail-chart-header">Total Stat Points:</Col>
-                        <Col className="species-detail-chart-text">{this.props.xalian.meta.totalStatPoints}</Col>
+                        <Col className="x-detail-label">Total Stat Points:</Col>
+                        <Col className="x-detail-value">{this.props.xalian.meta.totalStatPoints}</Col>
                     </Row>
                     <Row>
-                        <Col className="species-detail-chart-header">Potential Stat Points:</Col>
-                        <Col className="species-detail-chart-text">{this.props.xalian.meta.potentialStatPoints}</Col>
+                        <Col className="x-detail-label">Potential Stat Points:</Col>
+                        <Col className="x-detail-value">{this.props.xalian.meta.potentialStatPoints}</Col>
                     </Row> */}
                     <Row>
-                        <Col className="species-detail-chart-header">Stat Score:</Col>
-                        <Col className="species-detail-chart-text">{this.props.xalian.meta.statScore}</Col>
+                        <Col className="x-detail-label">Stat Score:</Col>
+                        <Col className="x-detail-value">{this.props.xalian.meta.statScore}</Col>
                     </Row>
                     <Row>
-                        <Col className="species-detail-chart-header">Stat Potential Score:</Col>
-                        <Col className="species-detail-chart-text">{this.props.xalian.meta.potentialStatScore}</Col>
+                        <Col className="x-detail-label">Stat Potential Score:</Col>
+                        <Col className="x-detail-value">{this.props.xalian.meta.potentialStatScore}</Col>
                     </Row>
                     </React.Fragment>
                 }

--- a/my-app/src/components/xalianStatChart.js
+++ b/my-app/src/components/xalianStatChart.js
@@ -8,6 +8,7 @@ import Col from 'react-bootstrap/Col';
 import Table from 'react-bootstrap/Table';
 import * as valueTranslator from '../utils/valueTranslator';
 import * as constants from '../constants/constants';
+import { chart, text } from '../constants/designTokens';
 
 class XalianStatChart extends React.Component {
 	state = {};
@@ -68,23 +69,23 @@ class XalianStatChart extends React.Component {
 						<BarChart data={this.setupData(this.props.stats)} layout="vertical" maxBarSize={this.props.barSize || 35}>
 							<XAxis type="number" hide />
 							{/* <YAxis width={60} type="category" dataKey="statLabel" stroke="#80ffb1" interval={0}/> */}
-							<YAxis width={this.props.abbreviatedNames ? 60 : 60} type="category" dataKey="statLabel" stroke={this.props.axisLabelColor || '#ffffff'} interval={0} />
+							<YAxis width={this.props.abbreviatedNames ? 60 : 60} type="category" dataKey="statLabel" stroke={this.props.axisLabelColor || chart.axis} interval={0} />
 
 							{this.props.includeRange && (
-								<Bar radius={[10, 10, 10, 10]} isAnimationActive={false} dataKey="rangeNumber" fill="#ecff8234"  minPointSize={minBarLength} >
+								<Bar radius={[10, 10, 10, 10]} isAnimationActive={false} dataKey="rangeNumber" fill={chart.rangeTrack}  minPointSize={minBarLength} >
 									{this.props.includeLabel && <LabelList dataKey="rangeName" position={this.props.labelPosition || 'center'} fill="white" style={{ fontSize: this.props.labelFontSize || '12pt' }} className="chart-bar-label" />}
 									{this.state.data && this.state.data.map((entry, index) => <Cell key={`cell-${index}`} fill={valueTranslator.statFieldToBarColor(entry.statName)} />)}
 								</Bar>
 							)}
-							<Bar radius={[0, 0, 0, 0]} isAnimationActive={false} dataKey="points" fill="#80dbff34" stackId="a"  minPointSize={minBarLength} >
+							<Bar radius={[0, 0, 0, 0]} isAnimationActive={false} dataKey="points" fill={chart.pointsFill} stackId="a"  minPointSize={minBarLength} >
 								{this.props.includeLabel && <LabelList dataKey="percentageText" position={this.props.labelPosition || 'center'} fill="white" style={{ fontSize: this.props.labelFontSize || '12pt' }} className="chart-bar-label" />}
 								{this.setupData(this.props.stats).map((entry, index) => <Cell key={`cell-${index}`} fill={valueTranslator.statFieldToBarColor(entry.statName)} />)}
 							</Bar>
-							<Bar style={{opacity: 0.35 }} radius={[0, 10, 10, 0]} isAnimationActive={false} dataKey="potentialPoints" fill="#80dbff34" stackId="a" minPointSize={minBarLength} >
-								{this.props.includeLabel && <LabelList dataKey="potentialPointsLabel" position={this.props.labelPosition || 'center'} fill="#ffffff50" style={{ fontSize: this.props.labelFontSize || '12pt' }} className="chart-bar-label" />}
+							<Bar style={{opacity: 0.35 }} radius={[0, 10, 10, 0]} isAnimationActive={false} dataKey="potentialPoints" fill={chart.pointsFill} stackId="a" minPointSize={minBarLength} >
+								{this.props.includeLabel && <LabelList dataKey="potentialPointsLabel" position={this.props.labelPosition || 'center'} fill={chart.barLabel} style={{ fontSize: this.props.labelFontSize || '12pt' }} className="chart-bar-label" />}
 								{this.setupData(this.props.stats).map((entry, index) => <Cell key={`cell-${index}`} fill={valueTranslator.statFieldToBarColor(entry.statName)} />)}
 							</Bar>
-							<Tooltip  cursor={{fill: '#FFFFFF25'  }} content={<CustomTooltip />} />
+							<Tooltip  cursor={{fill: chart.cursorFill  }} content={<CustomTooltip />} />
 						</BarChart>
 					</ResponsiveContainer>
 				)}
@@ -98,8 +99,8 @@ const CustomTooltip = ({ active, payload, label }) => {
 	  return (
 		<div style={{border: 'solid 2px' + valueTranslator.statFieldToBarColor(payload[0].payload.statName) }} className="stat-tooltip">
 		  <h5 style={{ color: 'white' }} className="stat-tooltip-label">{payload[0].payload.statLabel}</h5>
-		  <h6 style={{ color: '#cccccc' }} className="stat-tooltip-label">{`${payload[0].payload.rangeName}: ${payload[0].payload.points}`}</h6>
-		  <h6 style={{ color: '#cccccc' }} className="stat-tooltip-label">{`${payload[1].value} potential points`}</h6>
+		  <h6 style={{ color: text.muted }} className="stat-tooltip-label">{`${payload[0].payload.rangeName}: ${payload[0].payload.points}`}</h6>
+		  <h6 style={{ color: text.muted }} className="stat-tooltip-label">{`${payload[1].value} potential points`}</h6>
 		</div>
 	  );
 	}

--- a/my-app/src/constants/designTokens.js
+++ b/my-app/src/constants/designTokens.js
@@ -1,0 +1,107 @@
+/**
+ * The JavaScript half of the design token system.
+ *
+ * Some things can only be styled from JS - recharts takes colours as `fill`
+ * props, GSAP tweens take them as tween values, and SVG components take them as
+ * attributes. Those consumers cannot read a CSS custom property, so the palette
+ * has to exist on both sides.
+ *
+ * public/assets/css/tokens.css is the CSS half. The two are kept identical by
+ * src/__tests__/designTokens.test.js, which fails if any value here disagrees
+ * with the matching --x-* token. Change a colour in one place and the test will
+ * tell you about the other.
+ *
+ * Element/type colours live in colorConstants.js (imported and re-exported here
+ * so there is one import for consumers) because they predate this file and are
+ * referenced widely.
+ */
+
+const colorConstants = require('./colorConstants');
+
+// --- brand ---------------------------------------------------------------
+const brand = {
+	green: '#80ffb0',
+	greenHover: '#b3ffd0',
+	greenActive: '#57aa77',
+	greenBorder: '#6bd493',
+};
+
+// --- surfaces ------------------------------------------------------------
+const surface = {
+	bg: '#0d0d0d',
+	surface1: '#151515',
+	surface2: '#1a1a1a',
+	surface3: '#232323',
+	border: '#333333',
+	borderStrong: '#4a4a4a',
+};
+
+// --- text ----------------------------------------------------------------
+const text = {
+	primary: '#ffffff',
+	muted: '#cccccc',
+	dim: '#949494',
+	inverse: '#000000',
+};
+
+// --- feedback ------------------------------------------------------------
+const feedback = {
+	danger: '#ff5b5b',
+	warning: '#e2bd43',
+	success: '#80ffb0',
+};
+
+/**
+ * Stat colours. These are semantic - attack is red, defense is blue, speed is
+ * yellow-green, stamina/recovery are green - and the "special" variant of each
+ * is a darker shade of the same hue so the pairs read as related.
+ */
+const stat = {
+	standardAttack: '#a84032',
+	specialAttack: '#753027',
+	standardDefense: '#535dc2',
+	specialDefense: '#494f8c',
+	speed: '#d0d466',
+	evasion: '#aaad53',
+	stamina: '#4bbf4e',
+	recovery: '#479e4a',
+};
+
+/**
+ * The same eight stats as they appear in the points charts, where bars are
+ * drawn translucent over a range track.
+ */
+const statPoints = {
+	standardAttack: '#df9320be',
+	specialAttack: '#b37519d0',
+	standardDefense: '#70a5dbb7',
+	specialDefense: '#2e73b8c2',
+	speed: '#64b43cc2',
+	evasion: '#4b862dc4',
+	stamina: '#c04141c9',
+	recovery: '#8f1f1fc9',
+};
+
+// --- charts --------------------------------------------------------------
+const chart = {
+	/* the faint track a stat bar is drawn against */
+	rangeTrack: '#ecff8234',
+	/* the filled portion of a stat bar */
+	pointsFill: '#80dbff34',
+	/* label text drawn on top of a bar */
+	barLabel: '#ffffff50',
+	/* the hover highlight behind a tooltip */
+	cursorFill: '#ffffff25',
+	axis: '#ffffff',
+};
+
+module.exports = {
+	brand,
+	surface,
+	text,
+	feedback,
+	stat,
+	statPoints,
+	chart,
+	themeColors: colorConstants.themeColors,
+};

--- a/my-app/src/pages/generatorPage.js
+++ b/my-app/src/pages/generatorPage.js
@@ -48,24 +48,34 @@ class GeneratorPage extends React.Component {
 				<XalianNavbar authAlertCallback={this.setLoggedInUser}></XalianNavbar>
 				<SmokeEffectBackground id="smokeBackgroundCanvasBelow" particleCount={10} />
 				<SmokeEffectBackground id="smokeBackgroundCanvas" />
-				<div style={{ zIndex: '-1', width: '100vw', height: '100vh', position: 'fixed', top: 0, left: 0, background: 'linear-gradient(0deg, rgba(0,0,0,0) 25%, rgba(20,23,23,1) 100%)' }}/>
+				<div className="generator-page-gradient-overlay" />
+
+				{/* The smoke effect covers the whole viewport while the Lambda is
+				    answering, which on a cold start is several seconds of opaque grey
+				    with nothing to say the site is still working. */}
+				{this.state.isGenerating &&
+					<div className="generator-loading-overlay" role="status" aria-live="polite">
+						<div className="generator-loading-text">Generating Xalian...</div>
+						<div className="generator-loading-sub">Running the Xalian Generator</div>
+					</div>
+				}
 				<Container className="generator-page-content-background-container ">
 					<React.Fragment>
 						<Container fluid className="whole-container ">
 							<Row className="generator-button-row">
 								{/* {this.state.xalian && this.state.showXalian && ( */}
-								<Col class="">
+								<Col>
 									<Button variant="xalianGray" disabled={!this.state.loggedInUser} onClick={this.saveXalian} className="save-xalian-generator-page-button">
 										{this.state.loggedInUser ? 'Save to Your Faction' : 'Sign In to Keep'}
 									</Button>
 								</Col>
 								{/* )} */}
-								<Col class="">
+								<Col>
 									<Button variant="xalianGreen" onClick={this.getXalian}>
 										Generate New Xalian
 									</Button>
 								</Col>
-								{/* <Col class="">
+								{/* <Col>
                                     <Button variant='xalianGray' onClick={this.test} className='save-xalian-generator-page-button'>Test</Button>
                                 </Col> */}
 							</Row>
@@ -117,6 +127,7 @@ class GeneratorPage extends React.Component {
 	}
 
 	getXalian = () => {
+		this.setState({ isGenerating: true });
 		// this.setState({ showXalian: false }, () => {
 			// gsap.to('#generated-xalian-div', { opacity: 0, duration: 1, ease: 'power2.in' });
 			gsap.timeline()
@@ -129,6 +140,7 @@ class GeneratorPage extends React.Component {
 							{
 								xalian: x,
 								isLoading: false,
+								isGenerating: false,
 							},
 							() => {
 								// this.setState({ showXalian: true }, () => {
@@ -138,6 +150,7 @@ class GeneratorPage extends React.Component {
 							}
 						);
 					}).catch(() => {
+						this.setState({ isGenerating: false });
 						alertUtil.sendAlert('Could not generate a Xalian — please try again', null, 'danger');
 						gsap.to('#smokeBackgroundCanvas', { opacity: 0, duration: 1, ease: 'power2.in' });
 						gsap.to('#generated-xalian-fragment', { opacity: 1, duration: 0.5, ease: 'power2.out' }, '<');

--- a/my-app/src/pages/glossaryPage.js
+++ b/my-app/src/pages/glossaryPage.js
@@ -61,12 +61,12 @@ class GlossaryPage extends React.Component {
                 <XalianNavbar></XalianNavbar>
 
                 <Container>
-                    <h1 className="page-title-text template-col-wrapper" style={{ textAlign: 'center' }}>Glossary</h1>
+                    <h1 className="x-page-title">Glossary</h1>
 
                     <Row className="justify-content-center">
                         <Col md={7} lg={6}>
                             <InputGroup className="glossary-search">
-                                <InputGroup.Text className="glossary-search-icon">
+                                <InputGroup.Text className="x-input-addon">
                                     <i className="bi bi-search" />
                                 </InputGroup.Text>
                                 <Form.Control
@@ -75,7 +75,7 @@ class GlossaryPage extends React.Component {
                                     aria-label="Search glossary terms"
                                     value={this.state.query}
                                     onChange={(e) => this.setState({ query: e.target.value })}
-                                    className="glossary-search-input"
+                                    className="x-input"
                                 />
                             </InputGroup>
                             <p className="glossary-result-count">
@@ -90,7 +90,7 @@ class GlossaryPage extends React.Component {
                         <Col className="">
                             {entries.length > 0
                                 ? <dl className="glossary-list">{this.buildDictionary(entries)}</dl>
-                                : <p className="glossary-empty">No terms match “{this.state.query}”.</p>
+                                : <p className="x-empty-state">No terms match “{this.state.query}”.</p>
                             }
                         </Col>
                     </Row>

--- a/my-app/src/pages/planetPage.js
+++ b/my-app/src/pages/planetPage.js
@@ -46,7 +46,7 @@ class PlanetPage extends React.Component {
                     <Row >
 
                         <Col className="template-col-wrapper">
-                            <h1 className="page-title-text">Discovered Planets</h1>
+                            <h1 className="x-page-title">Discovered Planets</h1>
                             {this.buildPlanets()}
                         </Col>
 

--- a/my-app/src/pages/speciesDetailPage.js
+++ b/my-app/src/pages/speciesDetailPage.js
@@ -46,7 +46,7 @@ class SpeciesDetailPage extends React.Component {
 					<Container fluid className="content-background-container">
 						<XalianNavbar></XalianNavbar>
 						<Container className="content-container">
-							<h1 className="page-title-text">Species not found</h1>
+							<h1 className="x-page-title">Species not found</h1>
 							<p style={{ textAlign: 'center' }}>
 								No Xalian species matches this id. <a href="/species">Browse all species</a>
 							</p>

--- a/my-app/src/pages/speciesPage.js
+++ b/my-app/src/pages/speciesPage.js
@@ -141,7 +141,7 @@ class SpeciesPage extends React.Component {
                     <Row className="">
 
                         <Col className="template-col-wrapper ">
-                            <h1 className="page-title-text">Discovered Species</h1>
+                            <h1 className="x-page-title">Discovered Species</h1>
 
                             {species &&
                                 <Tabs defaultActiveKey="grid" id="tabbs" className="species-tab-group x-tabs">

--- a/my-app/src/pages/styleGuidePage.js
+++ b/my-app/src/pages/styleGuidePage.js
@@ -1,0 +1,198 @@
+import React from 'react';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/Button';
+import Container from 'react-bootstrap/Container';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+import XalianNavbar from '../components/navbar';
+import tokens from '../constants/designTokens';
+
+/**
+ * A living reference for the design system.
+ *
+ * This page is rendered from the same tokens and primitives the rest of the site
+ * uses, so it cannot drift: change a token and this page changes with it. Use it
+ * to check that a new colour or component actually fits before scattering it
+ * across pages.
+ */
+
+const SPACE_STEPS = ['1', '2', '3', '4', '5', '6', '7', '8'];
+const RADIUS_STEPS = ['sm', 'md', 'lg', 'xl', 'pill'];
+const ELEMENT_TYPES = Object.keys(tokens.themeColors);
+
+class StyleGuidePage extends React.Component {
+
+    renderSwatches(title, entries, note) {
+        return (
+            <section className="styleguide-section">
+                <h2 className="styleguide-heading">{title}</h2>
+                {note && <p className="styleguide-note">{note}</p>}
+                <div className="styleguide-swatch-grid">
+                    {entries.map(([name, value]) => (
+                        <div className="styleguide-swatch" key={name}>
+                            <div className="styleguide-swatch-chip" style={{ backgroundColor: value }} />
+                            <code className="styleguide-swatch-name">{name}</code>
+                            <code className="styleguide-swatch-value">{value}</code>
+                        </div>
+                    ))}
+                </div>
+            </section>
+        );
+    }
+
+    render() {
+        return (
+            <React.Fragment>
+                <Container fluid className="content-background-container">
+                    <XalianNavbar />
+
+                    <Container className="styleguide-container">
+                        <h1 className="x-page-title">Design System</h1>
+                        <p className="x-page-subtitle">
+                            Every colour, space and component the site is built from. Rendered from the same
+                            tokens the pages use, so it stays honest.
+                        </p>
+
+                        {this.renderSwatches('Brand', Object.entries(tokens.brand))}
+                        {this.renderSwatches('Surfaces', Object.entries(tokens.surface),
+                            'Backgrounds and borders, darkest first. The page sits on bg; panels lift off it.')}
+                        {this.renderSwatches('Text', Object.entries(tokens.text),
+                            'dim is the faintest step that still clears 4.5:1 on the page background. Anything fainter is decorative and must not carry meaning.')}
+                        {this.renderSwatches('Feedback', Object.entries(tokens.feedback))}
+                        {this.renderSwatches('Stats', Object.entries(tokens.stat),
+                            'Semantic: attack is red, defense blue, speed yellow-green, stamina and recovery green. Each special variant is a darker shade of its standard pair.')}
+                        {this.renderSwatches('Elements', Object.entries(tokens.themeColors),
+                            'One per element type. Mirrored as --x-type-* in CSS and enforced identical by designTokens.test.js.')}
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Spacing</h2>
+                            <p className="styleguide-note">A 4px-based scale. Use these rather than arbitrary pixel values.</p>
+                            {SPACE_STEPS.map((step) => (
+                                <div className="styleguide-space-row" key={step}>
+                                    <code className="styleguide-space-name">--x-space-{step}</code>
+                                    <div className="styleguide-space-bar" style={{ width: `var(--x-space-${step})` }} />
+                                </div>
+                            ))}
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Radius</h2>
+                            <div className="styleguide-radius-grid">
+                                {RADIUS_STEPS.map((step) => (
+                                    <div className="styleguide-radius-item" key={step}>
+                                        <div className="styleguide-radius-box" style={{ borderRadius: `var(--x-radius-${step})` }} />
+                                        <code className="styleguide-swatch-name">--x-radius-{step}</code>
+                                    </div>
+                                ))}
+                            </div>
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Panels</h2>
+                            <p className="styleguide-note">
+                                The core surface, lifted from the planets page. A tinted, inset-glowing card keyed to an
+                                element colour. Set the tint with an <code>.x-panel--type-*</code> class.
+                            </p>
+                            <Row>
+                                <Col md={4} className="styleguide-panel-col">
+                                    <div className="x-panel">
+                                        <h5 className="x-section-title">Default</h5>
+                                        <p className="styleguide-note">Falls back to the brand green.</p>
+                                    </div>
+                                </Col>
+                                <Col md={4} className="styleguide-panel-col">
+                                    <div className="x-panel x-panel--type-fire">
+                                        <h5 className="x-section-title">Fire tint</h5>
+                                        <p className="styleguide-note">Keyed with <code>.x-panel--type-fire</code>.</p>
+                                    </div>
+                                </Col>
+                                <Col md={4} className="styleguide-panel-col">
+                                    <div className="x-panel x-panel--flat">
+                                        <h5 className="x-section-title">Flat</h5>
+                                        <p className="styleguide-note">For dense content, where a glow is noise.</p>
+                                    </div>
+                                </Col>
+                            </Row>
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Element tints</h2>
+                            <div className="styleguide-tint-grid">
+                                {ELEMENT_TYPES.map((type) => (
+                                    <div className={`x-panel x-panel--type-${type} styleguide-tint`} key={type}>
+                                        {type}
+                                    </div>
+                                ))}
+                            </div>
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Buttons</h2>
+                            <p className="styleguide-note">
+                                xalianGreen is the primary action, xalianGray the secondary. Both show a green focus
+                                ring for keyboard users.
+                            </p>
+                            <div className="styleguide-button-row">
+                                <Button variant="xalianGreen">Primary</Button>
+                                <Button variant="xalianGray">Secondary</Button>
+                                <Button variant="xalianGreen" disabled>Disabled</Button>
+                                <Button variant="xalianGray" disabled>Disabled</Button>
+                            </div>
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Form controls</h2>
+                            <Row>
+                                <Col md={6}>
+                                    <InputGroup>
+                                        <InputGroup.Text className="x-input-addon"><i className="bi bi-search" /></InputGroup.Text>
+                                        <Form.Control className="x-input" placeholder="With an addon..." />
+                                    </InputGroup>
+                                </Col>
+                                <Col md={6}>
+                                    <Form.Control className="x-input" placeholder="On its own..." />
+                                </Col>
+                            </Row>
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Label / value rows</h2>
+                            <p className="styleguide-note">
+                                The value is the information and gets the emphasis; the label is chrome and stays dim.
+                            </p>
+                            <Row className="x-detail-row">
+                                <Col className="x-detail-label">Origin Planet:</Col>
+                                <Col className="x-detail-value">Grimedes</Col>
+                            </Row>
+                            <Row className="x-detail-row">
+                                <Col className="x-detail-label">Avg Height:</Col>
+                                <Col className="x-detail-value">30 in / 76 cm</Col>
+                            </Row>
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Measure</h2>
+                            <p className="styleguide-note">
+                                Body copy is capped at <code>--x-measure</code> so it stays readable on wide screens.
+                                The lore sections used to run the full viewport, roughly 200 characters per line.
+                            </p>
+                            <div className="x-measure styleguide-measure-demo">
+                                For thousands of years, the ancient race known as the Vallerii dominated the galaxy of
+                                Xalia. With their god-like mastery of biotechnology, they birthed the first Xalians —
+                                bioengineered organisms designed to thrive in Xalia's most extreme environments.
+                            </div>
+                        </section>
+
+                        <section className="styleguide-section">
+                            <h2 className="styleguide-heading">Empty state</h2>
+                            <p className="x-empty-state">Nothing here yet.</p>
+                        </section>
+                    </Container>
+                </Container>
+            </React.Fragment>
+        );
+    }
+}
+
+export default StyleGuidePage;

--- a/my-app/src/pages/trainingGroundsPage.js
+++ b/my-app/src/pages/trainingGroundsPage.js
@@ -43,7 +43,7 @@ class TrainingGroundsPage extends React.Component {
 
                     <Row className="">
                         <Col style={{ textAlign: 'center' }} >
-                            <h1 className="page-title-text">Training Grounds</h1>
+                            <h1 className="x-page-title">Training Grounds</h1>
                             <p className="training-grounds-subtitle">Warm-up games while you wait for a duel.</p>
 
                             {/* was a single unlabelled bootstrap-blue "switch" button that

--- a/my-app/src/utils/valueTranslator.js
+++ b/my-app/src/utils/valueTranslator.js
@@ -1,21 +1,23 @@
-let statColorMap = new Map();
-statColorMap['standardAttackRating'] = '#a84032';
-statColorMap['specialAttackRating'] = '#753027';
-statColorMap['standardDefenseRating'] = '#535dc2';
-statColorMap['specialDefenseRating'] = '#494f8c';
-statColorMap['speedRating'] = '#d0d466';
-statColorMap['evasionRating'] = '#aaad53';
-statColorMap['staminaRating'] = '#4bbf4e';
-statColorMap['recoveryRating'] = '#479e4a';
+import { stat, statPoints } from '../constants/designTokens';
 
-statColorMap['standardAttackPoints'] = '#df9320be';
-statColorMap['specialAttackPoints'] = '#b37519d0';
-statColorMap['standardDefensePoints'] = '#70a5dbb7';
-statColorMap['specialDefensePoints'] = '#2e73b8c2';
-statColorMap['speedPoints'] = '#64b43cc2';
-statColorMap['evasionPoints'] = '#4b862dc4';
-statColorMap['staminaPoints'] = '#c04141c9';
-statColorMap['recoveryPoints'] = '#8f1f1fc9';
+let statColorMap = new Map();
+statColorMap['standardAttackRating'] = stat.standardAttack;
+statColorMap['specialAttackRating'] = stat.specialAttack;
+statColorMap['standardDefenseRating'] = stat.standardDefense;
+statColorMap['specialDefenseRating'] = stat.specialDefense;
+statColorMap['speedRating'] = stat.speed;
+statColorMap['evasionRating'] = stat.evasion;
+statColorMap['staminaRating'] = stat.stamina;
+statColorMap['recoveryRating'] = stat.recovery;
+
+statColorMap['standardAttackPoints'] = statPoints.standardAttack;
+statColorMap['specialAttackPoints'] = statPoints.specialAttack;
+statColorMap['standardDefensePoints'] = statPoints.standardDefense;
+statColorMap['specialDefensePoints'] = statPoints.specialDefense;
+statColorMap['speedPoints'] = statPoints.speed;
+statColorMap['evasionPoints'] = statPoints.evasion;
+statColorMap['staminaPoints'] = statPoints.stamina;
+statColorMap['recoveryPoints'] = statPoints.recovery;
 
 let condensedTransMap = new Map();
 condensedTransMap['standardAttackPoints'] = 'ATT';


### PR DESCRIPTION
Extends the token layer from #51 / #52 into a system the whole site is built from, with documentation and a living reference page.

## The palette lives on both sides, on purpose

CSS paints with `--x-*` custom properties. But **recharts** takes colours as `fill` props, **GSAP** as tween values and **SVG** as attributes — none of which can read a CSS variable. So `src/constants/designTokens.js` mirrors `tokens.css`, and `designTokens.test.js` asserts all **32 pairs** match. Edit one side alone and the test fails naming the token that disagrees. I verified it catches drift by deliberately breaking a value.

Newly tokenised: the eight semantic stat colours (attack red, defense blue, speed yellow-green, stamina green — each `special` variant a darker shade of its `standard` pair) and the chart colours, all previously loose hex.

## Primitives

All prefixed `.x-`: page titles/subtitles, label/value rows, form controls, empty states, tabs, and the panel in **tinted**, **flat** and **element-keyed** variants. Pages had been hand-rolling each of these.

## `/styleguide`

A living reference rendering every token and primitive **from the same source the pages use**, so it can't go stale. Deliberately unlinked from the navbar — it's a developer tool, not a page for players. `docs/DESIGN_SYSTEM.md` covers the rules and how to add a colour; `CLAUDE.md` points at it.

## Bugs this surfaced

Building the style guide put every component side by side, which is exactly how these turned up:

- **The gray button turned pale green on hover while keeping white text** — about 1.3:1, effectively unreadable mid-hover. Now lifts a surface step with a green border.
- **Disabled buttons were black text on near-transparent green** — invisible. Now legible dim-on-surface at 4.6:1.
- Every button variant gained a **visible keyboard focus ring**.
- **The generator** covered the viewport in opaque smoke for the whole of a cold-start Lambda with nothing saying the site was working — which is precisely why I misread it as broken earlier in this work. It now shows a status message over the smoke, with the pulse disabled under `prefers-reduced-motion`. (Verified by DOM sampling under Slow 3G: present at z-index 1000 throughout the request, cleared on completion.)
- `generatorPage` used `class` instead of `className` on two `Col`s, so React silently dropped them.
- `characterGeneratedStatChart` drew its axis in `#80ffb1` — one digit off the brand green. A typo, not a second colour; now the token. I changed this **deliberately and visibly** rather than letting a near-duplicate sit in the palette.

## Measured

| | Before | After |
|---|---|---|
| JS colour literals (excluding token sources) | ~101 | 64 |
| Raw hex in the three consumer stylesheets | 232 | 163 |

## Verification

Every page driven in a browser at 1440×900 and 390×844 against the dev server and a production build: home, species, species detail, planets, glossary, training, generator, duel start, duel board, style guide. The duel board was played into to confirm the `duel.css` tokenisation is a true visual no-op. Glossary markup verified as 67 valid `dt`/`dd` pairs with **zero** headings (was ~134). No horizontal overflow at 390px. 47/47 tests pass.

## Not done, deliberately

- Named colour keywords (`black`/`white`) in `duel.css` are equivalent to tokens but were left alone — converting them is churn with no visual gain.
- Layout inline styles in the duel board components remain; they're layout rather than colour, and carry real regression risk for no visual benefit.
- Filed #53 for the match game's Start button overlapping its card grid — a pre-existing layout bug in that game, not page chrome, so out of scope here.