### PR TITLE
Design system v2: the Generator console

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,13 +136,17 @@ Game data JSON is **duplicated by build step, not imported across packages**: `m
 
 ### Design system
 
-**Read `docs/DESIGN_SYSTEM.md` before changing anything visual.** The short version:
+**Read `docs/DESIGN_SYSTEM.md` before changing anything visual.** The site is styled as the control panel of a Xalian Generator — Star Wars by way of Fallout, where the machine is centuries ahead but the interface is enamelled steel, brass and bakelite. The short version:
 
-- The palette lives **twice on purpose**: `public/assets/css/tokens.css` (`--x-*` custom properties, the CSS source of truth) and `src/constants/designTokens.js` (the same values for recharts `fill` props, GSAP tweens and SVG attributes, which cannot read a CSS variable). `src/__tests__/designTokens.test.js` fails if the two disagree — **never edit one side alone**.
-- Element/type colours stay in `constants/colorConstants.js` and are re-exported through `designTokens.js` as `themeColors`; they are mirrored as `--x-type-*` and enforced identical by the same test.
-- Reusable classes are prefixed `.x-` and defined in `tokens.css`: `.x-panel` (the tinted inset-glow card, the site's core surface), `.x-page-title`, `.x-detail-label`/`.x-detail-value`, `.x-measure`, `.x-tabs`, `.x-input`, `.x-empty-state`.
-- **No new raw hex** in CSS or JSX. Add a token to both sides plus the test's `PAIRINGS` list instead.
-- `/styleguide` is a living reference page rendering every token and primitive. It is deliberately not linked from the navbar — it is a developer tool.
+- **Panels are matte and never glow.** Depth is a bevel plus rivets. Phosphor, scanlines and bloom live strictly inside `.g-screen` (a CRT bolted into the hull), which is the only thing that emits light. Lamps (`.g-lamp`) are the other lit thing, and they are static.
+- **Colour is energy or a warning.** The hull is olive/bone/gunmetal; the 14 element hues and the hazard livery are the only saturated things. Element colours are fixed points — do not restyle them.
+- `--g-el` is the element in scope: put `.g-el-fire` on any container and every meter, chip and tagged panel inside it retunes. Components read `--g-el` rather than naming a colour.
+- The palette lives **twice on purpose**: `public/assets/css/system.css` (`--g-*`, the CSS source of truth) and `src/constants/designTokens.js` (the same values for recharts `fill` props, GSAP tweens and SVG attributes, which cannot read a CSS variable). `src/__tests__/designTokens.test.js` fails if they disagree — **never edit one side alone**.
+- Components are prefixed `.g-`: `.g-panel`, `.g-screen`, `.g-meter`, `.g-chip`, `.g-btn`, `.g-input`, `.g-segmented`, `.g-lamp`, `.g-specimen`, `.g-tile`, `.g-record`, `.g-spec`, `.g-data`.
+- **No new raw hex** in CSS or JSX. Add a token to both sides plus the test's `PAIRINGS` list.
+- Type is Oswald (stencilled legends), Barlow (prose), IBM Plex Mono (machine output, always tabular).
+- `/styleguide` is a living reference rendering every token and component. It is deliberately not linked from the navbar — it is a developer tool.
+- `public/assets/css/tokens.css` is a **temporary shim** mapping old `--x-*` names onto the new `--g-*` ones so unmigrated CSS still looks right. Do not add to it; delete rules from it as pages migrate.
 - `style.css` is a 3504-line BootstrapMade template. Many class names look unused but that signal has false positives (`btn-xalianGreen` is composed by bootstrap from `variant='xalianGreen'`), so do not bulk-delete it.
 
 ## Conventions and gotchas

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,75 +1,112 @@
-# Xalians Design System
+# Xalian Generator — Design System
 
-The site has one visual language: **dark, galactic, neon-green**, with each of the 14 element types carrying its own colour. This document is the rulebook. The live reference is at **`/styleguide`** — it renders from the same tokens the pages use, so it cannot go stale.
+The site is not a website about creatures. It is **the control panel of a Xalian Generator**: a machine that can bioengineer life on a dead world, built by an industrial empire during its atomic age. Star Wars by way of Fallout — the capability is centuries ahead, the interface is decades behind. Enamelled steel, brass bezels, bakelite keys, and a small green CRT bolted into the hull.
+
+The live reference is **`/styleguide`**, rendered from the same tokens and classes the pages use, so it cannot go stale. Read it before designing anything new.
+
+## The four rules
+
+1. **Panels are matte objects.** Pressed steel under olive enamel. Depth is a bevel — light along the top edge, shadow underneath — plus rivets where a real panel would need them. **No panel ever glows.**
+2. **Only screens and lamps emit.** Phosphor, scanlines and bloom live strictly inside `.g-screen`. A CRT behind glass is the one lit thing in the room, which is precisely why the eye goes to it. Putting a glow on the hull spends that.
+3. **Colour is energy or a warning.** The hull is olive, bone and gunmetal. The fourteen element hues and the hazard livery are the only saturated things in the system, so they read instantly.
+4. **Legends are stencilled, output is monospaced.** Condensed caps (Oswald) for anything painted on the hull; IBM Plex Mono for anything the machine itself prints. Numbers are always tabular so a changing value never shifts the layout.
 
 ## Where things live
 
 | File | Role |
 |---|---|
-| `my-app/public/assets/css/tokens.css` | **Source of truth for CSS.** All tokens (`--x-*`) plus the primitive classes (`.x-*`). Loaded before everything else. |
-| `my-app/src/constants/designTokens.js` | **Source of truth for JS.** The same palette, for consumers that can't read a CSS variable. |
-| `my-app/src/constants/colorConstants.js` | The 14 element/type colours. Predates the system and is referenced widely, so it stays; `designTokens.js` re-exports it as `themeColors`. |
+| `my-app/public/assets/css/system.css` | **The design system.** All `--g-*` tokens and every `.g-*` component. |
+| `my-app/src/constants/designTokens.js` | **The JS half of the palette.** For recharts / GSAP / SVG, which cannot read a CSS variable. |
+| `my-app/src/constants/colorConstants.js` | The 14 element colours. Re-exported through `designTokens.js` as `themeColors`. |
 | `my-app/src/__tests__/designTokens.test.js` | Fails the build if the CSS and JS palettes disagree. |
-| `my-app/public/assets/css/typeColors.css` | Element colour utility classes, generated from the element tokens. |
-| `my-app/public/assets/css/style.css` | Page- and component-specific styles. Consumes tokens; should not define new raw colours. |
+| `my-app/public/assets/css/tokens.css` | **Temporary compatibility shim** mapping the old `--x-*` names onto the new ones. Delete when nothing references `--x-*`. |
+| `my-app/public/assets/css/style.css` | Page-specific layout. Should not define new colours. |
 | `my-app/src/pages/styleGuidePage.js` | The living reference at `/styleguide`. |
 
-## The two-sided palette, and why
+## The palette
 
-Most styling belongs in CSS. But some consumers can only take a JavaScript string:
+Structure is deliberately desaturated so the element hues own every saturated pixel.
 
-- **recharts** takes colours as `fill` / `stroke` props
-- **GSAP** takes them as tween values
-- **SVG** components take them as attributes
+| Group | Tokens | Use |
+|---|---|---|
+| Hull | `--g-void`, `--g-hull-lo`, `--g-hull`, `--g-hull-hi`, `--g-seam` | The room and the panels bolted to it |
+| Brass | `--g-brass`, `--g-brass-dark`, `--g-brass-light` | Bezels, trim rings, fasteners |
+| Ink | `--g-ink`, `--g-ink-mid`, `--g-ink-low`, `--g-ink-invert` | Silkscreen legends. Never pure white — paint yellows |
+| Phosphor | `--g-phosphor`, `--g-screen-glass` | The CRT, and **only** the CRT |
+| Lamps | `--g-lamp-amber`, `--g-lamp-red`, `--g-lamp-off` | Indicator bulbs behind coloured plastic |
+| Hazard | `--g-hazard`, `--g-hazard-dark` | The committing action, and warning livery |
+| Elements | `--g-el-fire` … `--g-el-sand` | The 14 element hues. **Fixed points — do not restyle these.** |
+| Stats | `--g-stat-*` | Semantic stat colours for charts |
 
-So the palette exists twice. That is a genuine duplication risk, which is why `designTokens.test.js` asserts every pair matches — change a colour on one side and the test fails naming the token that no longer agrees. **Never edit one side alone.**
+### `--g-el` — the element in scope
 
-## Rules
+The single most useful thing in the system. Put `.g-el-fire` (or any element) on a container and **everything inside it retunes**: meters light in fire, chips print in fire, tagged panels take a fire band. Components read `--g-el` rather than naming a colour.
 
-1. **No new raw hex.** If you're typing `#`, you either want an existing token or you're adding one. Add it to *both* sides and to the pairings list in the test.
-2. **Use the spacing scale.** `--x-space-1` … `--x-space-8` (4px based). Not arbitrary pixel values.
-3. **Cap body copy at `--x-measure`.** Long prose across a 1440px viewport is unreadable — the lore sections used to run ~200 characters per line.
-4. **The value gets the emphasis, not the label.** In label/value pairs use `.x-detail-label` (dim) and `.x-detail-value` (bright). It used to be backwards.
-5. **Contrast floor is 4.5:1** against the page background. `--x-text-dim` is the faintest step that clears it; anything fainter is decorative and must not carry meaning.
-6. **Layering goes through the scale.** `--x-layer-navbar` and `--x-layer-modal`. The navbar sits at 99999, so a modal that doesn't outrank it gets its header covered — this is a real bug that shipped.
+```html
+<div class="g-panel g-panel--tagged g-el-psychic">
+  <span class="g-chip">Psychic</span>
+  <div class="g-meter"><div class="g-meter-fill" style="width:64%"></div></div>
+</div>
+```
 
-## Primitives
+## Components
 
-Class names are prefixed `.x-`.
-
-| Class | Use |
+| Class | What it is |
 |---|---|
-| `.x-panel` | The core surface: a tinted, inset-glowing card. Defaults to brand green. |
-| `.x-panel--type-<element>` | Keys a panel to an element colour (`.x-panel--type-fire`). |
-| `.x-panel--flat` | Quieter panel for dense content, where a glow is noise. |
-| `.x-page-title` / `.x-page-subtitle` | Page headers. Every page used to roll its own. |
-| `.x-section-title` | Heading above a panel or section. |
-| `.x-detail-row` / `.x-detail-label` / `.x-detail-value` | Label/value rows. |
-| `.x-measure` | Caps content to a readable line length. |
-| `.x-tabs` | Themed tabs. Bootstrap's default is blue-on-white and reads as broken here. |
-| `.x-input` / `.x-input-addon` | Themed form controls. Bootstrap's are white-on-white. |
-| `.x-empty-state` | "Nothing here" messaging. |
+| `.g-console` | The page. Warm near-black with paint tooth. Wraps everything. |
+| `.g-panel` | An enamelled steel panel. `--raised`, `--recessed`, `--bolted` (rivets), `--tagged` (element colour band). |
+| `.g-panel-head` | The stencilled title strip across the top of a panel. |
+| `.g-screen` | **A CRT.** Phosphor text on glass, scanlines, brass bezel. The only thing that emits. |
+| `.g-screen-line`, `--dim` | A line of terminal output. |
+| `.g-readout`, `.g-readout-unit` | A large machine-reported number. Belongs inside a screen. |
+| `.g-meter` + `-track` / `-ghost` / `-fill` | Segmented bulb strip. Lit = current, dim = growth potential, dead = unreachable ceiling. |
+| `.g-chip`, `--outline` | A printed classification label. |
+| `.g-btn`, `--primary`, `--danger` | Moulded keys that travel when pressed. Primary wears hazard paint; **one per screen**. |
+| `.g-input`, `.g-select` | Text entry is a screen: phosphor on glass in a brass bezel. |
+| `.g-segmented` + `.g-segment` | A bank of selector keys. Use `aria-pressed`. |
+| `.g-check` + `.g-check-box` | A toggle with a real throw. |
+| `.g-lamp`, `--amber` / `--red` / `--off` | Indicator bulbs. Static — they do not pulse. |
+| `.g-notice`, `--alert` / `--ok` / `--inert` | An inline notice with a painted edge. |
+| `.g-working` | Indeterminate progress. The machine will not fake a percentage. |
+| `.g-empty` | Nothing here yet. |
+| `.g-specimen` + `.g-specimen-inner` | Artwork behind glass in a brass housing. |
+| `.g-tile` | A catalogue tile for grids. |
+| `.g-record` | A row in a list — glossary terms, search results. |
+| `.g-spec` + `-key` / `-val` | Key/value pairs, as printed on a spec plate. |
+| `.g-data` | A data table. |
+| `.g-hazard-strip`, `.g-seam-rule`, `.g-rivet-rule` | Livery and dividers. |
+| `.g-shell`, `.g-measure` | Layout: page width, readable line length. |
 
-The panel is lifted from the planets page, which was the best-looking surface on the site before this system existed. `styleUtil.getInsideGlowThemeColor()` builds the same effect from JS where a dynamic element colour is needed.
+## Rules for new work
 
-## Buttons
+1. **No raw hex.** If you are typing `#`, you want an existing token or you are adding one. Add it to *both* sides and to `PAIRINGS` in the test.
+2. **Never glow the hull.** If something needs to draw the eye, make it a screen or give it a lamp.
+3. **Use the spacing scale** (`--g-1` … `--g-9`, 4px based), not arbitrary pixels.
+4. **Cap prose at `--g-measure`.** Long lines across a wide viewport are unreadable.
+5. **One `--primary` button per screen.** It is the committing action.
+6. **Contrast floor is 4.5:1.** `--g-ink-low` is the faintest step that clears it against the hull; anything fainter is decoration and must not carry meaning.
+7. **Disabled means unpowered, not faded.** The legend stays legible.
+8. **Motion is mechanical.** Switches throw, keys travel. Nothing drifts or eases lazily. Everything decorative is disabled under `prefers-reduced-motion`.
 
-Two variants, both bootstrap `variant` props: **`xalianGreen`** (primary action) and **`xalianGray`** (secondary). Both carry a green focus ring for keyboard users.
+## Deliberately avoided
 
-The `!important` flags on these rules are load-bearing — bootstrap's own `.btn` rules are more specific than a single class selector. Don't remove them without checking.
+These were tried and removed, because stacking every effect at once is what makes an interface look generated rather than designed:
 
-## Backgrounds
-
-`.content-background-container` paints the starfield used site-wide. Pages that want the *drifting* particle field additionally mount `SplashGalaxyBackground` (home, species, planets) — that's a JS animation loop, so it stays opt-in rather than global.
+- A scanline/vignette/grid overlay across the whole page — the CRT texture belongs on the CRT.
+- An animated scan sweep over artwork.
+- Pulsing status dots.
+- A marker glyph before every label.
+- Glow on large readouts that were already the biggest, most colourful thing present.
+- Chamfered corners on every component — the chamfer survives on the specimen mount alone, where it reads as a machined bezel rather than as wallpaper.
 
 ## Adding a colour
 
-1. Add the CSS token to `:root` in `tokens.css`.
+1. Add the CSS token to `:root` in `system.css`.
 2. Add the matching value to `designTokens.js`.
 3. Add the pair to `PAIRINGS` in `designTokens.test.js`.
-4. Run the tests. If you skipped step 2 or 3, they'll tell you.
+4. Run the tests. If you skipped step 2 or 3, they will tell you.
 
 ## Known debt
 
-- `style.css` is a 3504-line BootstrapMade template ("Gp v4.7.0") with a lot of unused rules. A naive scan says ~115 of 293 class names are unreferenced, **but that count has false positives**: `btn-xalianGreen` *is* used, composed by bootstrap from `variant='xalianGreen'`. Don't bulk-delete on that signal.
-- Plenty of inline `style={{}}` remains, concentrated in the duel board components. Layout inline styles are lower priority; colour ones should move to tokens.
+- `tokens.css` is a temporary shim. Every page migrated to `.g-*` should shrink it; delete it when nothing references `--x-*`.
+- `style.css` is a 3504-line BootstrapMade template ("Gp v4.7.0") with many unused rules. A naive scan says ~115 of 293 class names are unreferenced, **but that has false positives**: `btn-xalianGreen` *is* used, composed by bootstrap from `variant='xalianGreen'`. Do not bulk-delete on that signal.

--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -3585,118 +3585,217 @@ input, textarea {
 }
 
 /*--------------------------------------------------------------
-# Style Guide
-# The living design system reference at /styleguide.
+# Style Guide page layout
+# Page-specific scaffolding only. Everything that is part of the
+# design system itself lives in system.css.
 --------------------------------------------------------------*/
 
-.styleguide-container {
-  padding-bottom: var(--x-space-8);
+.sg-page {
+  padding-top: var(--g-8);
+  padding-bottom: var(--g-9);
 }
 
-.styleguide-section {
-  margin-bottom: var(--x-space-8);
+.sg-masthead {
+  max-width: var(--g-measure);
+  margin-bottom: var(--g-8);
 }
 
-.styleguide-heading {
-  color: var(--x-green);
-  border-bottom: 1px solid var(--x-border);
-  padding-bottom: var(--x-space-2);
-  margin-bottom: var(--x-space-4);
+.sg-masthead .g-title {
+  margin: var(--g-3) 0 var(--g-4) 0;
 }
 
-.styleguide-note {
-  color: var(--x-text-dim);
-  font-size: var(--x-text-sm);
-  max-width: var(--x-measure);
-  margin-bottom: var(--x-space-4);
-}
-
-.styleguide-swatch-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: var(--x-space-4);
-}
-
-.styleguide-swatch-chip {
-  height: 56px;
-  border-radius: var(--x-radius-md);
-  border: 1px solid var(--x-border);
-  margin-bottom: var(--x-space-2);
-}
-
-.styleguide-swatch-name {
-  display: block;
-  color: var(--x-text);
-  font-size: var(--x-text-xs);
-  word-break: break-all;
-}
-
-.styleguide-swatch-value {
-  display: block;
-  color: var(--x-text-dim);
-  font-size: var(--x-text-xs);
-}
-
-.styleguide-space-row {
+.sg-masthead-status {
   display: flex;
-  align-items: center;
-  gap: var(--x-space-4);
-  margin-bottom: var(--x-space-2);
-}
-
-.styleguide-space-name {
-  color: var(--x-text-dim);
-  font-size: var(--x-text-xs);
-  min-width: 110px;
-}
-
-.styleguide-space-bar {
-  height: 16px;
-  background-color: var(--x-green);
-  border-radius: var(--x-radius-sm);
-}
-
-.styleguide-radius-grid {
-  display: flex;
-  gap: var(--x-space-5);
   flex-wrap: wrap;
+  gap: var(--g-5);
+  margin-top: var(--g-5);
 }
 
-.styleguide-radius-box {
-  width: 80px;
-  height: 80px;
-  background-color: var(--x-surface-3);
-  border: 1px solid var(--x-green-a30);
-  margin-bottom: var(--x-space-2);
-}
-
-.styleguide-panel-col {
-  margin-bottom: var(--x-space-4);
-}
-
-.styleguide-tint-grid {
+.sg-index {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-  gap: var(--x-space-3);
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--g-1);
+  margin-bottom: var(--g-9);
 }
 
-.styleguide-tint {
+.sg-index-item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--g-2);
+  padding: var(--g-2) var(--g-3);
+  text-decoration: none;
+  transition: background var(--g-snap);
+}
+
+.sg-index-item:hover {
+  background: rgba(255, 244, 214, 0.05);
+}
+
+.sg-index-num {
+  font-size: var(--g-size-micro);
+  color: var(--g-hazard);
+}
+
+.sg-index-name {
+  font-family: var(--g-font-mono);
+  font-size: var(--g-size-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--g-track-label);
+  color: var(--g-ink-mid);
+}
+
+.sg-section {
+  margin-bottom: var(--g-9);
+  scroll-margin-top: var(--g-8);
+}
+
+.sg-section-head {
+  position: relative;
+  padding-top: var(--g-4);
+  border-top: var(--g-hairline) solid var(--g-rule);
+  margin-bottom: var(--g-6);
+}
+
+.sg-section-index {
+  position: absolute;
+  top: var(--g-4);
+  right: 0;
+  font-size: var(--g-size-micro);
+  color: var(--g-ink-low);
+  letter-spacing: var(--g-track-wide);
+}
+
+.sg-section-note {
+  margin-top: var(--g-3);
+  margin-bottom: 0;
+}
+
+.sg-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(330px, 1fr));
+  gap: var(--g-4);
+  margin-bottom: var(--g-4);
+}
+
+.sg-grid-3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--g-4);
+  margin-bottom: var(--g-4);
+}
+
+.sg-swatch-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: var(--g-3);
+}
+
+.sg-swatch-chip {
+  height: 52px;
+  border: var(--g-hairline) solid var(--g-rule);
+  margin-bottom: var(--g-2);
+}
+
+.sg-swatch-name {
+  display: block;
+  font-size: var(--g-size-micro);
+  color: var(--g-ink);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sg-swatch-use {
+  display: block;
+  font-family: var(--g-font-mono);
+  font-size: var(--g-size-micro);
+  color: var(--g-ink-low);
+}
+
+.sg-type-plate .g-h3 {
+  margin: var(--g-2) 0 var(--g-3) 0;
+}
+
+.sg-readout-demo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--g-2);
+}
+
+.sg-element-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--g-3);
+  margin-bottom: var(--g-5);
+}
+
+.sg-element-cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--g-2);
+  padding: var(--g-4);
+}
+
+.sg-element-hex {
+  font-size: var(--g-size-micro);
+  color: var(--g-ink-low);
+}
+
+.sg-element-meter {
+  margin-top: var(--g-1);
+}
+
+.sg-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--g-2);
+}
+
+.sg-btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--g-3);
+}
+
+.sg-small-body {
+  font-size: var(--g-size-small);
+  margin: 0;
+}
+
+.sg-mb { margin-bottom: var(--g-3); }
+.sg-mt { margin-top: var(--g-4); }
+
+.sg-specimen-card {
+  display: grid;
+  grid-template-columns: minmax(200px, 320px) 1fr;
+  gap: var(--g-6);
+  align-items: start;
+}
+
+.sg-specimen-name {
+  margin-top: var(--g-4);
+}
+
+.sg-specimen-id {
+  font-size: var(--g-size-small);
+  color: var(--g-ink-low);
+  margin: var(--g-1) 0 var(--g-4) 0;
+}
+
+.sg-specimen-img {
+  width: 100%;
+  height: 100%;
+}
+
+.sg-footer {
+  padding-top: var(--g-5);
+  border-top: var(--g-hairline) solid var(--g-rule);
   text-align: center;
-  text-transform: capitalize;
-  padding: var(--x-space-4) var(--x-space-2);
-  border-radius: var(--x-radius-md);
 }
 
-.styleguide-button-row {
-  display: flex;
-  gap: var(--x-space-3);
-  flex-wrap: wrap;
-}
-
-.styleguide-measure-demo {
-  color: var(--x-text-muted);
-  border-left: 3px solid var(--x-green-a60);
-  padding-left: var(--x-space-4);
+@media (max-width: 720px) {
+  .sg-specimen-card {
+    grid-template-columns: 1fr;
+  }
 }
 
 /*--------------------------------------------------------------
@@ -3755,4 +3854,27 @@ input, textarea {
     animation: none;
     opacity: 1;
   }
+}
+
+/* style guide: CRT demo layout */
+.sg-screen-layout {
+  display: grid;
+  grid-template-columns: 1fr minmax(180px, 260px);
+  gap: var(--g-4);
+  align-items: stretch;
+}
+
+.sg-screen-figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--g-2);
+  text-align: center;
+}
+
+.sg-mb-lg { margin-bottom: var(--g-4); }
+
+@media (max-width: 720px) {
+  .sg-screen-layout { grid-template-columns: 1fr; }
 }

--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -24,114 +24,98 @@
 }
 
 /* Buttons.
-   Two variants: xalianGreen is the primary action, xalianGray the secondary.
-   Both are driven by tokens. The !important flags are load-bearing - bootstrap's
-   own .btn rules are more specific than these class selectors. */
+   react-bootstrap composes these from `variant="xalianGreen"` / `"xalianGray"`,
+   so the class names stay even though the design changed underneath them. Both
+   are now moulded keys from system.css: xalianGreen is the committing action and
+   wears hazard paint; xalianGray is a plain bakelite key.
+
+   The !important flags are load-bearing - bootstrap's own .btn rules are more
+   specific than these class selectors. */
+
+.btn-xalianGreen,
+.btn-xalianGray {
+  font-family: var(--g-font-stencil) !important;
+  font-size: var(--g-size-body) !important;
+  font-weight: 600 !important;
+  text-transform: uppercase;
+  letter-spacing: var(--g-track-label);
+  border-radius: var(--g-radius) !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  transition: background-color var(--g-snap), transform var(--g-snap), box-shadow var(--g-snap) !important;
+}
 
 .btn-xalianGreen {
-  color: var(--x-text-inverse) !important;
-  background-color: var(--x-green) !important;
-  border-color: var(--x-green-border) !important;
-  font-weight: bold !important;
-  transition: background-color var(--x-transition-fast), border-color var(--x-transition-fast) !important;
+  color: #17120a !important;
+  background-color: var(--g-hazard) !important;
+  border-color: var(--g-hazard-dark) !important;
+  box-shadow: var(--g-relief), 0 3px 0 var(--g-seam), 0 4px 8px rgba(0, 0, 0, 0.55) !important;
 }
 
 .btn-xalianGreen:hover {
-  background-color: var(--x-green-hover) !important;
-  border-color: var(--x-text) !important;
-}
-
-.btn-check:focus+.btn-xalianGreen,
-.btn-xalianGreen:focus {
-  background-color: var(--x-green) !important;
-  border-color: var(--x-green-border) !important;
-  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
-}
-
-.btn-check:checked+.btn-xalianGreen,
-.btn-check:active+.btn-xalianGreen,
-.btn-xalianGreen:active,
-.btn-xalianGreen.active,
-.show>.btn-xalianGreen.dropdown-toggle {
-  background-color: var(--x-green-active) !important;
-  border-color: var(--x-green-border) !important;
-}
-
-.btn-check:checked+.btn-xalianGreen:focus,
-.btn-check:active+.btn-xalianGreen:focus,
-.btn-xalianGreen:active:focus,
-.btn-xalianGreen.active:focus,
-.show>.btn-xalianGreen.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
-}
-
-/* disabled kept black text over a near-transparent green, which disappeared
-   against the dark page. Disabled controls still have to be legible. */
-.btn-xalianGreen:disabled,
-.btn-xalianGreen.disabled {
-  color: var(--x-text-dim) !important;
-  background-color: var(--x-surface-3) !important;
-  border-color: var(--x-border-strong) !important;
-  opacity: 1 !important;
+  background-color: #f0b71a !important;
+  border-color: var(--g-hazard-dark) !important;
 }
 
 .btn-xalianGray {
-  color: var(--x-text) !important;
-  background-color: var(--x-surface-3) !important;
-  border-color: var(--x-border-strong) !important;
-  text-shadow: 1px 1px 2px var(--x-text-inverse) !important;
-  transition: background-color var(--x-transition-fast), border-color var(--x-transition-fast) !important;
-}
-
-/* the gray button used to go pale green on hover while keeping white text,
-   which landed around 1.3:1 and was effectively unreadable mid-hover. It now
-   lifts a surface step and picks up a green border instead. */
-.btn-xalianGray:hover {
-  background-color: var(--x-border-strong) !important;
-  border-color: var(--x-green) !important;
-}
-
-.btn-check:focus+.btn-xalianGray,
-.btn-xalianGray:focus {
-  background-color: var(--x-surface-3) !important;
-  border-color: var(--x-green-border) !important;
-  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
-}
-
-/* checked/active is a real selected state for the toggle groups, so it keeps
-   the green fill - with dark text, which the plain gray variant does not use */
-.btn-check:checked+.btn-xalianGray,
-.btn-check:active+.btn-xalianGray,
-.btn-xalianGray:active,
-.btn-xalianGray.active,
-.show>.btn-xalianGray.dropdown-toggle {
-  color: var(--x-text-inverse) !important;
-  background-color: var(--x-green-active) !important;
-  border-color: var(--x-green-border) !important;
+  color: var(--g-ink) !important;
+  background-color: var(--g-hull-hi) !important;
+  border-color: var(--g-seam) !important;
   text-shadow: none !important;
+  box-shadow: var(--g-relief), 0 3px 0 var(--g-seam), 0 4px 8px rgba(0, 0, 0, 0.55) !important;
 }
 
-.btn-check:checked+.btn-xalianGray:focus,
-.btn-check:active+.btn-xalianGray:focus,
-.btn-xalianGray:active:focus,
-.btn-xalianGray.active:focus,
-.show>.btn-xalianGray.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.25rem var(--x-green-a30) !important;
+.btn-xalianGray:hover {
+  background-color: #3c3c32 !important;
+  border-color: var(--g-seam) !important;
 }
 
+/* the key travels down onto the panel */
+.btn-xalianGreen:active,
+.btn-xalianGray:active,
+.btn-check:checked + .btn-xalianGreen,
+.btn-check:checked + .btn-xalianGray {
+  transform: translateY(3px);
+  box-shadow: var(--g-recess) !important;
+}
+
+/* a thrown selector key lights in hazard paint */
+.btn-check:checked + .btn-xalianGray,
+.btn-xalianGray.active {
+  color: #17120a !important;
+  background-color: var(--g-hazard) !important;
+  border-color: var(--g-hazard-dark) !important;
+}
+
+.btn-check:checked + .btn-xalianGreen,
+.btn-xalianGreen.active {
+  background-color: #b7890c !important;
+}
+
+.btn-xalianGreen:focus,
+.btn-xalianGray:focus,
+.btn-check:focus + .btn-xalianGreen,
+.btn-check:focus + .btn-xalianGray {
+  box-shadow: var(--g-relief), 0 3px 0 var(--g-seam) !important;
+}
+
+.btn:focus-visible,
+.btn-check:focus-visible + .btn {
+  outline: 2px solid var(--g-phosphor) !important;
+  outline-offset: 2px !important;
+}
+
+/* Unpowered, not faded: the key is still moulded there, the legend is dead. */
+.btn-xalianGreen:disabled,
+.btn-xalianGreen.disabled,
 .btn-xalianGray:disabled,
 .btn-xalianGray.disabled {
-  color: var(--x-text-dim) !important;
-  background-color: var(--x-surface-3) !important;
-  border-color: var(--x-border-strong) !important;
+  color: var(--g-ink-low) !important;
+  background-color: var(--g-hull-lo) !important;
+  border-color: var(--g-seam) !important;
   text-shadow: none !important;
+  box-shadow: var(--g-recess) !important;
   opacity: 1 !important;
-}
-
-/* keyboard users get a visible ring on every button variant */
-.btn:focus-visible {
-  outline: 2px solid var(--x-green) !important;
-  outline-offset: 2px !important;
 }
 
 hr.xalian-hr {
@@ -184,16 +168,40 @@ a:hover {
   text-decoration: none;
 }
 
-/* Headings default to the brand green site-wide. Anything that needs a white
-   heading (page titles, for instance) opts out explicitly. */
+/* Headings are stencilled onto the hull: condensed caps in bone silkscreen.
+   They are deliberately NOT phosphor - green is emitted light, and only a
+   screen or a lamp is allowed to emit. */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--x-font-body);
-  color: var(--x-green);
+  font-family: var(--g-font-stencil);
+  font-weight: 600;
+  letter-spacing: var(--g-track-label);
+  color: var(--g-ink);
+}
+
+/* Uppercase is applied by the .g-title / .g-h2 / .g-h3 type styles rather than
+   globally: several places in this codebase use a heading tag to hold prose,
+   and shouting a paragraph is worse than the wrong tag. */
+h1, h2, h3 {
+  text-transform: uppercase;
+}
+
+/* species and planet descriptions are prose that happens to sit in an h6 */
+.species-detail-description {
+  font-family: var(--g-font-ui);
+  font-weight: 400;
+  font-style: normal;
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: var(--g-size-body);
+  line-height: 1.65;
+  color: var(--g-ink-mid);
+  max-width: var(--g-measure);
+  margin: 0 auto;
 }
 
 
@@ -2369,11 +2377,22 @@ article {
   padding: 3px;
 }
 
+/* planet spec values are machine-reported, so they print in the mono voice
+   rather than the italic serif-ish default the template shipped */
 .planet-table tbody * td {
-  color: var(--x-text-muted);
-  padding: 3px;
-  font-style: italic;
+  color: var(--g-ink);
+  padding: var(--g-1) var(--g-2);
+  font-family: var(--g-font-mono);
+  font-size: var(--g-size-small);
+  font-style: normal;
   text-align: left !important;
+}
+
+.planet-table tbody * th {
+  font-family: var(--g-font-stencil);
+  font-weight: 500;
+  letter-spacing: var(--g-track-label);
+  color: var(--g-ink-low);
 }
 
 
@@ -2749,57 +2768,36 @@ article {
 */
 
 .glossary-wrapper {
-  padding-top: var(--x-space-5);
-  padding-bottom: var(--x-space-8);
-}
-
-/* each term is its own surface, so 63 entries scan as a list of cards rather
-   than one unbroken wall of prose */
-.glossary-word-row {
-  padding: var(--x-space-4) var(--x-space-3);
-  margin-bottom: var(--x-space-3);
-  border: 1px solid var(--x-border);
-  border-left: 3px solid var(--x-green-a60);
-  border-radius: var(--x-radius-md);
-  background-color: rgba(0, 0, 0, 0.35);
-  transition: border-color var(--x-transition-fast), background-color var(--x-transition-fast);
-}
-
-.glossary-word-row:hover {
-  border-color: var(--x-green-a30);
-  border-left-color: var(--x-green);
-  background-color: var(--x-surface-1);
+  padding: var(--g-2) var(--g-2) var(--g-3);
+  margin-bottom: var(--g-9);
 }
 
 .glossary-list {
-  margin-bottom: 0;
-}
-
-.glossary-title {
-  text-align: right;
-  font-weight: bolder;
-  font-size: var(--x-text-lg);
-  color: var(--x-green);
-  margin-bottom: 0;
-}
-
-.glossary-definition {
-  color: var(--x-text-muted);
-  line-height: 1.55;
-  margin-bottom: 0;
-}
-
-.glossary-search {
-  margin-top: var(--x-space-3);
+  margin: 0;
 }
 
 .glossary-result-count {
-  color: var(--x-text-dim);
-  font-size: var(--x-text-sm);
   text-align: right;
-  margin: var(--x-space-2) 0 0 0;
+  margin: var(--g-2) 0 var(--g-6) 0;
 }
 
+/* Shared page scaffolding for every migrated page. */
+.page-shell {
+  padding-top: var(--g-8);
+  padding-bottom: var(--g-9);
+}
+
+.page-header {
+  margin-bottom: var(--g-7);
+}
+
+.page-header .g-title {
+  margin-top: var(--g-2);
+}
+
+.page-header .g-body {
+  margin-top: var(--g-3);
+}
 
 /* HAPPENS WHEN SCREEN GOES TO SMALL OR XSMALL I THINK */
 @media (max-width: 575px) {
@@ -3877,4 +3875,67 @@ input, textarea {
 
 @media (max-width: 720px) {
   .sg-screen-layout { grid-template-columns: 1fr; }
+}
+
+/* Page titles need clearance under the sticky console header. The old
+   .page-title-text carried this padding; .g-title is a pure type style, so the
+   spacing lives here where the page composes it. */
+.template-col-wrapper .g-title,
+.g-shell > .page-header .g-title {
+  margin-top: 0;
+}
+
+.template-col-wrapper {
+  padding-top: var(--g-7);
+  padding-bottom: var(--g-5);
+}
+
+.template-col-wrapper > .g-title {
+  margin-bottom: var(--g-5);
+  text-align: center;
+}
+
+/* Planet record panels */
+.planet-panel {
+  margin-bottom: var(--g-6);
+  padding: var(--g-5) var(--g-4);
+}
+
+.planet-panel .planet-key-col,
+.planet-panel .planet-val-col {
+  border: 0;
+}
+
+.planet-panel .planet-key-col h4 {
+  font-family: var(--g-font-stencil);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: var(--g-track-label);
+  color: var(--g-ink-low);
+  font-size: var(--g-size-small);
+}
+
+.planet-panel .planet-val-col h4 {
+  font-family: var(--g-font-mono);
+  font-size: var(--g-size-small);
+  font-style: normal;
+  color: var(--g-ink);
+}
+
+.planet-panel .planet-history-link {
+  font-family: var(--g-font-stencil);
+  text-transform: uppercase;
+  letter-spacing: var(--g-track-label);
+  color: var(--g-ink-mid);
+  font-style: normal;
+}
+
+.planet-panel .planet-history-link:hover {
+  color: var(--g-hazard);
+}
+
+/* the training page composes its own header, so it needs the same clearance
+   under the sticky console header that .template-col-wrapper provides */
+.page-header {
+  padding-top: var(--g-7);
 }

--- a/my-app/public/assets/css/system.css
+++ b/my-app/public/assets/css/system.css
@@ -1,0 +1,1185 @@
+/**
+ * XALIAN GENERATOR — design system v2
+ * =============================================================================
+ * The premise: this is the control panel of a Xalian Generator. The machine can
+ * bioengineer life on a dead world — but it was built by an industrial empire
+ * during its atomic age, and it looks like it. Enamelled steel, brass bezels,
+ * bakelite keys, a small green CRT bolted into a hole in the panel.
+ *
+ * Star Wars by way of Fallout: the capability is centuries ahead, the interface
+ * is decades behind. Nothing here is sleek. Everything is a physical object
+ * that somebody screwed to a frame in a factory.
+ *
+ * Four rules:
+ *
+ *  1. PANELS ARE MATTE OBJECTS. Enamel over pressed steel. Depth comes from a
+ *     bevel — light on the top edge, shadow underneath — plus rivets and seams.
+ *     Nothing on the hull glows, ever.
+ *  2. ONLY SCREENS AND LAMPS EMIT. Phosphor, scanlines and bloom live strictly
+ *     inside .g-screen. A CRT behind glass is the one lit thing in the room,
+ *     which is precisely why the eye goes to it.
+ *  3. COLOUR IS ENERGY OR A WARNING. The hull is olive, bone and gunmetal. The
+ *     fourteen element hues and the hazard channels are the only saturated
+ *     things in the system, so they read instantly.
+ *  4. LEGENDS ARE STENCILLED. Condensed industrial caps for anything painted on
+ *     the hull; monospace for anything the machine itself prints.
+ *
+ * Namespace is --g-* / .g-*, alongside the old --x-* system during migration.
+ */
+
+/* -------------------------------------------------------------------------
+   TOKENS
+   ------------------------------------------------------------------------- */
+
+:root {
+	/* --- the room ---------------------------------------------------------
+	   Warm near-black, tinted brown rather than blue. A hangar, not a showroom. */
+	--g-void: #0d0b09;
+
+	/* --- hull -------------------------------------------------------------
+	   Enamelled steel in olive drab. Three steps — recessed, standard, raised —
+	   deliberately close together, because it is all one pressed sheet. */
+	--g-hull-lo: #16160f;
+	--g-hull: #23231a;
+	--g-hull-hi: #32322a;
+	--g-seam: #0a0a07;
+
+	/* Bevel. A painted edge catches light along the top and drops shadow below.
+	   These two values are what make a panel read as an object. */
+	--g-bevel-light: rgba(255, 244, 214, 0.11);
+	--g-bevel-dark: rgba(0, 0, 0, 0.6);
+	--g-rule: rgba(216, 207, 184, 0.14);
+	--g-rule-faint: rgba(216, 207, 184, 0.06);
+
+	/* --- brass ------------------------------------------------------------
+	   Bezels, trim rings and fasteners. Oxidised, not polished. */
+	--g-brass: #b08d3f;
+	--g-brass-dark: #6b5423;
+	--g-brass-light: #d8b45e;
+
+	/* --- printed matter ---------------------------------------------------
+	   Bone-white silkscreen and cream bakelite. Never pure white — paint yellows. */
+	--g-ink: #ddd4bd;
+	--g-ink-mid: #9a9280;
+	--g-ink-low: #6b665a;
+	--g-ink-invert: #14120c;
+
+	/* --- phosphor ---------------------------------------------------------
+	   The CRT. The only pure saturated light in the interface, confined to
+	   .g-screen. */
+	--g-phosphor: #74ffb0;
+	--g-phosphor-dim: rgba(116, 255, 176, 0.42);
+	--g-phosphor-a20: rgba(116, 255, 176, 0.20);
+	--g-screen-glass: #07120c;
+
+	/* --- lamps ------------------------------------------------------------
+	   Bulbs behind coloured plastic. */
+	--g-lamp-amber: #ffb037;
+	--g-lamp-red: #e4483c;
+	--g-lamp-off: #3d3a30;
+
+	/* --- hazard -----------------------------------------------------------
+	   Painted warning livery, straight off a loading bay. */
+	--g-hazard: #d9a410;
+	--g-hazard-dark: #6d5108;
+
+	/* --- element energy ---------------------------------------------------
+	   Unchanged, and the fixed point of the whole system: fire is red because
+	   fire is red. The hull went colourless so these own every saturated pixel. */
+	--g-el-fire: #df6d5e;
+	--g-el-water: #60a0c5;
+	--g-el-air: #ffffff;
+	--g-el-electric: #e2bd43;
+	--g-el-rock: #8d7050;
+	--g-el-plant: #708844;
+	--g-el-chemical: #64bd9f;
+	--g-el-light: #ffffc7;
+	--g-el-dark: #57619c;
+	--g-el-metal: #8d8d8d;
+	--g-el-psychic: #d39bcb;
+	--g-el-ghost: #8764a8;
+	--g-el-ice: #85dde4;
+	--g-el-sand: #e6b26f;
+
+	/* The element in scope. One class on a container retunes everything inside. */
+	--g-el: var(--g-phosphor);
+
+	/* --- type -------------------------------------------------------------
+	   Oswald is a mid-century poster and signage face: the condensed caps
+	   stencilled onto equipment and painted on placards. IBM Plex Mono is the
+	   machine's own output — a terminal line, a printed slip. Neither is a
+	   "sci-fi" typeface, because the fiction is industrial, not futuristic. */
+	--g-font-stencil: 'Oswald', 'Barlow Condensed', Impact, sans-serif;
+	--g-font-ui: 'Barlow', system-ui, sans-serif;
+	--g-font-mono: 'IBM Plex Mono', ui-monospace, Menlo, monospace;
+
+	--g-size-micro: 0.6875rem;
+	--g-size-tiny: 0.75rem;
+	--g-size-small: 0.875rem;
+	--g-size-body: 1rem;
+	--g-size-lead: 1.125rem;
+	--g-size-h3: clamp(1.25rem, 1.1rem + 0.6vw, 1.5rem);
+	--g-size-h2: clamp(1.75rem, 1.4rem + 1.6vw, 2.5rem);
+	--g-size-h1: clamp(2.5rem, 1.8rem + 3.4vw, 4.25rem);
+	--g-size-readout: clamp(1.75rem, 1.2rem + 2.2vw, 2.75rem);
+
+	--g-track-label: 0.12em;
+	--g-track-wide: 0.26em;
+
+	/* --- space ------------------------------------------------------------ */
+	--g-1: 4px;
+	--g-2: 8px;
+	--g-3: 12px;
+	--g-4: 16px;
+	--g-5: 24px;
+	--g-6: 32px;
+	--g-7: 48px;
+	--g-8: 64px;
+	--g-9: 96px;
+
+	/* --- geometry ---------------------------------------------------------
+	   Streamline moderne: softly rounded housings, not sharp corners and not
+	   sci-fi chamfers. Moulded plastic and pressed steel both have a radius. */
+	--g-radius: 4px;
+	--g-radius-panel: 8px;
+	--g-radius-housing: 14px;
+	--g-hairline: 1px;
+
+	/* --- light ------------------------------------------------------------
+	   Hull does not emit. Screens and lamps do. */
+	--g-relief: inset 0 1px 0 var(--g-bevel-light), inset 0 -1px 0 var(--g-bevel-dark);
+	--g-drop: 0 1px 0 rgba(0, 0, 0, 0.5), 0 4px 14px rgba(0, 0, 0, 0.5);
+	--g-recess: inset 0 2px 6px rgba(0, 0, 0, 0.8), inset 0 -1px 0 var(--g-bevel-light);
+	--g-screen-bloom: 0 0 26px rgba(116, 255, 176, 0.13);
+
+	/* --- motion -----------------------------------------------------------
+	   Mechanical. Switches throw; they do not glide. */
+	--g-snap: 90ms cubic-bezier(0.3, 0, 0.2, 1);
+	--g-move: 200ms cubic-bezier(0.3, 0, 0.2, 1);
+
+	--g-measure: 68ch;
+
+	--g-layer-nav: 500;
+	--g-layer-modal: 1000;
+}
+
+/* Element keying. */
+.g-el-fire { --g-el: var(--g-el-fire); }
+.g-el-water { --g-el: var(--g-el-water); }
+.g-el-air { --g-el: var(--g-el-air); }
+.g-el-electric { --g-el: var(--g-el-electric); }
+.g-el-rock { --g-el: var(--g-el-rock); }
+.g-el-plant { --g-el: var(--g-el-plant); }
+.g-el-chemical { --g-el: var(--g-el-chemical); }
+.g-el-light { --g-el: var(--g-el-light); }
+.g-el-dark { --g-el: var(--g-el-dark); }
+.g-el-metal { --g-el: var(--g-el-metal); }
+.g-el-psychic { --g-el: var(--g-el-psychic); }
+.g-el-ghost { --g-el: var(--g-el-ghost); }
+.g-el-ice { --g-el: var(--g-el-ice); }
+.g-el-sand { --g-el: var(--g-el-sand); }
+
+/* -------------------------------------------------------------------------
+   THE HULL
+   The page is a painted bulkhead. No grid, no scanlines, no vignette — that
+   equipment belongs on the screens.
+   ------------------------------------------------------------------------- */
+
+.g-console {
+	position: relative;
+	min-height: 100vh;
+	background-color: var(--g-void);
+	/* uneven light across a big enamelled surface */
+	background-image:
+		radial-gradient(ellipse 110% 60% at 25% -10%, rgba(255, 236, 194, 0.05), transparent 62%),
+		radial-gradient(ellipse 80% 50% at 95% 108%, rgba(255, 236, 194, 0.028), transparent 60%);
+	color: var(--g-ink);
+	font-family: var(--g-font-ui);
+}
+
+/* Paint tooth. One small turbulence tile at low opacity — what stops a large
+   flat surface reading as a CSS gradient. */
+.g-console::before {
+	content: '';
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	z-index: 1;
+	opacity: 0.18;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+}
+
+.g-console > * {
+	position: relative;
+	z-index: 2;
+}
+
+/* -------------------------------------------------------------------------
+   TYPE
+   ------------------------------------------------------------------------- */
+
+.g-kicker,
+.g-label {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	margin: 0;
+}
+
+.g-kicker { color: var(--g-ink-low); }
+.g-label { color: var(--g-ink-mid); }
+
+.g-title {
+	font-family: var(--g-font-stencil);
+	font-weight: 700;
+	font-size: var(--g-size-h1);
+	text-transform: uppercase;
+	letter-spacing: 0.005em;
+	line-height: 0.95;
+	color: var(--g-ink);
+	margin: 0;
+}
+
+.g-h2 {
+	font-family: var(--g-font-stencil);
+	font-weight: 600;
+	font-size: var(--g-size-h2);
+	text-transform: uppercase;
+	letter-spacing: 0.015em;
+	line-height: 1;
+	color: var(--g-ink);
+	margin: 0;
+}
+
+.g-h3 {
+	font-family: var(--g-font-stencil);
+	font-weight: 600;
+	font-size: var(--g-size-h3);
+	text-transform: uppercase;
+	letter-spacing: 0.02em;
+	color: var(--g-ink);
+	margin: 0;
+}
+
+.g-body {
+	font-family: var(--g-font-ui);
+	font-size: var(--g-size-body);
+	line-height: 1.65;
+	color: var(--g-ink-mid);
+	max-width: var(--g-measure);
+}
+
+.g-mono {
+	font-family: var(--g-font-mono);
+	font-variant-numeric: tabular-nums;
+}
+
+/* -------------------------------------------------------------------------
+   PANEL
+   Enamelled steel bolted to the hull. Matte. Depth is the bevel plus, where
+   it earns it, four rivets.
+   ------------------------------------------------------------------------- */
+
+.g-panel {
+	--panel-fill: var(--g-hull);
+	position: relative;
+	padding: var(--g-5);
+	background: var(--panel-fill);
+	border: var(--g-hairline) solid var(--g-seam);
+	border-radius: var(--g-radius-panel);
+	box-shadow: var(--g-relief), var(--g-drop);
+}
+
+.g-panel--raised { --panel-fill: var(--g-hull-hi); }
+
+.g-panel--recessed {
+	--panel-fill: var(--g-hull-lo);
+	box-shadow: var(--g-recess);
+}
+
+/* Fasteners, one per corner — drawn, not marked up, and small enough to read
+   as construction rather than as ornament. */
+.g-panel--bolted {
+	background-image:
+		radial-gradient(circle at 11px 11px, rgba(0,0,0,0.6) 1.5px, var(--g-brass-dark) 2.4px, var(--g-bevel-light) 3px, transparent 3.6px),
+		radial-gradient(circle at calc(100% - 11px) 11px, rgba(0,0,0,0.6) 1.5px, var(--g-brass-dark) 2.4px, var(--g-bevel-light) 3px, transparent 3.6px),
+		radial-gradient(circle at 11px calc(100% - 11px), rgba(0,0,0,0.6) 1.5px, var(--g-brass-dark) 2.4px, var(--g-bevel-light) 3px, transparent 3.6px),
+		radial-gradient(circle at calc(100% - 11px) calc(100% - 11px), rgba(0,0,0,0.6) 1.5px, var(--g-brass-dark) 2.4px, var(--g-bevel-light) 3px, transparent 3.6px);
+}
+
+/* The stencilled title strip along the top of a panel. */
+.g-panel-head {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--g-3);
+	padding-bottom: var(--g-2);
+	margin-bottom: var(--g-4);
+	border-bottom: var(--g-hairline) solid var(--g-rule);
+}
+
+/* On a narrow panel the legend and its annotation fight for the same line and
+   both wrap. Stack them instead, and drop the annotation down a step. */
+@media (max-width: 720px) {
+	.g-panel-head {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: var(--g-1);
+	}
+}
+
+/* Keyed to an element: a painted colour band along the top edge. The panel
+   stays matte metal — the machine does not light up because a specimen is
+   psychic. */
+.g-panel--tagged { border-top: 3px solid var(--g-el); }
+
+/* -------------------------------------------------------------------------
+   SCREEN
+   A CRT set into a hole in the panel, behind a brass bezel. The only thing in
+   the system that emits light, and the only place scanlines exist.
+   ------------------------------------------------------------------------- */
+
+.g-screen {
+	position: relative;
+	padding: var(--g-4);
+	background:
+		radial-gradient(ellipse 120% 90% at 50% 40%, rgba(116, 255, 176, 0.055), transparent 70%),
+		var(--g-screen-glass);
+	border: 2px solid var(--g-brass-dark);
+	border-radius: var(--g-radius);
+	box-shadow:
+		var(--g-recess),
+		0 0 0 1px rgba(0, 0, 0, 0.8),
+		var(--g-screen-bloom);
+	color: var(--g-phosphor);
+	font-family: var(--g-font-mono);
+	overflow: hidden;
+}
+
+/* Scanlines and the curve of the glass — confined to the screen, which is the
+   entire point of having a screen. */
+.g-screen::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background-image:
+		repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.32) 0 1px, transparent 1px 3px),
+		radial-gradient(ellipse 130% 130% at 50% 50%, transparent 52%, rgba(0, 0, 0, 0.6) 100%);
+}
+
+.g-screen-line {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-tiny);
+	line-height: 1.7;
+	color: var(--g-phosphor);
+	text-shadow: 0 0 6px var(--g-phosphor-dim);
+	margin: 0;
+}
+
+.g-screen-line--dim {
+	color: var(--g-phosphor-dim);
+	text-shadow: none;
+}
+
+.g-readout {
+	font-family: var(--g-font-mono);
+	font-variant-numeric: tabular-nums;
+	font-size: var(--g-size-readout);
+	font-weight: 500;
+	line-height: 1;
+	color: var(--g-el);
+	text-shadow: 0 0 14px color-mix(in srgb, var(--g-el) 55%, transparent);
+}
+
+.g-readout-unit {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-tiny);
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-phosphor-dim);
+}
+
+/* -------------------------------------------------------------------------
+   LIVERY
+   ------------------------------------------------------------------------- */
+
+.g-hazard-strip {
+	height: 12px;
+	background-image: repeating-linear-gradient(
+		-45deg,
+		var(--g-hazard) 0 11px,
+		#15130c 11px 22px
+	);
+	border-radius: 2px;
+	box-shadow: var(--g-relief);
+	opacity: 0.9;
+}
+
+.g-seam-rule {
+	height: 2px;
+	border: 0;
+	margin: var(--g-5) 0;
+	background: linear-gradient(180deg, var(--g-seam) 0 1px, var(--g-bevel-light) 1px 2px);
+}
+
+/* A riveted trim strip — used to break up long runs of bare panel. */
+.g-rivet-rule {
+	height: 8px;
+	border: 0;
+	margin: var(--g-5) 0;
+	background-image:
+		linear-gradient(180deg, var(--g-seam) 0 1px, var(--g-bevel-light) 1px 2px, transparent 2px),
+		radial-gradient(circle at 6px 6px, var(--g-brass-dark) 1.4px, transparent 2px);
+	background-size: 100% 100%, 28px 100%;
+	background-repeat: no-repeat, repeat-x;
+}
+
+/* -------------------------------------------------------------------------
+   METER
+   Segmented, because an instrument quantises. A recessed strip of bulbs let
+   into the hull, lit in the element's colour.
+   ------------------------------------------------------------------------- */
+
+.g-meter {
+	--seg: 7px;
+	--gap: 3px;
+	position: relative;
+	height: 14px;
+	background-color: var(--g-seam);
+	border-radius: 2px;
+	box-shadow: var(--g-recess);
+}
+
+.g-meter-track {
+	position: absolute;
+	inset: 2px;
+	background-image: repeating-linear-gradient(
+		90deg,
+		rgba(255, 244, 214, 0.05) 0 var(--seg),
+		transparent var(--seg) calc(var(--seg) + var(--gap))
+	);
+}
+
+/* Headroom the stat could still grow into: bulbs that exist but are not lit. */
+.g-meter-ghost {
+	position: absolute;
+	top: 2px;
+	bottom: 2px;
+	left: 2px;
+	background-image: repeating-linear-gradient(
+		90deg,
+		color-mix(in srgb, var(--g-el) 30%, transparent) 0 var(--seg),
+		transparent var(--seg) calc(var(--seg) + var(--gap))
+	);
+}
+
+/* Lit bulbs: what the stat actually is. */
+.g-meter-fill {
+	position: absolute;
+	top: 2px;
+	bottom: 2px;
+	left: 2px;
+	background-image: repeating-linear-gradient(
+		90deg,
+		var(--g-el) 0 var(--seg),
+		transparent var(--seg) calc(var(--seg) + var(--gap))
+	);
+	filter: drop-shadow(0 0 4px color-mix(in srgb, var(--g-el) 70%, transparent));
+	transition: width var(--g-move);
+}
+
+.g-meter-row {
+	display: grid;
+	grid-template-columns: 8.5rem 1fr 3.5rem;
+	align-items: center;
+	gap: var(--g-3);
+	padding: var(--g-1) 0;
+}
+
+.g-meter-name {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-mid);
+}
+
+.g-meter-value {
+	font-family: var(--g-font-mono);
+	font-variant-numeric: tabular-nums;
+	font-size: var(--g-size-tiny);
+	color: var(--g-ink);
+	text-align: right;
+}
+
+/* -------------------------------------------------------------------------
+   CHIP
+   A printed classification label, like a sticker on a specimen jar.
+   ------------------------------------------------------------------------- */
+
+.g-chip {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px var(--g-3);
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-invert);
+	background: var(--g-el);
+	border-radius: 2px;
+	box-shadow: var(--g-relief);
+}
+
+.g-chip--outline {
+	color: var(--g-el);
+	background: transparent;
+	border: var(--g-hairline) solid color-mix(in srgb, var(--g-el) 55%, transparent);
+	box-shadow: none;
+}
+
+/* -------------------------------------------------------------------------
+   CONTROLS
+   A button is a moulded bakelite key that sits proud of the panel and travels
+   when pressed.
+   ------------------------------------------------------------------------- */
+
+.g-btn {
+	--btn-face: var(--g-hull-hi);
+	--btn-ink: var(--g-ink);
+	--btn-edge: var(--g-seam);
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--g-2);
+	padding: var(--g-3) var(--g-5);
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-body);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--btn-ink);
+	background: var(--btn-face);
+	border: var(--g-hairline) solid var(--btn-edge);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-relief), 0 3px 0 var(--g-seam), 0 4px 8px rgba(0, 0, 0, 0.55);
+	cursor: pointer;
+	transition: background var(--g-snap), transform var(--g-snap), box-shadow var(--g-snap);
+}
+
+.g-btn:hover:not(:disabled) { --btn-face: #3c3c32; }
+
+/* The key travels down onto the panel. */
+.g-btn:active:not(:disabled) {
+	transform: translateY(3px);
+	box-shadow: var(--g-recess);
+}
+
+.g-btn:focus-visible {
+	outline: 2px solid var(--g-phosphor);
+	outline-offset: 2px;
+}
+
+/* The committing action wears hazard paint. */
+.g-btn--primary {
+	--btn-face: var(--g-hazard);
+	--btn-ink: #17120a;
+	--btn-edge: var(--g-hazard-dark);
+}
+
+.g-btn--primary:hover:not(:disabled) { --btn-face: #f0b71a; }
+
+.g-btn--danger {
+	--btn-face: #7c2b26;
+	--btn-ink: #ffdedb;
+	--btn-edge: #43110e;
+}
+
+.g-btn--danger:hover:not(:disabled) { --btn-face: #94332d; }
+
+/* Unpowered, not faded: the key is still moulded there, the legend is dead. */
+.g-btn:disabled {
+	--btn-face: var(--g-hull-lo);
+	--btn-ink: var(--g-ink-low);
+	cursor: not-allowed;
+	box-shadow: var(--g-recess);
+}
+
+/* Text entry is a screen, so it is phosphor on glass. */
+.g-input,
+.g-select {
+	width: 100%;
+	padding: var(--g-3) var(--g-4);
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-small);
+	color: var(--g-phosphor);
+	background: var(--g-screen-glass);
+	border: 2px solid var(--g-brass-dark);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-recess);
+}
+
+.g-input::placeholder { color: rgba(116, 255, 176, 0.32); }
+
+.g-input:focus,
+.g-select:focus {
+	outline: none;
+	border-color: var(--g-brass);
+	box-shadow: var(--g-recess), var(--g-screen-bloom);
+}
+
+.g-select {
+	appearance: none;
+	padding-right: var(--g-7);
+	background-image:
+		linear-gradient(45deg, transparent 50%, var(--g-phosphor) 50%),
+		linear-gradient(135deg, var(--g-phosphor) 50%, transparent 50%);
+	background-position: right 20px center, right 14px center;
+	background-size: 6px 6px, 6px 6px;
+	background-repeat: no-repeat;
+	cursor: pointer;
+}
+
+.g-field-label {
+	display: block;
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-low);
+	margin-bottom: var(--g-2);
+}
+
+/* A bank of selector keys in a recessed housing. */
+.g-segmented {
+	display: inline-flex;
+	padding: 3px;
+	gap: 3px;
+	background: var(--g-seam);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-recess);
+}
+
+.g-segment {
+	padding: var(--g-2) var(--g-4);
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-mid);
+	background: var(--g-hull);
+	border: 0;
+	border-radius: 2px;
+	box-shadow: var(--g-relief);
+	cursor: pointer;
+	transition: background var(--g-snap), color var(--g-snap);
+}
+
+.g-segment:hover:not([aria-pressed='true']) {
+	background: var(--g-hull-hi);
+	color: var(--g-ink);
+}
+
+.g-segment[aria-pressed='true'] {
+	color: var(--g-ink-invert);
+	background: var(--g-hazard);
+}
+
+.g-segment:focus-visible {
+	outline: 2px solid var(--g-phosphor);
+	outline-offset: -3px;
+}
+
+/* A toggle with a real throw. */
+.g-check {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--g-3);
+	cursor: pointer;
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-body);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-mid);
+}
+
+.g-check input {
+	position: absolute;
+	opacity: 0;
+	width: 0;
+	height: 0;
+}
+
+.g-check-box {
+	position: relative;
+	width: 46px;
+	height: 24px;
+	flex: none;
+	background: var(--g-seam);
+	border-radius: 3px;
+	box-shadow: var(--g-recess);
+	transition: background var(--g-snap);
+}
+
+.g-check-box::after {
+	content: '';
+	position: absolute;
+	top: 3px;
+	left: 3px;
+	width: 20px;
+	height: 18px;
+	background: var(--g-hull-hi);
+	border-radius: 2px;
+	box-shadow: var(--g-relief), 0 1px 3px rgba(0, 0, 0, 0.7);
+	transition: transform var(--g-snap), background var(--g-snap);
+}
+
+.g-check input:checked + .g-check-box { background: #40340b; }
+.g-check input:checked + .g-check-box::after {
+	transform: translateX(20px);
+	background: var(--g-hazard);
+}
+
+.g-check input:focus-visible + .g-check-box {
+	outline: 2px solid var(--g-phosphor);
+	outline-offset: 2px;
+}
+
+/* -------------------------------------------------------------------------
+   LAMPS
+   Bulbs behind coloured plastic. Lit or unlit — they do not pulse.
+   ------------------------------------------------------------------------- */
+
+.g-lamp {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--g-2);
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-mid);
+}
+
+.g-lamp::before {
+	content: '';
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	flex: none;
+	background: var(--g-phosphor);
+	box-shadow: 0 0 8px var(--g-phosphor), inset 0 -2px 2px rgba(0, 0, 0, 0.45);
+}
+
+.g-lamp--amber::before {
+	background: var(--g-lamp-amber);
+	box-shadow: 0 0 8px var(--g-lamp-amber), inset 0 -2px 2px rgba(0, 0, 0, 0.45);
+}
+
+.g-lamp--red::before {
+	background: var(--g-lamp-red);
+	box-shadow: 0 0 8px var(--g-lamp-red), inset 0 -2px 2px rgba(0, 0, 0, 0.45);
+}
+
+.g-lamp--off::before {
+	background: var(--g-lamp-off);
+	box-shadow: inset 0 -2px 2px rgba(0, 0, 0, 0.55);
+}
+
+/* -------------------------------------------------------------------------
+   FEEDBACK
+   ------------------------------------------------------------------------- */
+
+.g-notice {
+	--tone: var(--g-hazard);
+	display: flex;
+	gap: var(--g-3);
+	padding: var(--g-3) var(--g-4);
+	background: var(--g-hull-lo);
+	border-left: 4px solid var(--tone);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-relief);
+	font-family: var(--g-font-ui);
+	font-size: var(--g-size-small);
+	color: var(--g-ink);
+}
+
+.g-notice--alert { --tone: var(--g-lamp-red); }
+.g-notice--ok { --tone: var(--g-phosphor); }
+.g-notice--inert { --tone: var(--g-ink-low); }
+
+.g-notice-title {
+	display: block;
+	font-family: var(--g-font-stencil);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--tone);
+}
+
+/* Working: a sweep across a recessed strip. Indeterminate on purpose — the
+   machine will not pretend to know how long it needs. */
+.g-working {
+	display: flex;
+	align-items: center;
+	gap: var(--g-3);
+}
+
+.g-working-bar {
+	position: relative;
+	flex: 1;
+	height: 14px;
+	overflow: hidden;
+	background: var(--g-seam);
+	border-radius: 2px;
+	box-shadow: var(--g-recess);
+}
+
+.g-working-bar::after {
+	content: '';
+	position: absolute;
+	top: 2px;
+	bottom: 2px;
+	left: 0;
+	width: 30%;
+	background-image: repeating-linear-gradient(90deg, var(--g-hazard) 0 7px, transparent 7px 10px);
+	animation: g-sweep 1.4s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+@keyframes g-sweep {
+	0% { transform: translateX(-110%); }
+	100% { transform: translateX(360%); }
+}
+
+.g-working-label {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-mid);
+	white-space: nowrap;
+}
+
+.g-empty {
+	padding: var(--g-8) var(--g-4);
+	text-align: center;
+	border: 2px dashed var(--g-rule);
+	border-radius: var(--g-radius);
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-body);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-low);
+}
+
+/* -------------------------------------------------------------------------
+   SPECIMEN MOUNT
+   Artwork behind glass in a brass-bezelled housing, bolted to the panel.
+   ------------------------------------------------------------------------- */
+
+.g-specimen {
+	position: relative;
+	aspect-ratio: 1;
+	padding: 8px;
+	background: linear-gradient(160deg, var(--g-hull-hi), var(--g-hull));
+	border: 2px solid var(--g-brass-dark);
+	border-radius: var(--g-radius-housing);
+	box-shadow: var(--g-relief), var(--g-drop);
+}
+
+.g-specimen-inner {
+	position: relative;
+	height: 100%;
+	background: color-mix(in srgb, var(--g-el) 80%, transparent);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-recess);
+	overflow: hidden;
+}
+
+.g-specimen-inner img,
+.g-specimen-inner svg,
+.g-specimen-inner > div {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+/* -------------------------------------------------------------------------
+   COLLECTIONS
+   ------------------------------------------------------------------------- */
+
+.g-tile {
+	display: block;
+	text-decoration: none;
+	padding: var(--g-2);
+	background: var(--g-hull);
+	border: var(--g-hairline) solid var(--g-seam);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-relief);
+	transition: background var(--g-snap), transform var(--g-snap);
+}
+
+.g-tile:hover {
+	background: var(--g-hull-hi);
+	transform: translateY(-1px);
+}
+
+.g-tile-art {
+	aspect-ratio: 1;
+	background: color-mix(in srgb, var(--g-el) 85%, transparent);
+	border-radius: 2px;
+	box-shadow: var(--g-recess);
+	overflow: hidden;
+}
+
+.g-tile-meta {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--g-2);
+	padding: var(--g-2) var(--g-1) 0;
+}
+
+.g-tile-name {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-body);
+	font-weight: 600;
+	text-transform: uppercase;
+	color: var(--g-ink);
+}
+
+.g-tile-id {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-micro);
+	color: var(--g-ink-low);
+}
+
+.g-record {
+	display: grid;
+	grid-template-columns: minmax(8rem, 15rem) 1fr;
+	gap: var(--g-3) var(--g-5);
+	padding: var(--g-4);
+	border-bottom: var(--g-hairline) solid var(--g-rule-faint);
+	transition: background var(--g-snap);
+}
+
+.g-record:hover { background: rgba(255, 244, 214, 0.03); }
+
+.g-record-term {
+	font-family: var(--g-font-stencil);
+	font-weight: 600;
+	font-size: var(--g-size-lead);
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-el);
+	margin: 0;
+}
+
+.g-record-body {
+	font-family: var(--g-font-ui);
+	font-size: var(--g-size-small);
+	line-height: 1.6;
+	color: var(--g-ink-mid);
+	margin: 0;
+}
+
+/* Key/value, as printed on a spec plate riveted to the machine. */
+.g-spec {
+	display: grid;
+	grid-template-columns: minmax(7rem, auto) 1fr;
+	gap: var(--g-2) var(--g-5);
+	align-items: baseline;
+}
+
+.g-spec-key {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-low);
+}
+
+.g-spec-val {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-small);
+	font-variant-numeric: tabular-nums;
+	color: var(--g-ink);
+}
+
+.g-data {
+	width: 100%;
+	border-collapse: collapse;
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-tiny);
+}
+
+.g-data th {
+	text-align: left;
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-low);
+	padding: var(--g-2) var(--g-3);
+	border-bottom: var(--g-hairline) solid var(--g-rule);
+}
+
+.g-data td {
+	padding: var(--g-2) var(--g-3);
+	border-bottom: var(--g-hairline) solid var(--g-rule-faint);
+	color: var(--g-ink);
+	font-variant-numeric: tabular-nums;
+}
+
+.g-data tr:hover td { background: rgba(255, 244, 214, 0.03); }
+
+.g-link {
+	color: var(--g-el);
+	text-decoration: underline;
+	text-underline-offset: 3px;
+	text-decoration-thickness: 1px;
+}
+
+.g-link:hover { color: var(--g-ink); }
+
+/* -------------------------------------------------------------------------
+   LAYOUT
+   ------------------------------------------------------------------------- */
+
+.g-shell {
+	max-width: 1320px;
+	margin: 0 auto;
+	padding: 0 var(--g-5);
+}
+
+.g-measure { max-width: var(--g-measure); }
+
+@media (max-width: 640px) {
+	.g-record { grid-template-columns: 1fr; gap: var(--g-2); }
+}
+
+/* -------------------------------------------------------------------------
+   REDUCED MOTION
+   ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+	.g-working-bar::after {
+		animation: none;
+		width: 100%;
+		opacity: 0.6;
+	}
+
+	.g-btn,
+	.g-meter-fill,
+	.g-segment,
+	.g-check-box::after,
+	.g-tile {
+		transition: none;
+	}
+}
+
+/* -------------------------------------------------------------------------
+   CONSOLE HEADER
+   The navbar as a bulkhead strip: enamelled metal, stencilled legends, one
+   hazard-painted key. Overrides bootstrap, hence the specificity.
+   ------------------------------------------------------------------------- */
+
+.xalian-navbar.navbar {
+	background: linear-gradient(180deg, var(--g-hull-hi) 0%, var(--g-hull) 100%) !important;
+	border: 0 !important;
+	border-bottom: 2px solid var(--g-seam) !important;
+	box-shadow: inset 0 1px 0 var(--g-bevel-light), 0 3px 10px rgba(0, 0, 0, 0.6);
+	padding: var(--g-2) 0 !important;
+	z-index: var(--g-layer-nav) !important;
+}
+
+.xalian-navbar .nav-link {
+	font-family: var(--g-font-stencil) !important;
+	font-size: var(--g-size-body) !important;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-mid) !important;
+	padding: var(--g-2) var(--g-4) !important;
+	transition: color var(--g-snap);
+}
+
+.xalian-navbar .nav-link:hover,
+.xalian-navbar .nav-link:focus-visible {
+	color: var(--g-ink) !important;
+}
+
+.xalian-navbar .xalian-generator-navbar-button {
+	color: #17120a !important;
+	background: var(--g-hazard);
+	border: var(--g-hairline) solid var(--g-hazard-dark);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-relief), 0 3px 0 var(--g-seam);
+	margin-left: var(--g-3);
+	font-style: normal !important;
+	font-weight: 600;
+	transition: background var(--g-snap), transform var(--g-snap);
+}
+
+.xalian-navbar .xalian-generator-navbar-button:hover {
+	background: #f0b71a;
+	color: #17120a !important;
+}
+
+.xalian-navbar .xalian-generator-navbar-button:active {
+	transform: translateY(3px);
+	box-shadow: var(--g-recess);
+}
+
+.xalian-navbar .navbar-auth-button-wrapper { margin-left: var(--g-2); }
+
+.xalian-navbar .navbar-auth-button-wrapper .btn {
+	font-family: var(--g-font-stencil) !important;
+	font-size: var(--g-size-body) !important;
+	font-style: normal !important;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink) !important;
+	background: var(--g-hull-hi) !important;
+	border: var(--g-hairline) solid var(--g-seam) !important;
+	border-radius: var(--g-radius) !important;
+	padding: var(--g-1) var(--g-4) !important;
+	box-shadow: var(--g-relief), 0 3px 0 var(--g-seam) !important;
+}
+
+.xalian-navbar .navbar-auth-button-wrapper .btn:hover {
+	background: #3c3c32 !important;
+}
+
+.xalian-navbar .navbar-toggler {
+	border: var(--g-hairline) solid var(--g-seam);
+	border-radius: var(--g-radius);
+	background: var(--g-hull-hi);
+	box-shadow: var(--g-relief);
+	padding: var(--g-2) var(--g-3);
+}
+
+.xalian-navbar .username-navbar-link {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-body);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-hazard);
+	text-decoration: none;
+}

--- a/my-app/public/assets/css/system.css
+++ b/my-app/public/assets/css/system.css
@@ -104,6 +104,27 @@
 	/* The element in scope. One class on a container retunes everything inside. */
 	--g-el: var(--g-phosphor);
 
+	/* --- stat colours -----------------------------------------------------
+	   Semantic and independent of element: attack is red, defense blue, speed
+	   yellow-green, stamina and recovery green. Each "special" variant is a
+	   darker shade of its standard pair so the two read as related. */
+	--g-stat-standard-attack: #a84032;
+	--g-stat-special-attack: #753027;
+	--g-stat-standard-defense: #535dc2;
+	--g-stat-special-defense: #494f8c;
+	--g-stat-speed: #d0d466;
+	--g-stat-evasion: #aaad53;
+	--g-stat-stamina: #4bbf4e;
+	--g-stat-recovery: #479e4a;
+
+	/* --- charts -----------------------------------------------------------
+	   Recharts paints these from JS, so they are mirrored in designTokens.js. */
+	--g-chart-range-track: #ecff8234;
+	--g-chart-points-fill: #80dbff34;
+	--g-chart-bar-label: #ffffff50;
+	--g-chart-cursor-fill: #ffffff25;
+	--g-chart-axis: #ddd4bd;
+
 	/* --- type -------------------------------------------------------------
 	   Oswald is a mid-century poster and signage face: the condensed caps
 	   stencilled onto equipment and painted on placards. IBM Plex Mono is the
@@ -611,18 +632,21 @@
 	box-shadow: var(--g-recess);
 }
 
-/* Text entry is a screen, so it is phosphor on glass. */
+/* Text entry is a screen, so it is phosphor on glass.
+   The !important flags are load-bearing: bootstrap ships a `.form-control`
+   rule in an injected <style> tag, which outranks any linked stylesheet at
+   equal specificity. */
 .g-input,
 .g-select {
 	width: 100%;
 	padding: var(--g-3) var(--g-4);
-	font-family: var(--g-font-mono);
+	font-family: var(--g-font-mono) !important;
 	font-size: var(--g-size-small);
-	color: var(--g-phosphor);
-	background: var(--g-screen-glass);
-	border: 2px solid var(--g-brass-dark);
-	border-radius: var(--g-radius);
-	box-shadow: var(--g-recess);
+	color: var(--g-phosphor) !important;
+	background: var(--g-screen-glass) !important;
+	border: 2px solid var(--g-brass-dark) !important;
+	border-radius: var(--g-radius) !important;
+	box-shadow: var(--g-recess) !important;
 }
 
 .g-input::placeholder { color: rgba(116, 255, 176, 0.32); }
@@ -630,8 +654,8 @@
 .g-input:focus,
 .g-select:focus {
 	outline: none;
-	border-color: var(--g-brass);
-	box-shadow: var(--g-recess), var(--g-screen-bloom);
+	border-color: var(--g-brass) !important;
+	box-shadow: var(--g-recess), var(--g-screen-bloom) !important;
 }
 
 .g-select {
@@ -1182,4 +1206,50 @@
 	letter-spacing: var(--g-track-label);
 	color: var(--g-hazard);
 	text-decoration: none;
+}
+
+/* -------------------------------------------------------------------------
+   BOOTSTRAP TABS
+   react-bootstrap <Tabs> renders .nav-tabs, whose defaults are blue links on a
+   white pill. Restyled as the same bank of selector keys as .g-segmented.
+   ------------------------------------------------------------------------- */
+
+.g-tabs.nav-tabs {
+	border-bottom: var(--g-hairline) solid var(--g-rule);
+	gap: 3px;
+	padding: 3px 3px 0;
+	background: var(--g-seam);
+	border-radius: var(--g-radius) var(--g-radius) 0 0;
+}
+
+.g-tabs.nav-tabs .nav-link {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-mid);
+	background: var(--g-hull);
+	border: 0;
+	border-radius: 2px 2px 0 0;
+	box-shadow: var(--g-relief);
+	padding: var(--g-2) var(--g-5);
+	transition: background var(--g-snap), color var(--g-snap);
+}
+
+.g-tabs.nav-tabs .nav-link:hover:not(.active) {
+	background: var(--g-hull-hi);
+	color: var(--g-ink);
+	border: 0;
+}
+
+.g-tabs.nav-tabs .nav-link.active {
+	color: var(--g-ink-invert);
+	background: var(--g-hazard);
+	border: 0;
+}
+
+.g-tabs.nav-tabs .nav-link:focus-visible {
+	outline: 2px solid var(--g-phosphor);
+	outline-offset: -3px;
 }

--- a/my-app/public/assets/css/tokens.css
+++ b/my-app/public/assets/css/tokens.css
@@ -1,54 +1,53 @@
 /**
- * Xalians design tokens
- * -----------------------------------------------------------------------------
- * The single source of truth for colour, spacing, radius, type scale and glow.
+ * COMPATIBILITY SHIM — temporary, delete when the last --x-* reference is gone.
+ * =============================================================================
+ * The design system now lives in system.css under the --g-* namespace. A lot of
+ * older CSS in style.css still asks for --x-* names, and rewriting every one of
+ * those rules in a single pass would be a large, risky diff for no visual gain.
  *
- * Before this file the brand palette lived in a COMMENT at the top of style.css
- * and was then hand-copied as raw hex into ~70 places across the CSS and another
- * ~67 inline styles in JSX. Anything reused should be added here rather than
- * pasted as a literal.
+ * So this file re-points the old names at the new ones. Legacy rules keep
+ * working and immediately pick up the retrofuture palette, and pages can be
+ * migrated to .g-* components one at a time instead of all at once.
  *
- * Element/type colours are mirrored in src/constants/colorConstants.js, which is
- * what the JS side reads. The two are kept honest by a test:
- * src/__tests__/designTokens.test.js fails if they ever drift apart.
+ * Rules:
+ *   - Do NOT add new --x-* tokens here. New work uses --g-* from system.css.
+ *   - When a page is migrated, delete the --x-* rules it leaves behind.
+ *   - This file disappears entirely once nothing references --x-*.
+ *
+ * Loaded BEFORE system.css so system.css remains the source of truth.
  */
 
 :root {
-	/* --- brand ------------------------------------------------------------ */
-	--x-green: #80ffb0;
-	--x-green-hover: #b3ffd0;
-	--x-green-active: #57aa77;
-	--x-green-border: #6bd493;
-	/* translucent greens, for borders and focus rings */
-	--x-green-a15: rgba(128, 255, 176, 0.15);
-	--x-green-a30: rgba(128, 255, 176, 0.3);
-	--x-green-a60: rgba(128, 255, 176, 0.6);
+	/* brand green -> the CRT phosphor */
+	--x-green: #74ffb0;
+	--x-green-hover: #b9ffd7;
+	--x-green-active: #1f8f5c;
+	--x-green-border: #6b5423;
+	--x-green-a15: rgba(116, 255, 176, 0.15);
+	--x-green-a30: rgba(116, 255, 176, 0.30);
+	--x-green-a60: rgba(116, 255, 176, 0.60);
 
-	/* --- surfaces --------------------------------------------------------- */
-	/* the galactic backdrop: near-black, never pure #000, so starfields read */
-	--x-bg: #0d0d0d;
-	--x-surface-1: #151515;
-	--x-surface-2: #1a1a1a;
-	--x-surface-3: #232323;
-	--x-surface-overlay: rgba(13, 13, 13, 0.85);
-	--x-border: #333333;
-	--x-border-strong: #4a4a4a;
+	/* surfaces -> hull */
+	--x-bg: #0d0b09;
+	--x-surface-1: #16160f;
+	--x-surface-2: #23231a;
+	--x-surface-3: #32322a;
+	--x-surface-overlay: rgba(13, 11, 9, 0.85);
+	--x-border: rgba(216, 207, 184, 0.14);
+	--x-border-strong: rgba(216, 207, 184, 0.28);
 
-	/* --- text ------------------------------------------------------------- */
-	--x-text: #ffffff;
-	--x-text-muted: #cccccc;
-	/* --x-text-dim is the lowest step that still clears 4.5:1 on --x-bg;
-	   anything fainter is decorative only and must not carry meaning */
-	--x-text-dim: #949494;
-	--x-text-inverse: #000000;
+	/* text -> ink */
+	--x-text: #ddd4bd;
+	--x-text-muted: #9a9280;
+	--x-text-dim: #6b665a;
+	--x-text-inverse: #14120c;
 
-	/* --- feedback --------------------------------------------------------- */
-	--x-danger: #ff5b5b;
-	--x-warning: #e2bd43;
-	--x-success: var(--x-green);
+	/* feedback -> lamps */
+	--x-danger: #e4483c;
+	--x-warning: #ffb037;
+	--x-success: #74ffb0;
 
-	/* --- element / type colours ------------------------------------------- */
-	/* mirrored in src/constants/colorConstants.js - see note above */
+	/* element colours are unchanged by the redesign */
 	--x-type-fire: #df6d5e;
 	--x-type-water: #60a0c5;
 	--x-type-air: #ffffff;
@@ -64,27 +63,7 @@
 	--x-type-ice: #85dde4;
 	--x-type-sand: #e6b26f;
 
-	/* --- stat colours ----------------------------------------------------- */
-	/* semantic: attack is red, defense is blue, speed yellow-green, stamina and
-	   recovery green. Each "special" variant is a darker shade of the same hue
-	   so the standard/special pairs read as related. */
-	--x-stat-standard-attack: #a84032;
-	--x-stat-special-attack: #753027;
-	--x-stat-standard-defense: #535dc2;
-	--x-stat-special-defense: #494f8c;
-	--x-stat-speed: #d0d466;
-	--x-stat-evasion: #aaad53;
-	--x-stat-stamina: #4bbf4e;
-	--x-stat-recovery: #479e4a;
-
-	/* --- charts ----------------------------------------------------------- */
-	--x-chart-range-track: #ecff8234;
-	--x-chart-points-fill: #80dbff34;
-	--x-chart-bar-label: #ffffff50;
-	--x-chart-cursor-fill: #ffffff25;
-	--x-chart-axis: #ffffff;
-
-	/* --- spacing ---------------------------------------------------------- */
+	/* spacing / radius / motion map straight onto the new scale */
 	--x-space-1: 4px;
 	--x-space-2: 8px;
 	--x-space-3: 12px;
@@ -94,198 +73,31 @@
 	--x-space-7: 48px;
 	--x-space-8: 64px;
 
-	/* --- radius ----------------------------------------------------------- */
-	--x-radius-sm: 6px;
-	--x-radius-md: 10px;
-	--x-radius-lg: 16px;
-	--x-radius-xl: 25px;
+	--x-radius-sm: 3px;
+	--x-radius-md: 4px;
+	--x-radius-lg: 8px;
+	--x-radius-xl: 14px;
 	--x-radius-pill: 999px;
 
-	/* --- elevation / glow ------------------------------------------------- */
-	/* glow is this site's depth cue instead of drop shadow - space has no sun */
 	--x-glow-inset: inset 0px 0px 30px;
 	--x-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.5);
 	--x-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.6);
 
-	/* --- typography ------------------------------------------------------- */
-	--x-font-display: 'ProcrastinatingPixie', 'Abel', sans-serif;
-	--x-font-body: 'Abel', 'Open Sans', sans-serif;
+	/* the old display font is gone; these now resolve to the console faces */
+	--x-font-display: 'Oswald', 'Barlow Condensed', Impact, sans-serif;
+	--x-font-body: 'Barlow', system-ui, sans-serif;
+
 	--x-text-xs: 0.75rem;
 	--x-text-sm: 0.875rem;
 	--x-text-md: 1rem;
 	--x-text-lg: 1.25rem;
 	--x-text-xl: 1.75rem;
 	--x-text-2xl: 2.5rem;
-	/* cap body copy at a readable measure - the lore sections used to run the
-	   full 1400px viewport, roughly 200 characters per line */
-	--x-measure: 70ch;
+	--x-measure: 68ch;
 
-	/* --- motion ----------------------------------------------------------- */
-	--x-transition-fast: 0.15s ease;
-	--x-transition: 0.3s ease;
+	--x-transition-fast: 90ms cubic-bezier(0.3, 0, 0.2, 1);
+	--x-transition: 200ms cubic-bezier(0.3, 0, 0.2, 1);
 
-	/* --- layers ----------------------------------------------------------- */
-	/* the navbar historically sat at 99999, which put every bootstrap modal
-	   (1055) underneath it. Layers belong in one ordered list, here. */
-	--x-layer-navbar: 99999;
-	--x-layer-modal: 100000;
+	--x-layer-navbar: 500;
+	--x-layer-modal: 1000;
 }
-
-/*--------------------------------------------------------------
-# Primitives
-# Built from the language already proven on the planets page: a
-# tinted, inset-glowing panel keyed to an element colour.
---------------------------------------------------------------*/
-
-/* A surface panel. Set --x-panel-tint on it (or use .x-panel--type-* below)
-   to key it to an element colour; it falls back to the brand green. */
-.x-panel {
-	--x-panel-tint: var(--x-green);
-	border: solid 2px color-mix(in srgb, var(--x-panel-tint) 60%, transparent);
-	box-shadow: var(--x-glow-inset) var(--x-panel-tint);
-	background-color: color-mix(in srgb, var(--x-panel-tint) 12%, rgba(0, 0, 0, 0.75));
-	border-radius: var(--x-radius-xl);
-	padding: var(--x-space-5);
-}
-
-/* A quieter panel for dense content (lists, tables) where a full glow is noise */
-.x-panel--flat {
-	box-shadow: none;
-	border-width: 1px;
-	border-radius: var(--x-radius-md);
-	background-color: var(--x-surface-1);
-}
-
-/* Constrain body copy to a readable line length, centred in its column. */
-.x-measure {
-	max-width: var(--x-measure);
-	margin-left: auto;
-	margin-right: auto;
-}
-
-/* Section heading used above panels and page sections. */
-.x-section-title {
-	color: var(--x-green);
-	font-family: var(--x-font-body);
-	margin-bottom: var(--x-space-4);
-}
-
-/* Tabs. Bootstrap's defaults are blue links on a white pill, which is the one
-   piece of unthemed chrome that reads as broken against the starfield. */
-.x-tabs.nav-tabs {
-	border-bottom: 1px solid var(--x-border);
-	gap: var(--x-space-2);
-}
-
-.x-tabs.nav-tabs .nav-link {
-	color: var(--x-text-muted);
-	background-color: transparent;
-	border: 1px solid transparent;
-	border-bottom: none;
-	border-radius: var(--x-radius-md) var(--x-radius-md) 0 0;
-	padding: var(--x-space-2) var(--x-space-4);
-	transition: color var(--x-transition-fast), background-color var(--x-transition-fast);
-}
-
-.x-tabs.nav-tabs .nav-link:hover {
-	color: var(--x-green-hover);
-	background-color: var(--x-green-a15);
-	border-color: transparent;
-}
-
-.x-tabs.nav-tabs .nav-link.active {
-	color: var(--x-green);
-	background-color: var(--x-surface-2);
-	border-color: var(--x-green-a30);
-	border-bottom-color: transparent;
-}
-
-.x-tabs.nav-tabs .nav-link:focus-visible {
-	outline: 2px solid var(--x-green);
-	outline-offset: -2px;
-}
-
-/* --- page headers -------------------------------------------------------
-   Every page hand-rolled its own title treatment, so "Discovered Species",
-   "Discovered Planets" and "Glossary" were each styled slightly differently. */
-.x-page-title {
-	text-align: center;
-	color: var(--x-text);
-	padding-top: var(--x-space-7);
-	padding-bottom: var(--x-space-3);
-	margin: 0;
-}
-
-.x-page-subtitle {
-	text-align: center;
-	color: var(--x-text-dim);
-	max-width: var(--x-measure);
-	margin: 0 auto var(--x-space-6) auto;
-}
-
-/* --- label / value rows -------------------------------------------------
-   The generator, species detail and planet pages all show rows of
-   "Attribute: value". The value is the information, so it gets the emphasis;
-   the label is chrome and stays dim. */
-.x-detail-row {
-	padding-top: var(--x-space-1);
-	padding-bottom: var(--x-space-1);
-}
-
-.x-detail-label {
-	color: var(--x-text-dim);
-	text-align: right;
-}
-
-.x-detail-value {
-	color: var(--x-text);
-	text-align: left;
-}
-
-/* --- form controls ------------------------------------------------------
-   Bootstrap's inputs are white-on-white, which reads as a hole punched in the
-   starfield. */
-.x-input.form-control {
-	background-color: var(--x-surface-2) !important;
-	border: 1px solid var(--x-border) !important;
-	color: var(--x-text) !important;
-}
-
-.x-input.form-control::placeholder {
-	color: var(--x-text-dim);
-}
-
-.x-input.form-control:focus {
-	border-color: var(--x-green-a60) !important;
-	box-shadow: 0 0 0 0.2rem var(--x-green-a15) !important;
-}
-
-.x-input-addon.input-group-text {
-	background-color: var(--x-surface-2) !important;
-	border: 1px solid var(--x-border) !important;
-	color: var(--x-green) !important;
-}
-
-/* --- empty state -------------------------------------------------------- */
-.x-empty-state {
-	color: var(--x-text-dim);
-	text-align: center;
-	padding: var(--x-space-7) var(--x-space-4);
-}
-
-/* Element-keyed panel tints, so JSX can pick a panel colour with a class
-   instead of computing inline styles. */
-.x-panel--type-fire { --x-panel-tint: var(--x-type-fire); }
-.x-panel--type-water { --x-panel-tint: var(--x-type-water); }
-.x-panel--type-air { --x-panel-tint: var(--x-type-air); }
-.x-panel--type-electric { --x-panel-tint: var(--x-type-electric); }
-.x-panel--type-rock { --x-panel-tint: var(--x-type-rock); }
-.x-panel--type-plant { --x-panel-tint: var(--x-type-plant); }
-.x-panel--type-chemical { --x-panel-tint: var(--x-type-chemical); }
-.x-panel--type-light { --x-panel-tint: var(--x-type-light); }
-.x-panel--type-dark { --x-panel-tint: var(--x-type-dark); }
-.x-panel--type-metal { --x-panel-tint: var(--x-type-metal); }
-.x-panel--type-psychic { --x-panel-tint: var(--x-type-psychic); }
-.x-panel--type-ghost { --x-panel-tint: var(--x-type-ghost); }
-.x-panel--type-ice { --x-panel-tint: var(--x-type-ice); }
-.x-panel--type-sand { --x-panel-tint: var(--x-type-sand); }

--- a/my-app/public/index.html
+++ b/my-app/public/index.html
@@ -40,8 +40,13 @@
   
   <script src="https://unpkg.com/react-bootstrap@next/dist/react-bootstrap.min.js" crossorigin></script> -->
 
+  <!-- Generator Console: technical display + the machine's monospace voice -->
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Barlow:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
   <!-- Design tokens - must load first, everything below consumes them -->
   <link href="/assets/css/tokens.css" rel="stylesheet">
+  <link href="/assets/css/system.css" rel="stylesheet">
 
   <!-- Template Main CSS File -->
   <link href="/assets/css/style.css" rel="stylesheet">

--- a/my-app/src/__tests__/designTokens.test.js
+++ b/my-app/src/__tests__/designTokens.test.js
@@ -3,82 +3,89 @@ const path = require('path');
 const colorConstants = require('../constants/colorConstants');
 const designTokens = require('../constants/designTokens');
 
-// The palette exists on both sides of the stack by necessity: CSS classes paint
-// with custom properties, while recharts `fill` props, GSAP tweens and SVG
+// The palette exists on both sides of the stack by necessity: CSS paints with
+// custom properties, while recharts `fill` props, GSAP tweens and SVG
 // attributes can only take a JS string. Nothing enforces that the two agree at
-// runtime, so this test does it at build time - edit a colour in one place and
-// this fails naming the token that no longer matches.
+// runtime, so this does it at build time — edit a colour in one place and this
+// fails naming the token that no longer matches.
 
-const TOKENS_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'css', 'tokens.css');
+const SYSTEM_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'css', 'system.css');
 const TYPE_COLORS_PATH = path.join(__dirname, '..', '..', 'public', 'assets', 'css', 'typeColors.css');
 
-const readAllTokens = () => {
-	const css = fs.readFileSync(TOKENS_PATH, 'utf8');
+const readTokens = () => {
+	const css = fs.readFileSync(SYSTEM_PATH, 'utf8');
 	const tokens = {};
-	const re = /(--x-[a-z0-9-]+):\s*([^;]+);/g;
+	const re = /(--g-[a-z0-9-]+):\s*([^;]+);/g;
 	let match;
 	while ((match = re.exec(css)) !== null) {
-		tokens[match[1]] = match[2].trim().toLowerCase();
+		// only the first definition wins, matching the cascade in :root
+		if (!(match[1] in tokens)) {
+			tokens[match[1]] = match[2].trim().toLowerCase();
+		}
 	}
 	return tokens;
 };
 
-const tokens = readAllTokens();
+const tokens = readTokens();
 
-// Each entry maps a JS token to the CSS custom property that must match it.
 const PAIRINGS = [
-	['--x-green', designTokens.brand.green],
-	['--x-green-hover', designTokens.brand.greenHover],
-	['--x-green-active', designTokens.brand.greenActive],
-	['--x-green-border', designTokens.brand.greenBorder],
+	['--g-void', designTokens.hull.void],
+	['--g-hull-lo', designTokens.hull.lo],
+	['--g-hull', designTokens.hull.base],
+	['--g-hull-hi', designTokens.hull.hi],
+	['--g-seam', designTokens.hull.seam],
 
-	['--x-bg', designTokens.surface.bg],
-	['--x-surface-1', designTokens.surface.surface1],
-	['--x-surface-2', designTokens.surface.surface2],
-	['--x-surface-3', designTokens.surface.surface3],
-	['--x-border', designTokens.surface.border],
-	['--x-border-strong', designTokens.surface.borderStrong],
+	['--g-brass', designTokens.brass.base],
+	['--g-brass-dark', designTokens.brass.dark],
+	['--g-brass-light', designTokens.brass.light],
 
-	['--x-text', designTokens.text.primary],
-	['--x-text-muted', designTokens.text.muted],
-	['--x-text-dim', designTokens.text.dim],
-	['--x-text-inverse', designTokens.text.inverse],
+	['--g-ink', designTokens.ink.base],
+	['--g-ink-mid', designTokens.ink.mid],
+	['--g-ink-low', designTokens.ink.low],
+	['--g-ink-invert', designTokens.ink.invert],
 
-	['--x-danger', designTokens.feedback.danger],
-	['--x-warning', designTokens.feedback.warning],
+	['--g-phosphor', designTokens.phosphor.base],
+	['--g-screen-glass', designTokens.phosphor.glass],
 
-	['--x-stat-standard-attack', designTokens.stat.standardAttack],
-	['--x-stat-special-attack', designTokens.stat.specialAttack],
-	['--x-stat-standard-defense', designTokens.stat.standardDefense],
-	['--x-stat-special-defense', designTokens.stat.specialDefense],
-	['--x-stat-speed', designTokens.stat.speed],
-	['--x-stat-evasion', designTokens.stat.evasion],
-	['--x-stat-stamina', designTokens.stat.stamina],
-	['--x-stat-recovery', designTokens.stat.recovery],
+	['--g-lamp-amber', designTokens.lamp.amber],
+	['--g-lamp-red', designTokens.lamp.red],
+	['--g-lamp-off', designTokens.lamp.off],
 
-	['--x-chart-range-track', designTokens.chart.rangeTrack],
-	['--x-chart-points-fill', designTokens.chart.pointsFill],
-	['--x-chart-bar-label', designTokens.chart.barLabel],
-	['--x-chart-cursor-fill', designTokens.chart.cursorFill],
-	['--x-chart-axis', designTokens.chart.axis],
+	['--g-hazard', designTokens.hazard.base],
+	['--g-hazard-dark', designTokens.hazard.dark],
+
+	['--g-stat-standard-attack', designTokens.stat.standardAttack],
+	['--g-stat-special-attack', designTokens.stat.specialAttack],
+	['--g-stat-standard-defense', designTokens.stat.standardDefense],
+	['--g-stat-special-defense', designTokens.stat.specialDefense],
+	['--g-stat-speed', designTokens.stat.speed],
+	['--g-stat-evasion', designTokens.stat.evasion],
+	['--g-stat-stamina', designTokens.stat.stamina],
+	['--g-stat-recovery', designTokens.stat.recovery],
+
+	['--g-chart-range-track', designTokens.chart.rangeTrack],
+	['--g-chart-points-fill', designTokens.chart.pointsFill],
+	['--g-chart-bar-label', designTokens.chart.barLabel],
+	['--g-chart-cursor-fill', designTokens.chart.cursorFill],
+	['--g-chart-axis', designTokens.chart.axis],
 ];
 
 describe('design tokens', () => {
 
 	describe('element colours', () => {
-		const typeTokens = Object.fromEntries(
+		const elementTokens = Object.fromEntries(
 			Object.entries(tokens)
-				.filter(([name]) => name.startsWith('--x-type-'))
-				.map(([name, value]) => [name.replace('--x-type-', ''), value])
+				.filter(([name]) => name.startsWith('--g-el-'))
+				.map(([name, value]) => [name.replace('--g-el-', ''), value])
 		);
 
-		it('defines a --x-type-* token for every element in colorConstants', () => {
-			expect(Object.keys(typeTokens).sort()).toEqual(Object.keys(colorConstants.themeColors).sort());
+		it('defines a --g-el-* token for every element in colorConstants', () => {
+			expect(Object.keys(elementTokens).sort()).toEqual(Object.keys(colorConstants.themeColors).sort());
 		});
 
 		it('matches colorConstants exactly, so CSS and JS paint the same colours', () => {
 			Object.entries(colorConstants.themeColors).forEach(([type, hex]) => {
-				expect(`${type}: ${typeTokens[type]}`).toEqual(`${type}: ${hex.toLowerCase()}`);
+				expect(`${type}: ${elementTokens[type]}`).toEqual(`${type}: ${hex.toLowerCase()}`);
 			});
 		});
 	});

--- a/my-app/src/components/characterGeneratedStatChart.js
+++ b/my-app/src/components/characterGeneratedStatChart.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from "react";
 import { LabelList, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
-import { brand, chart } from "../constants/designTokens";
+import { phosphor, chart } from "../constants/designTokens";
 
 const d = [];
 
@@ -77,7 +77,7 @@ class CharacterGeneratedStatChart extends React.Component {
             <BarChart data={this.setupData(this.props.xalian)} layout="vertical" maxBarSize={35}>
               <XAxis type="number" hide />
               {/* was #80ffb1, one digit off the brand green - a typo, not a second colour */}
-              <YAxis type="category" dataKey="statLabel" stroke={brand.green} />
+              <YAxis type="category" dataKey="statLabel" stroke={phosphor.base} />
               {/* <Tooltip cursor={false}/> */}
 
               <Bar isAnimationActive={false} animationBegin={50} dataKey="rangeNumber" fill={chart.rangeTrack}>

--- a/my-app/src/components/games/duel/board/attackMoveChooserModal.js
+++ b/my-app/src/components/games/duel/board/attackMoveChooserModal.js
@@ -6,7 +6,7 @@ import Col from 'react-bootstrap/Col';
 import Stack from 'react-bootstrap/Stack';
 import XalianTypeSymbolBadge from './xalianTypeSymbolBadge';
 import * as duelCalculator from '../../../../gameplay/duel/duelCalculator';
-import { surface } from '../../../../constants/designTokens';
+import { hull } from '../../../../constants/designTokens';
 
 class AttackMoveChooserModal extends React.Component {
 
@@ -99,7 +99,7 @@ class AttackMoveChooserModal extends React.Component {
                         {this.props.attacker.species.name} attacks {this.props.defender.species.name}
                     </Modal.Title>
                 </Modal.Header>
-                <Modal.Body style={{ backgroundColor: surface.surface2 }}>
+                <Modal.Body style={{ backgroundColor: hull.base }}>
                     <Stack gap={1}>
                         {moves.map((move, index) => this.renderMoveRow(move, index))}
                         {this.renderBasicAttackRow()}

--- a/my-app/src/components/games/duel/board/duelBoard.js
+++ b/my-app/src/components/games/duel/board/duelBoard.js
@@ -42,7 +42,7 @@ import MotionPathPlugin from 'gsap/MotionPathPlugin';
 import constants from '../../../../constants/constants';
 import * as alertUtil from '../../../../utils/alertUtil';
 import FadeAlert from '../../../fadeAlert';
-import { text } from '../../../../constants/designTokens';
+import { ink } from '../../../../constants/designTokens';
 gsap.registerPlugin(Flip, MotionPathPlugin, Draggable);
 
 
@@ -627,8 +627,8 @@ class DuelBoard extends React.Component {
 		var opponentOutCols = this.buildTeamList(boardState.playerStates[1].inactiveXalianIds, boardState);
 
 		let isPlayersTurn = parseInt(this.props.ctx.currentPlayer) == 0;
-		let glowIfCurrentTurnPlayer = isPlayersTurn ? `0px 0px 5px 5px ${text.primary}` : 'none';
-		let glowIfCurrentTurnOpponent = !isPlayersTurn ? `0px 0px 5px 5px ${text.primary}` : 'none';
+		let glowIfCurrentTurnPlayer = isPlayersTurn ? `0px 0px 5px 5px ${ink.base}` : 'none';
+		let glowIfCurrentTurnOpponent = !isPlayersTurn ? `0px 0px 5px 5px ${ink.base}` : 'none';
 
 		let selectedXalian = duelUtil.getXalianFromId(selectedId, boardState);
 		// let referencedXalian = duelUtil.getXalianFromId(this.state.referencedXalianId, boardState);

--- a/my-app/src/components/games/duel/board/xalianPieceStateChart.js
+++ b/my-app/src/components/games/duel/board/xalianPieceStateChart.js
@@ -6,7 +6,7 @@ import * as svgUtil from '../../../../utils/svgUtil';
 import { PieChart, Pie, Sector, Cell, ResponsiveContainer } from 'recharts';
 import * as gameConstants from '../../../../gameplay/duel/duelGameConstants';
 import gsap from 'gsap';
-import { text } from '../../../../constants/designTokens';
+import { ink } from '../../../../constants/designTokens';
 
 const COLORS = ['#0088FE', '#00000000'];
 const STROKES = ['black', '#00000000'];
@@ -42,11 +42,11 @@ class XalianPieceStateChart extends React.Component {
         
         return (
             <div className={classes} style={{ height: 'auto', minWidth: '25px', pointerEvents: 'none', width: '100%', zIndex: '104' }}>
-                <div className={wrapperClasses} style={{display: 'flex', flexDirection: 'column', filter: `drop-shadow(0px 0px 2px ${text.inverse})` }}>
-                    <div style={{ width: '100%', height: '100%', filter: `drop-shadow(0px 0px 1px ${text.inverse}) drop-shadow(0px 0px 2px ${text.inverse})`, border: `1px outset ${healthBarColor}`, borderRadius: '4px'}}>
+                <div className={wrapperClasses} style={{display: 'flex', flexDirection: 'column', filter: `drop-shadow(0px 0px 2px ${ink.invert})` }}>
+                    <div style={{ width: '100%', height: '100%', filter: `drop-shadow(0px 0px 1px ${ink.invert}) drop-shadow(0px 0px 2px ${ink.invert})`, border: `1px outset ${healthBarColor}`, borderRadius: '4px'}}>
                         <div style={{ ...style, width: `${healthBarPercentage}%`, background: this.buildBackgroundGradient(healthBarLighterColor), pointerEvents: 'none', boxShadow: `0px 0px 1px 1px ${healthBarColor}`, borderRadius: '4px' }} />
                     </div>
-                    <div style={{ width: '100%', height: '100%', filter: `drop-shadow(0px 0px 1px ${text.inverse}) drop-shadow(0px 0px 2px ${text.inverse})`, border: `1px outset #4d4bc2`, borderRadius: '4px', marginTop: spacing}}>
+                    <div style={{ width: '100%', height: '100%', filter: `drop-shadow(0px 0px 1px ${ink.invert}) drop-shadow(0px 0px 2px ${ink.invert})`, border: `1px outset #4d4bc2`, borderRadius: '4px', marginTop: spacing}}>
                         <div style={{ ...style, width: `${staminaBarPercentage}%`, background: this.buildBackgroundGradient('#6d8ed9'), pointerEvents: 'none', boxShadow: `0px 0px 1px 1px #4d4bc2`, borderRadius: '4px' }}  />
                     </div>
                 </div>

--- a/my-app/src/components/games/duel/howToPlayModal.js
+++ b/my-app/src/components/games/duel/howToPlayModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 import * as duelConstants from '../../../gameplay/duel/duelGameConstants';
-import { surface } from '../../../constants/designTokens';
+import { hull } from '../../../constants/designTokens';
 
 // The rules text is derived from constants rather than hardcoded so it cannot
 // drift away from the actual game as tunables change.
@@ -110,16 +110,16 @@ class HowToPlayModal extends React.Component {
                 scrollable
                 className="themed-modal dark-themed-modal"
             >
-                <Modal.Header closeButton closeVariant="white" style={{ borderBottom: '1px solid #444', backgroundColor: surface.surface2 }}>
+                <Modal.Header closeButton closeVariant="white" style={{ borderBottom: '1px solid #444', backgroundColor: hull.base }}>
                     <Modal.Title style={{ color: 'white', fontSize: '1.2em' }}>How to play Duel</Modal.Title>
                 </Modal.Header>
-                <Modal.Body style={{ backgroundColor: surface.surface2 }}>
+                <Modal.Body style={{ backgroundColor: hull.base }}>
                     <p style={{ color: '#a0a0a0', fontSize: '0.9em', marginBottom: '20px' }}>
                         Duel is a squad tactics game: capture the flag on a chess-sized board, with elemental creatures instead of chess pieces.
                     </p>
                     {SECTIONS.map(this.renderSection)}
                 </Modal.Body>
-                <Modal.Footer style={{ borderTop: '1px solid #444', backgroundColor: surface.surface2 }}>
+                <Modal.Footer style={{ borderTop: '1px solid #444', backgroundColor: hull.base }}>
                     <Button variant="xalianGreen" onClick={this.props.onHide}>Got it</Button>
                 </Modal.Footer>
             </Modal>

--- a/my-app/src/components/planetTable.js
+++ b/my-app/src/components/planetTable.js
@@ -66,7 +66,9 @@ class PlanetTable extends React.Component {
 
     return (
 		<React.Fragment>
-			<Container className={'dark-section-div'} style={styleUtil.getInsideGlowThemeColor(this.props.planet.data.Type.toLowerCase())} >
+			{/* a panel is matte metal: the element shows as a painted band along the
+			    top edge rather than as a glow bleeding out of the card */}
+			<Container className={`g-panel g-panel--tagged g-el-${this.props.planet.data.Type.toLowerCase()} planet-panel`} >
 				<Row className="planet-details-row vertically-center-contents">
 					<Col xs={12} md={3} className="planet-details-row-col">
 						<img src={this.props.planet.planetImage} class="planet-gif" alt=""></img>
@@ -74,7 +76,8 @@ class PlanetTable extends React.Component {
 					<Col xs={12} md={6} className="planet-description-col">
 						<Row className="planet-title-row">
 							<Col xs={12}>
-								<h2 className={this.props.planet.data.Type.toLowerCase() + '-text-color black-text-shadow'} style={{ textShadow: styleUtil.textBorder('black', 2) + ', ' + styleUtil.getBorder(this.props.planet.data.Type.toLowerCase(), 6, 12), color: '#ffffffff' }} >{this.props.planet.name}</h2>
+								{/* a planet name is stencilled on the plate, not glowing */}
+								<h2 className="g-h2">{this.props.planet.name}</h2>
 							</Col>
                 <Col xs={12}>
                   <XalianSpeciesBadge type={this.props.planet.data.Type.toLowerCase()} />

--- a/my-app/src/components/xalianAttributeChart.js
+++ b/my-app/src/components/xalianAttributeChart.js
@@ -13,14 +13,14 @@ class XalianAttributeChart extends React.Component {
                 {this.props.xalian && this.props.xalian.elements && 
                     <React.Fragment>
                         <Row>
-                            <Col className="x-detail-label">Primary Element:</Col>
-                            <Col className="x-detail-value">
+                            <Col className="g-spec-key">Primary Element:</Col>
+                            <Col className="g-spec-val">
                                 {this.props.xalian.elements.primaryType} [{this.props.xalian.elements.primaryElement}]
                             </Col>
                         </Row>
                         <Row>
-                            <Col className="x-detail-label">Secondary Element:</Col>
-                            <Col className="x-detail-value">
+                            <Col className="g-spec-key">Secondary Element:</Col>
+                            <Col className="g-spec-val">
                                 {this.props.xalian.elements.secondaryType} [{this.props.xalian.elements.secondaryElement}]
                             </Col>
                         </Row>
@@ -29,40 +29,40 @@ class XalianAttributeChart extends React.Component {
                 {this.props.xalian && this.props.xalian.species && 
                     <React.Fragment>
                         <Row>
-                            <Col className="x-detail-label">Generation:</Col>
-                            <Col className="x-detail-value">{this.props.xalian.species.generation}</Col>
+                            <Col className="g-spec-key">Generation:</Col>
+                            <Col className="g-spec-val">{this.props.xalian.species.generation}</Col>
                         </Row>
                         <Row>
-                            <Col className="x-detail-label">Origin Planet:</Col>
-                            <Col className="x-detail-value">{this.props.xalian.species.planet}</Col>
+                            <Col className="g-spec-key">Origin Planet:</Col>
+                            <Col className="g-spec-val">{this.props.xalian.species.planet}</Col>
                         </Row>
                         <Row>
-                            <Col className="x-detail-label">Avg Height:</Col>
-                            <Col className="x-detail-value">{this.props.xalian.species.height}</Col>
+                            <Col className="g-spec-key">Avg Height:</Col>
+                            <Col className="g-spec-val">{this.props.xalian.species.height}</Col>
                         </Row>
                         <Row>
-                            <Col className="x-detail-label">Avg Weight:</Col>
-                            <Col className="x-detail-value">{this.props.xalian.species.weight}</Col>
+                            <Col className="g-spec-key">Avg Weight:</Col>
+                            <Col className="g-spec-val">{this.props.xalian.species.weight}</Col>
                         </Row>
                     </React.Fragment>
                 }
                 {this.props.species && 
                     <React.Fragment>
                         <Row>
-                            <Col className="x-detail-label">Generation:</Col>
-                            <Col className="x-detail-value">{this.props.species.generation || '0'}</Col>
+                            <Col className="g-spec-key">Generation:</Col>
+                            <Col className="g-spec-val">{this.props.species.generation || '0'}</Col>
                         </Row>
                         <Row>
-                            <Col className="x-detail-label">Origin Planet:</Col>
-                            <Col className="x-detail-value">{this.props.species.planet}</Col>
+                            <Col className="g-spec-key">Origin Planet:</Col>
+                            <Col className="g-spec-val">{this.props.species.planet}</Col>
                         </Row>
                         <Row>
-                            <Col className="x-detail-label">Avg Height:</Col>
-                            <Col className="x-detail-value">{this.props.species.height}</Col>
+                            <Col className="g-spec-key">Avg Height:</Col>
+                            <Col className="g-spec-val">{this.props.species.height}</Col>
                         </Row>
                         <Row>
-                            <Col className="x-detail-label">Avg Weight:</Col>
-                            <Col className="x-detail-value">{this.props.species.weight}</Col>
+                            <Col className="g-spec-key">Avg Weight:</Col>
+                            <Col className="g-spec-val">{this.props.species.weight}</Col>
                         </Row>
                     </React.Fragment>
                 }
@@ -70,20 +70,20 @@ class XalianAttributeChart extends React.Component {
                     <React.Fragment>
 
                     {/* <Row>
-                        <Col className="x-detail-label">Total Stat Points:</Col>
-                        <Col className="x-detail-value">{this.props.xalian.meta.totalStatPoints}</Col>
+                        <Col className="g-spec-key">Total Stat Points:</Col>
+                        <Col className="g-spec-val">{this.props.xalian.meta.totalStatPoints}</Col>
                     </Row>
                     <Row>
-                        <Col className="x-detail-label">Potential Stat Points:</Col>
-                        <Col className="x-detail-value">{this.props.xalian.meta.potentialStatPoints}</Col>
+                        <Col className="g-spec-key">Potential Stat Points:</Col>
+                        <Col className="g-spec-val">{this.props.xalian.meta.potentialStatPoints}</Col>
                     </Row> */}
                     <Row>
-                        <Col className="x-detail-label">Stat Score:</Col>
-                        <Col className="x-detail-value">{this.props.xalian.meta.statScore}</Col>
+                        <Col className="g-spec-key">Stat Score:</Col>
+                        <Col className="g-spec-val">{this.props.xalian.meta.statScore}</Col>
                     </Row>
                     <Row>
-                        <Col className="x-detail-label">Stat Potential Score:</Col>
-                        <Col className="x-detail-value">{this.props.xalian.meta.potentialStatScore}</Col>
+                        <Col className="g-spec-key">Stat Potential Score:</Col>
+                        <Col className="g-spec-val">{this.props.xalian.meta.potentialStatScore}</Col>
                     </Row>
                     </React.Fragment>
                 }

--- a/my-app/src/components/xalianInfoBox.js
+++ b/my-app/src/components/xalianInfoBox.js
@@ -25,7 +25,7 @@ class XalianInfoBox extends React.Component {
 							{this.props.json && (
 								<div className="centered-view">
 									<button className="json-modal-button" onClick={() => this.setState({ jsonModalShow: true })}>
-										<i class="bi bi-file-earmark-binary"></i>
+										<i className="bi bi-file-earmark-binary"></i>
 									</button>
 								</div>
 							)}
@@ -44,7 +44,7 @@ class XalianInfoBox extends React.Component {
 							{this.props.json && (
 								<div className="centered-view">
 									<button className="json-modal-button" onClick={() => this.setState({ jsonModalShow: true })}>
-										<i class="bi bi-file-earmark-binary"></i>
+										<i className="bi bi-file-earmark-binary"></i>
 									</button>
 								</div>
 							)}

--- a/my-app/src/components/xalianMoveSet.js
+++ b/my-app/src/components/xalianMoveSet.js
@@ -8,7 +8,7 @@ import Col from 'react-bootstrap/Col';
 class XalianMoveSet extends React.Component {
 	buildMoveRow(val) {
 		return (
-			<Row style={{ paddingTop: this.props.spacing || '5px', paddingBottom: this.props.spacing || '5px' }} className="moves-row ms-auto me-auto ">
+			<Row key={val.name} style={{ paddingTop: this.props.spacing || '5px', paddingBottom: this.props.spacing || '5px' }} className="moves-row ms-auto me-auto ">
 					<Col xs={2} className="move-rating-col">
 						<h4 className="move-rating">{val.rating}</h4>
 					</Col>

--- a/my-app/src/components/xalianStatChart.js
+++ b/my-app/src/components/xalianStatChart.js
@@ -8,7 +8,7 @@ import Col from 'react-bootstrap/Col';
 import Table from 'react-bootstrap/Table';
 import * as valueTranslator from '../utils/valueTranslator';
 import * as constants from '../constants/constants';
-import { chart, text } from '../constants/designTokens';
+import { chart, ink } from '../constants/designTokens';
 
 class XalianStatChart extends React.Component {
 	state = {};
@@ -99,8 +99,8 @@ const CustomTooltip = ({ active, payload, label }) => {
 	  return (
 		<div style={{border: 'solid 2px' + valueTranslator.statFieldToBarColor(payload[0].payload.statName) }} className="stat-tooltip">
 		  <h5 style={{ color: 'white' }} className="stat-tooltip-label">{payload[0].payload.statLabel}</h5>
-		  <h6 style={{ color: text.muted }} className="stat-tooltip-label">{`${payload[0].payload.rangeName}: ${payload[0].payload.points}`}</h6>
-		  <h6 style={{ color: text.muted }} className="stat-tooltip-label">{`${payload[1].value} potential points`}</h6>
+		  <h6 style={{ color: ink.mid }} className="stat-tooltip-label">{`${payload[0].payload.rangeName}: ${payload[0].payload.points}`}</h6>
+		  <h6 style={{ color: ink.mid }} className="stat-tooltip-label">{`${payload[1].value} potential points`}</h6>
 		</div>
 	  );
 	}

--- a/my-app/src/constants/designTokens.js
+++ b/my-app/src/constants/designTokens.js
@@ -1,60 +1,71 @@
 /**
- * The JavaScript half of the design token system.
+ * The JavaScript half of the design system.
  *
- * Some things can only be styled from JS - recharts takes colours as `fill`
+ * Some things can only be styled from JS — recharts takes colours as `fill`
  * props, GSAP tweens take them as tween values, and SVG components take them as
- * attributes. Those consumers cannot read a CSS custom property, so the palette
- * has to exist on both sides.
+ * attributes. None of those can read a CSS custom property, so the palette has
+ * to exist on both sides.
  *
- * public/assets/css/tokens.css is the CSS half. The two are kept identical by
+ * public/assets/css/system.css is the CSS half. The two are held identical by
  * src/__tests__/designTokens.test.js, which fails if any value here disagrees
- * with the matching --x-* token. Change a colour in one place and the test will
+ * with the matching --g-* token. Change a colour in one place and the test will
  * tell you about the other.
  *
- * Element/type colours live in colorConstants.js (imported and re-exported here
- * so there is one import for consumers) because they predate this file and are
+ * Element colours live in colorConstants.js (imported and re-exported here so
+ * consumers have a single import) because they predate this file and are
  * referenced widely.
  */
 
 const colorConstants = require('./colorConstants');
 
-// --- brand ---------------------------------------------------------------
-const brand = {
-	green: '#80ffb0',
-	greenHover: '#b3ffd0',
-	greenActive: '#57aa77',
-	greenBorder: '#6bd493',
+/**
+ * The hull: enamelled steel, brass and bone silkscreen. Deliberately
+ * desaturated — the element hues are the only saturated things in the system.
+ */
+const hull = {
+	void: '#0d0b09',
+	lo: '#16160f',
+	base: '#23231a',
+	hi: '#32322a',
+	seam: '#0a0a07',
 };
 
-// --- surfaces ------------------------------------------------------------
-const surface = {
-	bg: '#0d0d0d',
-	surface1: '#151515',
-	surface2: '#1a1a1a',
-	surface3: '#232323',
-	border: '#333333',
-	borderStrong: '#4a4a4a',
+const brass = {
+	base: '#b08d3f',
+	dark: '#6b5423',
+	light: '#d8b45e',
 };
 
-// --- text ----------------------------------------------------------------
-const text = {
-	primary: '#ffffff',
-	muted: '#cccccc',
-	dim: '#949494',
-	inverse: '#000000',
+/** Printed matter. Never pure white: paint yellows. */
+const ink = {
+	base: '#ddd4bd',
+	mid: '#9a9280',
+	low: '#6b665a',
+	invert: '#14120c',
 };
 
-// --- feedback ------------------------------------------------------------
-const feedback = {
-	danger: '#ff5b5b',
-	warning: '#e2bd43',
-	success: '#80ffb0',
+/** The CRT. The only pure saturated light, confined to screens. */
+const phosphor = {
+	base: '#74ffb0',
+	glass: '#07120c',
+};
+
+/** Bulbs behind coloured plastic, and painted warning livery. */
+const lamp = {
+	amber: '#ffb037',
+	red: '#e4483c',
+	off: '#3d3a30',
+};
+
+const hazard = {
+	base: '#d9a410',
+	dark: '#6d5108',
 };
 
 /**
- * Stat colours. These are semantic - attack is red, defense is blue, speed is
- * yellow-green, stamina/recovery are green - and the "special" variant of each
- * is a darker shade of the same hue so the pairs read as related.
+ * Stat colours. Semantic and independent of element: attack red, defense blue,
+ * speed yellow-green, stamina and recovery green, with each "special" variant a
+ * darker shade of its standard pair.
  */
 const stat = {
 	standardAttack: '#a84032',
@@ -67,10 +78,7 @@ const stat = {
 	recovery: '#479e4a',
 };
 
-/**
- * The same eight stats as they appear in the points charts, where bars are
- * drawn translucent over a range track.
- */
+/** The same eight stats as drawn in the points charts, translucent over a track. */
 const statPoints = {
 	standardAttack: '#df9320be',
 	specialAttack: '#b37519d0',
@@ -82,24 +90,21 @@ const statPoints = {
 	recovery: '#8f1f1fc9',
 };
 
-// --- charts --------------------------------------------------------------
 const chart = {
-	/* the faint track a stat bar is drawn against */
 	rangeTrack: '#ecff8234',
-	/* the filled portion of a stat bar */
 	pointsFill: '#80dbff34',
-	/* label text drawn on top of a bar */
 	barLabel: '#ffffff50',
-	/* the hover highlight behind a tooltip */
 	cursorFill: '#ffffff25',
-	axis: '#ffffff',
+	axis: '#ddd4bd',
 };
 
 module.exports = {
-	brand,
-	surface,
-	text,
-	feedback,
+	hull,
+	brass,
+	ink,
+	phosphor,
+	lamp,
+	hazard,
 	stat,
 	statPoints,
 	chart,

--- a/my-app/src/pages/glossaryPage.js
+++ b/my-app/src/pages/glossaryPage.js
@@ -3,7 +3,6 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
 import Form from 'react-bootstrap/Form';
-import InputGroup from 'react-bootstrap/InputGroup';
 import XalianNavbar from '../components/navbar';
 import glossary from '../json/glossary.json';
 
@@ -40,14 +39,10 @@ class GlossaryPage extends React.Component {
     // screen reader and conveyed none of the term-to-definition relationship.
     buildDictionary(entries) {
         return entries.map((row) => (
-            <Row className="glossary-word-row vertically-center-contents" key={row.word} as="div">
-                <Col sm={3}>
-                    <dt className="glossary-title">{row.word}</dt>
-                </Col>
-                <Col sm={true}>
-                    <dd className="glossary-definition">{row.definition}</dd>
-                </Col>
-            </Row>
+            <div className="g-record" key={row.word}>
+                <dt className="g-record-term">{row.word}</dt>
+                <dd className="g-record-body">{row.definition}</dd>
+            </div>
         ));
     }
 
@@ -55,30 +50,28 @@ class GlossaryPage extends React.Component {
         let entries = this.getMatchingEntries();
         let total = this.getSortedEntries().length;
 
-        return <React.Fragment>
+        return (
+            <div className="g-console">
+                <XalianNavbar />
 
-            <Container fluid className="content-background-container">
-                <XalianNavbar></XalianNavbar>
-
-                <Container>
-                    <h1 className="x-page-title">Glossary</h1>
+                <div className="g-shell page-shell">
+                    <header className="page-header">
+                        <p className="g-kicker">Vallerii Archive</p>
+                        <h1 className="g-title">Glossary</h1>
+                    </header>
 
                     <Row className="justify-content-center">
                         <Col md={7} lg={6}>
-                            <InputGroup className="glossary-search">
-                                <InputGroup.Text className="x-input-addon">
-                                    <i className="bi bi-search" />
-                                </InputGroup.Text>
-                                <Form.Control
-                                    type="search"
-                                    placeholder="Search the galaxy's terms..."
-                                    aria-label="Search glossary terms"
-                                    value={this.state.query}
-                                    onChange={(e) => this.setState({ query: e.target.value })}
-                                    className="x-input"
-                                />
-                            </InputGroup>
-                            <p className="glossary-result-count">
+                            {/* the search field is a screen, so it reads as phosphor on glass */}
+                            <Form.Control
+                                type="search"
+                                placeholder="SEARCH TERMS"
+                                aria-label="Search glossary terms"
+                                value={this.state.query}
+                                onChange={(e) => this.setState({ query: e.target.value })}
+                                className="g-input"
+                            />
+                            <p className="glossary-result-count g-kicker">
                                 {this.state.query
                                     ? `${entries.length} of ${total} terms`
                                     : `${total} terms`}
@@ -86,19 +79,15 @@ class GlossaryPage extends React.Component {
                         </Col>
                     </Row>
 
-                    <Row className="glossary-wrapper">
-                        <Col className="">
-                            {entries.length > 0
-                                ? <dl className="glossary-list">{this.buildDictionary(entries)}</dl>
-                                : <p className="x-empty-state">No terms match “{this.state.query}”.</p>
-                            }
-                        </Col>
-                    </Row>
-                </Container>
-            </Container>
-        </React.Fragment>
-
-
+                    <div className="g-panel g-panel--recessed glossary-wrapper">
+                        {entries.length > 0
+                            ? <dl className="glossary-list">{this.buildDictionary(entries)}</dl>
+                            : <p className="g-empty">No terms match “{this.state.query}”</p>
+                        }
+                    </div>
+                </div>
+            </div>
+        );
     }
 
 }

--- a/my-app/src/pages/planetPage.js
+++ b/my-app/src/pages/planetPage.js
@@ -46,7 +46,7 @@ class PlanetPage extends React.Component {
                     <Row >
 
                         <Col className="template-col-wrapper">
-                            <h1 className="x-page-title">Discovered Planets</h1>
+                            <h1 className="g-title">Discovered Planets</h1>
                             {this.buildPlanets()}
                         </Col>
 

--- a/my-app/src/pages/speciesDetailPage.js
+++ b/my-app/src/pages/speciesDetailPage.js
@@ -46,7 +46,7 @@ class SpeciesDetailPage extends React.Component {
 					<Container fluid className="content-background-container">
 						<XalianNavbar></XalianNavbar>
 						<Container className="content-container">
-							<h1 className="x-page-title">Species not found</h1>
+							<h1 className="g-title">Species not found</h1>
 							<p style={{ textAlign: 'center' }}>
 								No Xalian species matches this id. <a href="/species">Browse all species</a>
 							</p>

--- a/my-app/src/pages/speciesPage.js
+++ b/my-app/src/pages/speciesPage.js
@@ -141,10 +141,10 @@ class SpeciesPage extends React.Component {
                     <Row className="">
 
                         <Col className="template-col-wrapper ">
-                            <h1 className="x-page-title">Discovered Species</h1>
+                            <h1 className="g-title">Discovered Species</h1>
 
                             {species &&
-                                <Tabs defaultActiveKey="grid" id="tabbs" className="species-tab-group x-tabs">
+                                <Tabs defaultActiveKey="grid" id="tabbs" className="species-tab-group g-tabs">
                                     <Tab eventKey="grid" title="Grid" className="species-tab">
                                         <Row>
                                             {this.state.gridList}

--- a/my-app/src/pages/styleGuidePage.js
+++ b/my-app/src/pages/styleGuidePage.js
@@ -1,196 +1,433 @@
 import React from 'react';
-import Row from 'react-bootstrap/Row';
-import Col from 'react-bootstrap/Col';
-import Button from 'react-bootstrap/Button';
-import Container from 'react-bootstrap/Container';
-import Form from 'react-bootstrap/Form';
-import InputGroup from 'react-bootstrap/InputGroup';
 import XalianNavbar from '../components/navbar';
+import XalianImage from '../components/xalianImage';
 import tokens from '../constants/designTokens';
 
 /**
- * A living reference for the design system.
+ * GENERATOR CONSOLE — the design system reference.
  *
- * This page is rendered from the same tokens and primitives the rest of the site
- * uses, so it cannot drift: change a token and this page changes with it. Use it
- * to check that a new colour or component actually fits before scattering it
- * across pages.
+ * Rendered from the same tokens and classes the site uses, so it cannot drift
+ * from reality. If something here looks wrong, the system is wrong.
  */
 
-const SPACE_STEPS = ['1', '2', '3', '4', '5', '6', '7', '8'];
-const RADIUS_STEPS = ['sm', 'md', 'lg', 'xl', 'pill'];
-const ELEMENT_TYPES = Object.keys(tokens.themeColors);
+const ELEMENTS = Object.keys(tokens.themeColors);
+
+const SECTIONS = [
+    { id: 'foundation', index: '01', name: 'Foundation' },
+    { id: 'elements', index: '02', name: 'Element Energy' },
+    { id: 'surfaces', index: '03', name: 'Panels' },
+    { id: 'readouts', index: '04', name: 'Readouts' },
+    { id: 'controls', index: '05', name: 'Controls' },
+    { id: 'specimen', index: '06', name: 'Specimen' },
+];
+
+/* A stat has three zones: what it is now, how far it could still grow, and the
+   ceiling it can never reach. The meter shows all three at once. */
+const STAT_CEILING = 1000;
+const STATS = [
+    { name: 'Std Attack', value: 741, potential: 890 },
+    { name: 'Spc Attack', value: 236, potential: 610 },
+    { name: 'Std Defense', value: 503, potential: 780 },
+    { name: 'Spc Defense', value: 414, potential: 690 },
+    { name: 'Speed', value: 611, potential: 950 },
+    { name: 'Evasion', value: 531, potential: 720 },
+];
 
 class StyleGuidePage extends React.Component {
 
-    renderSwatches(title, entries, note) {
+    state = { channel: 'grid' };
+
+    renderSectionHead(index, name, note) {
         return (
-            <section className="styleguide-section">
-                <h2 className="styleguide-heading">{title}</h2>
-                {note && <p className="styleguide-note">{note}</p>}
-                <div className="styleguide-swatch-grid">
-                    {entries.map(([name, value]) => (
-                        <div className="styleguide-swatch" key={name}>
-                            <div className="styleguide-swatch-chip" style={{ backgroundColor: value }} />
-                            <code className="styleguide-swatch-name">{name}</code>
-                            <code className="styleguide-swatch-value">{value}</code>
-                        </div>
-                    ))}
+            <header className="sg-section-head">
+                <span className="sg-section-index g-mono">{index}</span>
+                <h2 className="g-h2">{name}</h2>
+                {note && <p className="g-body sg-section-note">{note}</p>}
+            </header>
+        );
+    }
+
+    renderMeter(stat) {
+        const pct = Math.round((stat.value / STAT_CEILING) * 100);
+        const potentialPct = Math.round((stat.potential / STAT_CEILING) * 100);
+        return (
+            <div className="g-meter-row" key={stat.name}>
+                <span className="g-meter-name">{stat.name}</span>
+                <div className="g-meter">
+                    <div className="g-meter-ghost" style={{ width: `${potentialPct}%` }} />
+                    <div className="g-meter-fill" style={{ width: `${pct}%` }} />
                 </div>
-            </section>
+                <span className="g-meter-value">{stat.value}</span>
+            </div>
         );
     }
 
     render() {
         return (
-            <React.Fragment>
-                <Container fluid className="content-background-container">
-                    <XalianNavbar />
+            <div className="g-console">
+                <XalianNavbar />
 
-                    <Container className="styleguide-container">
-                        <h1 className="x-page-title">Design System</h1>
-                        <p className="x-page-subtitle">
-                            Every colour, space and component the site is built from. Rendered from the same
-                            tokens the pages use, so it stays honest.
+                <div className="g-shell sg-page">
+
+                    {/* ---- masthead ---- */}
+                    <header className="sg-masthead">
+                        <p className="g-label">Xalian Generator</p>
+                        <h1 className="g-title">Console Design System</h1>
+                        <p className="g-body">
+                            The machine can bioengineer life on a dead world. The interface it does that
+                            through is enamelled steel, brass and bakelite, because the empire that built it
+                            was industrial rather than futuristic. Panels are matte objects and never glow.
+                            The only light in the room comes from a small green CRT bolted into the hull, and
+                            from the indicator lamps beside it.
                         </p>
+                        <div className="sg-masthead-status">
+                            <span className="g-lamp">Generator online</span>
+                            <span className="g-lamp g-lamp--amber">Plague containment nominal</span>
+                            <span className="g-lamp g-lamp--off">APEX link severed</span>
+                        </div>
+                    </header>
 
-                        {this.renderSwatches('Brand', Object.entries(tokens.brand))}
-                        {this.renderSwatches('Surfaces', Object.entries(tokens.surface),
-                            'Backgrounds and borders, darkest first. The page sits on bg; panels lift off it.')}
-                        {this.renderSwatches('Text', Object.entries(tokens.text),
-                            'dim is the faintest step that still clears 4.5:1 on the page background. Anything fainter is decorative and must not carry meaning.')}
-                        {this.renderSwatches('Feedback', Object.entries(tokens.feedback))}
-                        {this.renderSwatches('Stats', Object.entries(tokens.stat),
-                            'Semantic: attack is red, defense blue, speed yellow-green, stamina and recovery green. Each special variant is a darker shade of its standard pair.')}
-                        {this.renderSwatches('Elements', Object.entries(tokens.themeColors),
-                            'One per element type. Mirrored as --x-type-* in CSS and enforced identical by designTokens.test.js.')}
+                    {/* ---- index ---- */}
+                    <nav className="sg-index g-panel g-panel--recessed">
+                        {SECTIONS.map((s) => (
+                            <a className="sg-index-item" href={`#${s.id}`} key={s.id}>
+                                <span className="sg-index-num g-mono">{s.index}</span>
+                                <span className="sg-index-name">{s.name}</span>
+                            </a>
+                        ))}
+                    </nav>
 
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Spacing</h2>
-                            <p className="styleguide-note">A 4px-based scale. Use these rather than arbitrary pixel values.</p>
-                            {SPACE_STEPS.map((step) => (
-                                <div className="styleguide-space-row" key={step}>
-                                    <code className="styleguide-space-name">--x-space-{step}</code>
-                                    <div className="styleguide-space-bar" style={{ width: `var(--x-space-${step})` }} />
+                    {/* ---- 01 foundation ---- */}
+                    <section id="foundation" className="sg-section">
+                        {this.renderSectionHead('01', 'Foundation',
+                            'The hull is olive enamel, bone silkscreen and oxidised brass. Nothing structural is saturated, which is exactly why the element hues and the hazard livery read instantly when they turn up.')}
+
+                        <div className="sg-grid-2">
+                            <div className="g-panel">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Hull</span>
+                                    <span className="g-kicker">surfaces</span>
+                                </div>
+                                <div className="sg-swatch-row">
+                                    {[
+                                        ['--g-void', 'void', 'the room'],
+                                        ['--g-hull-lo', 'recessed', 'wells'],
+                                        ['--g-hull', 'hull', 'panels'],
+                                        ['--g-hull-hi', 'raised', 'keys'],
+                                        ['--g-brass', 'brass', 'bezels'],
+                                        ['--g-ink', 'ink', 'legends'],
+                                    ].map(([varName, label, use]) => (
+                                        <div className="sg-swatch" key={varName}>
+                                            <div className="sg-swatch-chip" style={{ background: `var(${varName})` }} />
+                                            <span className="sg-swatch-name g-mono">{label}</span>
+                                            <span className="sg-swatch-use">{use}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <div className="g-panel">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Phosphor &amp; hazard</span>
+                                    <span className="g-kicker">light + warning</span>
+                                </div>
+                                <div className="sg-swatch-row">
+                                    {[
+                                        ['--g-phosphor', 'phosphor', 'the CRT'],
+                                        ['--g-hazard', 'hazard', 'commit / warn'],
+                                        ['--g-lamp-amber', 'amber', 'advisory lamp'],
+                                        ['--g-lamp-red', 'red', 'failure lamp'],
+                                        ['--g-lamp-off', 'unlit', 'no power'],
+                                    ].map(([varName, label, use]) => (
+                                        <div className="sg-swatch" key={varName}>
+                                            <div className="sg-swatch-chip" style={{ background: `var(${varName})` }} />
+                                            <span className="sg-swatch-name g-mono">{label}</span>
+                                            <span className="sg-swatch-use">{use}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="g-panel sg-type-plate">
+                            <div className="g-panel-head">
+                                <span className="g-label">Voice</span>
+                                <span className="g-kicker">oswald · barlow · ibm plex mono</span>
+                            </div>
+                            <p className="g-kicker">Silkscreen label</p>
+                            <h3 className="g-h3">Stencil — painted on the hull</h3>
+                            <p className="g-body">
+                                Body copy sits in Barlow at a comfortable measure. It carries the lore and the
+                                explanations — the only place the interface speaks in sentences rather than
+                                in values stamped onto metal.
+                            </p>
+                            <hr className="g-seam-rule" />
+                            <div className="sg-readout-demo g-el-ice">
+                                <div>
+                                    <span className="g-readout">1,204</span>
+                                    <span className="g-readout-unit"> stat score</span>
+                                </div>
+                                <p className="g-kicker">Machine readout — tabular, never reflows</p>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* ---- 02 elements ---- */}
+                    <section id="elements" className="sg-section">
+                        {this.renderSectionHead('02', 'Element Energy',
+                            'The fourteen element hues are the fixed point of the whole system — fire is red because fire is red. They get painted onto the hull as a colour band, printed onto labels, and lit in the bulbs of a meter. Key any container to an element and everything inside it retunes.')}
+
+                        <div className="sg-element-grid">
+                            {ELEMENTS.map((el) => (
+                                <div className={`g-panel g-panel--tagged g-el-${el} sg-element-cell`} key={el}>
+                                    <span className="g-label">{el}</span>
+                                    <span className="g-mono sg-element-hex">{tokens.themeColors[el]}</span>
+                                    <div className="g-meter sg-element-meter">
+                                        <div className="g-meter-fill" style={{ width: '72%' }} />
+                                    </div>
                                 </div>
                             ))}
-                        </section>
+                        </div>
 
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Radius</h2>
-                            <div className="styleguide-radius-grid">
-                                {RADIUS_STEPS.map((step) => (
-                                    <div className="styleguide-radius-item" key={step}>
-                                        <div className="styleguide-radius-box" style={{ borderRadius: `var(--x-radius-${step})` }} />
-                                        <code className="styleguide-swatch-name">--x-radius-{step}</code>
-                                    </div>
-                                ))}
+                        <div className="sg-grid-2">
+                            <div className="g-panel g-el-fire">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Chips</span>
+                                    <span className="g-kicker">printed labels</span>
+                                </div>
+                                <div className="sg-chip-row">
+                                    <span className="g-chip">Fire</span>
+                                    <span className="g-chip g-el-water">Water</span>
+                                    <span className="g-chip g-el-psychic">Psychic</span>
+                                    <span className="g-chip g-el-ghost">Ghost</span>
+                                    <span className="g-chip g-el-electric">Electric</span>
+                                </div>
                             </div>
-                        </section>
 
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Panels</h2>
-                            <p className="styleguide-note">
-                                The core surface, lifted from the planets page. A tinted, inset-glowing card keyed to an
-                                element colour. Set the tint with an <code>.x-panel--type-*</code> class.
-                            </p>
-                            <Row>
-                                <Col md={4} className="styleguide-panel-col">
-                                    <div className="x-panel">
-                                        <h5 className="x-section-title">Default</h5>
-                                        <p className="styleguide-note">Falls back to the brand green.</p>
-                                    </div>
-                                </Col>
-                                <Col md={4} className="styleguide-panel-col">
-                                    <div className="x-panel x-panel--type-fire">
-                                        <h5 className="x-section-title">Fire tint</h5>
-                                        <p className="styleguide-note">Keyed with <code>.x-panel--type-fire</code>.</p>
-                                    </div>
-                                </Col>
-                                <Col md={4} className="styleguide-panel-col">
-                                    <div className="x-panel x-panel--flat">
-                                        <h5 className="x-section-title">Flat</h5>
-                                        <p className="styleguide-note">For dense content, where a glow is noise.</p>
-                                    </div>
-                                </Col>
-                            </Row>
-                        </section>
-
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Element tints</h2>
-                            <div className="styleguide-tint-grid">
-                                {ELEMENT_TYPES.map((type) => (
-                                    <div className={`x-panel x-panel--type-${type} styleguide-tint`} key={type}>
-                                        {type}
-                                    </div>
-                                ))}
+                            <div className="g-panel g-el-electric">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Meters</span>
+                                    <span className="g-kicker">recessed bulb strip</span>
+                                </div>
+                                {STATS.slice(0, 3).map((s) => this.renderMeter(s))}
                             </div>
-                        </section>
+                        </div>
+                    </section>
 
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Buttons</h2>
-                            <p className="styleguide-note">
-                                xalianGreen is the primary action, xalianGray the secondary. Both show a green focus
-                                ring for keyboard users.
-                            </p>
-                            <div className="styleguide-button-row">
-                                <Button variant="xalianGreen">Primary</Button>
-                                <Button variant="xalianGray">Secondary</Button>
-                                <Button variant="xalianGreen" disabled>Disabled</Button>
-                                <Button variant="xalianGray" disabled>Disabled</Button>
+                    {/* ---- 03 plates ---- */}
+                    <section id="surfaces" className="sg-section">
+                        {this.renderSectionHead('03', 'Panels',
+                            'Pressed steel under olive enamel, bolted to the frame. Depth is a bevel — light along the top edge, shadow underneath — plus rivets where a real panel would need them. No panel emits light, and that restraint is what makes the screens matter.')}
+
+                        <div className="sg-grid-3">
+                            <div className="g-panel">
+                                <span className="g-label">Standard</span>
+                                <p className="g-body sg-small-body">Olive enamel. Holds most content.</p>
                             </div>
-                        </section>
-
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Form controls</h2>
-                            <Row>
-                                <Col md={6}>
-                                    <InputGroup>
-                                        <InputGroup.Text className="x-input-addon"><i className="bi bi-search" /></InputGroup.Text>
-                                        <Form.Control className="x-input" placeholder="With an addon..." />
-                                    </InputGroup>
-                                </Col>
-                                <Col md={6}>
-                                    <Form.Control className="x-input" placeholder="On its own..." />
-                                </Col>
-                            </Row>
-                        </section>
-
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Label / value rows</h2>
-                            <p className="styleguide-note">
-                                The value is the information and gets the emphasis; the label is chrome and stays dim.
-                            </p>
-                            <Row className="x-detail-row">
-                                <Col className="x-detail-label">Origin Planet:</Col>
-                                <Col className="x-detail-value">Grimedes</Col>
-                            </Row>
-                            <Row className="x-detail-row">
-                                <Col className="x-detail-label">Avg Height:</Col>
-                                <Col className="x-detail-value">30 in / 76 cm</Col>
-                            </Row>
-                        </section>
-
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Measure</h2>
-                            <p className="styleguide-note">
-                                Body copy is capped at <code>--x-measure</code> so it stays readable on wide screens.
-                                The lore sections used to run the full viewport, roughly 200 characters per line.
-                            </p>
-                            <div className="x-measure styleguide-measure-demo">
-                                For thousands of years, the ancient race known as the Vallerii dominated the galaxy of
-                                Xalia. With their god-like mastery of biotechnology, they birthed the first Xalians —
-                                bioengineered organisms designed to thrive in Xalia's most extreme environments.
+                            <div className="g-panel g-panel--raised">
+                                <span className="g-label">Raised</span>
+                                <p className="g-body sg-small-body">A lighter pressing, for things you act on.</p>
                             </div>
-                        </section>
+                            <div className="g-panel g-panel--recessed">
+                                <span className="g-label">Recessed</span>
+                                <p className="g-body sg-small-body">A well pressed into the hull.</p>
+                            </div>
+                        </div>
 
-                        <section className="styleguide-section">
-                            <h2 className="styleguide-heading">Empty state</h2>
-                            <p className="x-empty-state">Nothing here yet.</p>
-                        </section>
-                    </Container>
-                </Container>
-            </React.Fragment>
+                        <div className="sg-grid-2">
+                            <div className="g-panel g-panel--tagged g-el-psychic">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Tagged panel</span>
+                                    <span className="g-kicker">keyed to element</span>
+                                </div>
+                                <p className="g-body sg-small-body">
+                                    A band of the element's colour painted along the top edge. Used when a
+                                    panel belongs to a specific creature, planet or type.
+                                </p>
+                            </div>
+
+                            <div className="g-panel g-panel--bolted g-el-signal">
+                                <span className="g-label">Bolted</span>
+                                <p className="g-body sg-small-body">
+                                    Four brass fasteners, one per corner. For panels that should read as
+                                    structural rather than decorative.
+                                </p>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* ---- 04 readouts ---- */}
+                    <section id="readouts" className="sg-section">
+                        {this.renderSectionHead('04', 'Readouts',
+                            'Everything the machine reports, in its own monospaced voice. Tabular throughout, so digits line up in columns and a value that ticks upward never shoves the layout sideways. Anything phosphor-green sits behind glass; anything bone-white is printed on metal.')}
+
+                        <div className="sg-grid-2">
+                            <div className="g-panel g-el-plant">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Specification</span>
+                                    <span className="g-kicker">key / value</span>
+                                </div>
+                                <div className="g-spec">
+                                    <span className="g-spec-key">Designation</span>
+                                    <span className="g-spec-val">Kosanos</span>
+                                    <span className="g-spec-key">Index</span>
+                                    <span className="g-spec-val">#00015</span>
+                                    <span className="g-spec-key">Origin</span>
+                                    <span className="g-spec-val">Floria</span>
+                                    <span className="g-spec-key">Height</span>
+                                    <span className="g-spec-val">93 in / 236 cm</span>
+                                    <span className="g-spec-key">Mass</span>
+                                    <span className="g-spec-val">830 lbs / 376 kg</span>
+                                </div>
+                            </div>
+
+                            <div className="g-panel g-el-water">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Manifest</span>
+                                    <span className="g-kicker">tabular data</span>
+                                </div>
+                                <table className="g-data">
+                                    <thead>
+                                        <tr><th>Move</th><th>Type</th><th>Rating</th></tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr><td>Glacial Slash</td><td>Ice</td><td>12</td></tr>
+                                        <tr><td>Corrosive Impact</td><td>Chemical</td><td>7</td></tr>
+                                        <tr><td>Mighty Pinch</td><td>—</td><td>8</td></tr>
+                                        <tr><td>Poisonous Kick</td><td>Chemical</td><td>7</td></tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div className="g-panel g-panel--bolted sg-mb-lg">
+                            <div className="g-panel-head">
+                                <span className="g-label">Cathode readout</span>
+                                <span className="g-kicker">the only lit thing on the machine</span>
+                            </div>
+                            <div className="sg-screen-layout">
+                                <div className="g-screen">
+                                    <p className="g-screen-line">XALIAN GENERATOR / TELYPSO UNIT 04</p>
+                                    <p className="g-screen-line g-screen-line--dim">SCRAMBLER TOKEN ACCEPTED</p>
+                                    <p className="g-screen-line g-screen-line--dim">DECRYPTING GENOME . . . . . . OK</p>
+                                    <p className="g-screen-line">SPECIES &nbsp; HYPNOPET</p>
+                                    <p className="g-screen-line">ELEMENTS &nbsp;PSYCHIC / DARK</p>
+                                    <p className="g-screen-line g-screen-line--dim">PLAGUE IMMUNITY CONFIRMED</p>
+                                    <p className="g-screen-line">READY TO PRINT_</p>
+                                </div>
+                                <div className="g-screen g-el-ice sg-screen-figure">
+                                    <span className="g-readout">1,204</span>
+                                    <span className="g-readout-unit">stat score</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="g-panel g-el-fire">
+                            <div className="g-panel-head">
+                                <span className="g-label">Stat block</span>
+                                <span className="g-kicker">lit segments = current · dim = potential</span>
+                            </div>
+                            {STATS.map((s) => this.renderMeter(s))}
+                        </div>
+                    </section>
+
+                    {/* ---- 05 controls ---- */}
+                    <section id="controls" className="sg-section">
+                        {this.renderSectionHead('05', 'Controls',
+                            'Moulded keys that sit proud of the panel and travel when you press them. The committing action wears hazard paint, and there is only ever one on screen. Disabled reads as unpowered rather than faded, so the legend stays legible.')}
+
+                        <div className="sg-grid-2">
+                            <div className="g-panel">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Keys</span>
+                                    <span className="g-kicker">press one</span>
+                                </div>
+                                <div className="sg-btn-row">
+                                    <button className="g-btn g-btn--primary" type="button">Generate</button>
+                                    <button className="g-btn" type="button">Secondary</button>
+                                    <button className="g-btn g-btn--danger" type="button">Release</button>
+                                    <button className="g-btn" type="button" disabled>Unpowered</button>
+                                </div>
+
+                                <hr className="g-seam-rule" />
+
+                                <p className="g-kicker sg-mb">Input</p>
+                                <input className="g-input" placeholder="SEARCH THE GALAXY'S TERMS" aria-label="Demo search" />
+                            </div>
+
+                            <div className="g-panel">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Selector</span>
+                                    <span className="g-kicker">key bank</span>
+                                </div>
+                                <div className="g-segmented" >
+                                    {['grid', 'stats', 'size'].map((c) => (
+                                        <button
+                                            key={c}
+                                            
+                                            type="button"
+                                            aria-pressed={this.state.channel === c}
+                                            className="g-segment"
+                                            onClick={() => this.setState({ channel: c })}
+                                        >
+                                            {c}
+                                        </button>
+                                    ))}
+                                </div>
+                                <p className="g-body sg-small-body sg-mt">
+                                    Key <span className="g-mono">{this.state.channel}</span> is thrown. Selector keys light in hazard
+                                    paint rather than moving an underline.
+                                </p>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* ---- 06 specimen ---- */}
+                    <section id="specimen" className="sg-section">
+                        {this.renderSectionHead('06', 'Specimen',
+                            'Everything above, assembled. This is the shape most of the site should take: a creature mounted behind glass in a brass bezel, with its identity, its energy signature and its numbers printed on the plate beside it.')}
+
+                        <div className="g-panel g-panel--tagged g-el-psychic sg-specimen-card">
+                            <div className="sg-specimen-mount">
+                                <div className="g-specimen">
+                                    <div className="g-specimen-inner">
+                                        <XalianImage colored speciesName="Hypnopet" primaryType="Psychic" moreClasses="sg-specimen-img" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="sg-specimen-body">
+                                <div className="g-panel-head">
+                                    <span className="g-label">Specimen record</span>
+                                    <span className="g-lamp">Viable</span>
+                                </div>
+
+                                <h3 className="g-h2 sg-specimen-name">Hypnopet</h3>
+                                <p className="g-mono sg-specimen-id">#00028</p>
+
+                                <div className="sg-chip-row sg-mb">
+                                    <span className="g-chip g-el-psychic">Psychic</span>
+                                    <span className="g-chip g-el-dark">Dark</span>
+                                </div>
+
+                                <p className="g-body sg-small-body">
+                                    Created by the Telypso Generator as a therapy animal for the insane Vallerii
+                                    imprisoned on that world, where its empathic healing balanced the patients it
+                                    was assigned to.
+                                </p>
+
+                                <hr className="g-seam-rule" />
+
+                                {STATS.slice(0, 4).map((s) => this.renderMeter(s))}
+                            </div>
+                        </div>
+                    </section>
+
+                    <footer className="sg-footer">
+                        <span className="g-kicker">End of reference · Xalian Generator console</span>
+                    </footer>
+                </div>
+            </div>
         );
     }
 }

--- a/my-app/src/pages/trainingGroundsPage.js
+++ b/my-app/src/pages/trainingGroundsPage.js
@@ -43,8 +43,10 @@ class TrainingGroundsPage extends React.Component {
 
                     <Row className="">
                         <Col style={{ textAlign: 'center' }} >
-                            <h1 className="x-page-title">Training Grounds</h1>
-                            <p className="training-grounds-subtitle">Warm-up games while you wait for a duel.</p>
+                            <header className="page-header">
+                                <h1 className="g-title">Training Grounds</h1>
+                                <p className="training-grounds-subtitle">Warm-up games while you wait for a duel.</p>
+                            </header>
 
                             {/* was a single unlabelled bootstrap-blue "switch" button that
                                 cycled games without saying which one you were on */}


### PR DESCRIPTION
Replaces the previous token layer with a system built on an actual premise.

## The idea

This is **the control panel of a Xalian Generator**. The machine can bioengineer life on a dead world, but the empire that built it was industrial rather than futuristic — so the interface is enamelled steel, brass bezels, bakelite keys and a small green CRT bolted into the hull. **Star Wars by way of Fallout**: the capability is centuries ahead, the interface is decades behind.

Four rules:

1. **Panels are matte objects.** Depth is a bevel — light on the top edge, shadow underneath — plus rivets. No panel glows.
2. **Only screens and lamps emit.** Phosphor, scanlines and bloom live strictly inside `.g-screen`. That restraint is what makes the CRT draw the eye.
3. **Colour is energy or a warning.** The hull is olive, bone and gunmetal; the 14 element hues and the hazard livery are the only saturated things in the system.
4. **Legends are stencilled** (Oswald), **machine output is monospaced** (IBM Plex Mono, always tabular).

The element colours are carried over **untouched** — fire is red because fire is red — and `--g-el` makes them portable: put `.g-el-fire` on any container and every meter, chip and tagged panel inside retunes.

## Structure

`system.css` is the source of truth. `designTokens.js` mirrors it for recharts / GSAP / SVG, which can't read a CSS variable, and `designTokens.test.js` holds the two identical (50 tests). `tokens.css` is now a **documented temporary shim** mapping old `--x-*` names onto the new ones, so unmigrated CSS still looks right and pages move over one at a time rather than in one risky diff.

## Migrated

Navbar, buttons site-wide, glossary, species, species detail, planets, training, generator, duel start. Planet cards traded their inset glow for a painted element band. Headings became stencilled bone instead of phosphor green — green now *means* emitted light.

## Bugs found and fixed

- **Three duel components referenced `designTokens` exports this change renamed**, which white-screened the duel page. Caught by loading every route rather than assuming.
- A global uppercase heading rule was **shouting the species descriptions**, which are prose sitting in an `h6`. Uppercase now belongs to the type styles, not the element selector.
- Planet spec values were styled through `.planet-val-col h4`, a selector that **never matched** — they're `<td>`s, so they'd stayed italic Abel. They print in the mono voice now.
- `XalianInfoBox` used `class` instead of `className` on two icons, so React dropped them; `XalianMoveSet` was missing list keys.

## On "AI slop"

Nick raised this mid-build and it changed the design. The v1 tell was **everything decorated at once** — grid, vignette, scanlines, glow, chamfers, brackets, pulsing dots, a scanning sweep. Removed: the animated scan sweep over artwork, pulsing status dots, the marker glyph before every label, glow on already-prominent readouts, and chamfers on every component (the chamfer survives on the specimen mount alone). `docs/DESIGN_SYSTEM.md` records these as deliberate omissions so they don't creep back.

## Verification

Every route loaded and checked for runtime errors at 1440×900 and 390×844; console is clean apart from the expected signed-out auth message. No horizontal overflow at 390px. 50/50 tests pass, production build compiles.

## Not done

The duel **board** itself keeps its existing visual language — it's a game surface with its own rules, and restyling it is a separate piece of work. `system.css` already carries the vocabulary for it (`.g-cell`, `.g-token`, `.g-vital`) when we get there.