### PR TITLE
Fix spacing, typography leaks, and redesign the planet record

### DIFF
--- a/my-app/public/assets/css/style.css
+++ b/my-app/public/assets/css/style.css
@@ -179,8 +179,14 @@ h5,
 h6 {
   font-family: var(--g-font-stencil);
   font-weight: 600;
-  letter-spacing: var(--g-track-label);
   color: var(--g-ink);
+}
+
+/* Tracking and uppercase belong to the display sizes only. h4-h6 are used in
+   this codebase to hold prose, and tracking out a paragraph makes it harder to
+   read, not more designed. */
+h1, h2, h3 {
+  letter-spacing: var(--g-track-label);
 }
 
 /* Uppercase is applied by the .g-title / .g-h2 / .g-h3 type styles rather than
@@ -1533,29 +1539,37 @@ section {
    copy - the heading and the prose sit in different containers, so centring
    them separately left the heading floating off to one side. */
 .story-splash-section {
-  background: radial-gradient(circle, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%);
-  border: 2px solid var(--x-green-a30);
-  border-radius: var(--x-radius-lg);
-  box-shadow: var(--x-glow-inset) var(--x-green-a15);
-  padding: var(--x-space-6);
-  max-width: calc(var(--x-measure) + (2 * var(--x-space-6)));
+  /* a matte panel, like every other surface: the lore is printed on the hull,
+     it is not a lit screen */
+  background: var(--g-hull);
+  border: var(--g-hairline) solid var(--g-seam);
+  border-radius: var(--g-radius-panel);
+  box-shadow: var(--g-relief), var(--g-drop);
+  padding: var(--g-7) var(--g-6);
+  max-width: calc(var(--g-measure) + (2 * var(--g-6)));
   margin-left: auto;
   margin-right: auto;
 }
 
 .story-splash-section h3 {
-  margin-bottom: var(--x-space-5);
-  color: var(--x-green);
+  margin-bottom: var(--g-5);
+  color: var(--g-ink);
+  text-transform: uppercase;
+  letter-spacing: var(--g-track-label);
 }
 
 .story-text {
-  color: var(--x-text-muted);
-  font-weight: lighter !important;
+  color: var(--g-ink-mid);
+  font-weight: 400 !important;
   /* was a Segoe UI stack, the only place on the site that broke from the
      body font - the lore read like it came from a different product */
-  font-family: var(--x-font-body);
-  line-height: 1.6;
-  margin-bottom: var(--x-space-4);
+  font-family: var(--g-font-ui);
+  font-size: var(--g-size-body);
+  /* explicitly reset: this is a paragraph that happens to sit in an h6 */
+  letter-spacing: normal;
+  text-transform: none;
+  line-height: 1.7;
+  margin-bottom: var(--g-4);
 }
 
 
@@ -2386,6 +2400,7 @@ article {
   font-size: var(--g-size-small);
   font-style: normal;
   text-align: left !important;
+  width: 60%;
 }
 
 .planet-table tbody * th {
@@ -2538,15 +2553,23 @@ article {
   padding-bottom: 12px !important;
 }
 
+/* the catalogue index is machine output, the name is a stencilled legend */
 .species-col h6 {
-  color: lightgrey;
-  opacity: 0.75;
-  font-style: italic;
+  font-family: var(--g-font-mono);
+  font-size: var(--g-size-micro);
+  font-style: normal;
+  letter-spacing: normal;
+  color: var(--g-ink-low);
+  opacity: 1;
 }
 
 .species-col h5 {
-  color: white;
-
+  font-family: var(--g-font-stencil);
+  font-size: var(--g-size-body);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--g-track-label);
+  color: var(--g-ink);
 }
 
 .species-name-title {
@@ -2777,8 +2800,14 @@ article {
 }
 
 .glossary-result-count {
-  text-align: right;
+  text-align: left;
   margin: var(--g-2) 0 var(--g-6) 0;
+}
+
+/* a definition is prose: cap it so it does not run 140 characters wide on a
+   large monitor */
+.g-record-body {
+  max-width: var(--g-measure);
 }
 
 /* Shared page scaffolding for every migrated page. */
@@ -3895,47 +3924,123 @@ input, textarea {
   text-align: center;
 }
 
-/* Planet record panels */
+/* Planetary survey record ------------------------------------------------- */
+
 .planet-panel {
   margin-bottom: var(--g-6);
-  padding: var(--g-5) var(--g-4);
+  padding: var(--g-6);
 }
 
-.planet-panel .planet-key-col,
-.planet-panel .planet-val-col {
-  border: 0;
+.planet-record {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) 1fr;
+  gap: var(--g-8);
+  align-items: center;
 }
 
-.planet-panel .planet-key-col h4 {
-  font-family: var(--g-font-stencil);
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: var(--g-track-label);
-  color: var(--g-ink-low);
-  font-size: var(--g-size-small);
+/* the photographic plate: the world itself, mounted in a brass bezel */
+.planet-record-plate {
+  position: relative;
 }
 
-.planet-panel .planet-val-col h4 {
-  font-family: var(--g-font-mono);
-  font-size: var(--g-size-small);
-  font-style: normal;
-  color: var(--g-ink);
+.planet-plate {
+  padding: 6px;
+  background: linear-gradient(160deg, var(--g-hull-hi), var(--g-hull));
+  border: 2px solid var(--g-brass-dark);
+  border-radius: var(--g-radius-housing);
+  box-shadow: var(--g-relief), var(--g-drop);
 }
 
-.planet-panel .planet-history-link {
-  font-family: var(--g-font-stencil);
-  text-transform: uppercase;
-  letter-spacing: var(--g-track-label);
-  color: var(--g-ink-mid);
-  font-style: normal;
+.planet-plate-img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: var(--g-radius);
+  box-shadow: var(--g-recess);
 }
 
-.planet-panel .planet-history-link:hover {
-  color: var(--g-hazard);
+/* the rendered globe, pinned over the corner of the plate as a locator */
+.planet-globe {
+  position: absolute;
+  left: calc(-1 * var(--g-5));
+  bottom: calc(-1 * var(--g-4));
+  width: 38%;
+  max-width: 130px;
+  object-fit: contain;
+  filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.8));
 }
+
+.planet-record-body {
+  min-width: 0;
+}
+
+.planet-record-name {
+  margin: var(--g-1) 0 var(--g-3) 0;
+}
+
+.planet-spec {
+  margin: var(--g-5) 0 var(--g-5) 0;
+  grid-template-columns: minmax(6rem, 10rem) 1fr;
+  gap: var(--g-2) var(--g-5);
+  max-width: 34rem;
+}
+
+.planet-spec dd {
+  margin: 0;
+}
+
+.planet-story-btn {
+  margin-top: 0;
+}
+
+@media (max-width: 767px) {
+  .planet-record {
+    grid-template-columns: 1fr;
+    gap: var(--g-7);
+  }
+
+  .planet-globe {
+    left: auto;
+    right: calc(-1 * var(--g-2));
+    bottom: calc(-1 * var(--g-4));
+    width: 30%;
+  }
+}
+
 
 /* the training page composes its own header, so it needs the same clearance
    under the sticky console header that .template-col-wrapper provides */
 .page-header {
   padding-top: var(--g-7);
+}
+
+/* trailing margin on the last paragraph makes a panel look bottom-heavy */
+.story-splash-section .story-text:last-child,
+.g-panel > p:last-child,
+.planet-panel .planet-table {
+  margin-bottom: 0;
+}
+
+/* the badge centres itself by default (it sits alone in a column elsewhere);
+   in a left-aligned record it has to sit under the name */
+.planet-record-body .xalian-species-badge {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+@media (max-width: 575px) {
+  /* a 10rem label column leaves the values almost no room on a phone */
+  .planet-spec {
+    grid-template-columns: 1fr;
+    gap: 0 0;
+  }
+
+  .planet-spec .g-spec-key {
+    margin-top: var(--g-3);
+  }
+
+  .planet-spec .g-spec-val {
+    margin-bottom: 0;
+  }
 }

--- a/my-app/public/assets/css/system.css
+++ b/my-app/public/assets/css/system.css
@@ -351,10 +351,40 @@
 	}
 }
 
-/* Keyed to an element: a painted colour band along the top edge. The panel
-   stays matte metal — the machine does not light up because a specimen is
-   psychic. */
-.g-panel--tagged { border-top: 3px solid var(--g-el); }
+/* Keyed to an element.
+   This was a coloured strip across the top edge, which is the house style of
+   every dashboard card ever made and said nothing about this machine. It is now
+   painted livery: a corner flash sprayed onto the plate, the way a unit marking
+   or a hazard classification is applied to real equipment. Drawn as a
+   background so the panel's rounded corner clips it for free. */
+.g-panel--tagged {
+	background-image:
+		linear-gradient(135deg,
+			var(--g-el) 0 40px,
+			var(--g-seam) 40px 43px,
+			transparent 43px);
+	background-size: 72px 72px;
+	background-position: top left;
+	background-repeat: no-repeat;
+}
+
+/* The element's designation, stencilled onto the plate beside the flash.
+   Set data-tag on the panel to print it. */
+.g-panel--tagged[data-tag] { position: relative; }
+
+.g-panel--tagged[data-tag]::after {
+	content: attr(data-tag);
+	position: absolute;
+	top: var(--g-3);
+	left: 56px;
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-micro);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-wide);
+	color: var(--g-ink-low);
+	pointer-events: none;
+}
 
 /* -------------------------------------------------------------------------
    SCREEN

--- a/my-app/src/components/planetTable.js
+++ b/my-app/src/components/planetTable.js
@@ -1,26 +1,21 @@
 import React from 'react'
 import Container from 'react-bootstrap/Container';
-import Row from 'react-bootstrap/Row';
-import Col from 'react-bootstrap/Col';
-import Button from 'react-bootstrap/Button';
-import ListGroup from 'react-bootstrap/ListGroup';
-import Badge from 'react-bootstrap/Badge';
 import TextReaderModal from '../components/textReaderModal';
-import * as constants from '../constants/colorConstants';
-import * as styleUtil from '../utils/styleUtil';
 import { Hub } from 'aws-amplify';
 import XalianSpeciesBadge from './xalianSpeciesBadge';
 
+/**
+ * A planetary survey record.
+ *
+ * Laid out as a dossier rather than a three-column card: one photographic plate
+ * carrying the world, the rendered globe pinned to it as a subordinate locator,
+ * and the record itself printed alongside. The previous version put the globe
+ * and the landscape side by side at equal weight, so the two images competed
+ * and the specs floated in the gap between them.
+ */
 class PlanetTable extends React.Component {
 
   state = { showing: false }
-
-  buildRow(key, val) {
-    return <tr>
-      <th scope="row">{key}:</th>
-      <td>{val}</td>
-    </tr>
-  }
 
   toggleShowHistory = () => {
     if (!this.state.showing) {
@@ -37,95 +32,89 @@ class PlanetTable extends React.Component {
   }
 
   getHistoryParagraphs(history) {
-    let images = ["assets/img/background/castle.jpg", "assets/img/background/castle.jpg", "assets/img/background/castle.jpg"]
     var result = [];
     var tempImage = null;
-    history.forEach(para => {
+    history.forEach((para, i) => {
       if (tempImage) {
-        result.push(<p>{para} <img src={tempImage} style={{ float: 'left', maxWidth: '25vw', width: '100px', padding: '5px' }} /></p>);
+        result.push(<p key={i}>{para} <img src={tempImage} alt="" style={{ float: 'left', maxWidth: '25vw', width: '100px', padding: '5px' }} /></p>);
         tempImage = null;
       } else if (para.toString().includes('IMAGE_INSERT:')) {
         tempImage = para.replace('IMAGE_INSERT:', '');
       } else {
-        result.push(<p>{para}</p>);
+        result.push(<p key={i}>{para}</p>);
       }
     });
     return result;
   }
 
-
-
-  render() {
-    let list = [];
+  buildSpecs() {
+    let pairs = [];
     for (const key in this.props.planet.data) {
-      let val = this.props.planet.data[key];
-      if (key.toLowerCase() != 'type') {
-        list.push(this.buildRow(key, val));
+      if (key.toLowerCase() !== 'type') {
+        pairs.push(
+          <React.Fragment key={key}>
+            <dt className="g-spec-key">{key}</dt>
+            <dd className="g-spec-val">{this.props.planet.data[key]}</dd>
+          </React.Fragment>
+        );
       }
     }
-
-    return (
-		<React.Fragment>
-			{/* a panel is matte metal: the element shows as a painted band along the
-			    top edge rather than as a glow bleeding out of the card */}
-			<Container className={`g-panel g-panel--tagged g-el-${this.props.planet.data.Type.toLowerCase()} planet-panel`} >
-				<Row className="planet-details-row vertically-center-contents">
-					<Col xs={12} md={3} className="planet-details-row-col">
-						<img src={this.props.planet.planetImage} class="planet-gif" alt=""></img>
-					</Col>
-					<Col xs={12} md={6} className="planet-description-col">
-						<Row className="planet-title-row">
-							<Col xs={12}>
-								{/* a planet name is stencilled on the plate, not glowing */}
-								<h2 className="g-h2">{this.props.planet.name}</h2>
-							</Col>
-                <Col xs={12}>
-                  <XalianSpeciesBadge type={this.props.planet.data.Type.toLowerCase()} />
-								</Col>
-							{this.props.planet.history && this.props.planet.history.length > 0 && (
-								<Col xs={12}>
-									<h6 className="planet-history-link" onClick={this.toggleShowHistory}>
-										<i class="bi bi-book"> </i><span style={{ fontStyle: 'italic', textDecoration: 'underline' }}>Read the Story of {this.props.planet.name}</span>
-									</h6>
-								</Col>
-							)}
-						</Row>
-            {/* <Row style={{ marginBottom: '10px' }} >
-            </Row> */}
-						<div class="planet-table">
-							<table class="planet-table">
-								<tbody>{list}</tbody>
-							</table>
-						</div>
-					</Col>
-					<Col xs={12} md={3} className="planet-details-row-col">
-						<img src={this.props.planet.image} className="planet-img img-fluid" alt=""></img>
-					</Col>
-				</Row>
-
-				{/* <Row className="planet-details-row vertically-center-contents">
-            {this.getPlanetHistory()}
-        </Row> */}
-			</Container>
-
-			{this.props.planet.history && 
-        <TextReaderModal 
-          title={'The History of ' + this.props.planet.name} 
-          body={this.getHistoryParagraphs(this.props.planet.history)} 
-          show={this.state.showing}
-          light
-          onHide={this.hideHistory}>
-        </TextReaderModal>
-      }
-		</React.Fragment>
-	);
+    return pairs;
   }
 
-  
-  
+  render() {
+    let type = this.props.planet.data.Type.toLowerCase();
+    let hasHistory = this.props.planet.history && this.props.planet.history.length > 0;
+
+    return (
+      <React.Fragment>
+        {/* the corner flash keys the card to its element; the badge below
+            already names it, so the panel does not repeat it with data-tag */}
+        <Container className={`g-panel g-panel--tagged g-el-${type} planet-panel`}>
+          <div className="planet-record">
+
+            <div className="planet-record-plate">
+              <div className="planet-plate">
+                <img className="planet-plate-img" src={this.props.planet.image} alt="" />
+              </div>
+              {/* the globe is a locator pinned to the plate, not a second hero image */}
+              <img className="planet-globe" src={this.props.planet.planetImage} alt="" />
+            </div>
+
+            <div className="planet-record-body">
+              <p className="g-kicker">Survey Record</p>
+              <h2 className="g-h2 planet-record-name">{this.props.planet.name}</h2>
+
+              <XalianSpeciesBadge type={type} />
+
+              <dl className="g-spec planet-spec">
+                {this.buildSpecs()}
+              </dl>
+
+              {hasHistory && (
+                <button type="button" className="g-btn planet-story-btn" onClick={this.toggleShowHistory}>
+                  <i className="bi bi-book" /> Read the story
+                </button>
+              )}
+            </div>
+
+          </div>
+        </Container>
+
+        {this.props.planet.history &&
+          <TextReaderModal
+            title={'The History of ' + this.props.planet.name}
+            body={this.getHistoryParagraphs(this.props.planet.history)}
+            show={this.state.showing}
+            light
+            onHide={this.hideHistory}>
+          </TextReaderModal>
+        }
+      </React.Fragment>
+    );
+  }
+
 }
 
 
-
 export default PlanetTable;
-

--- a/my-app/src/pages/glossaryPage.js
+++ b/my-app/src/pages/glossaryPage.js
@@ -60,8 +60,8 @@ class GlossaryPage extends React.Component {
                         <h1 className="g-title">Glossary</h1>
                     </header>
 
-                    <Row className="justify-content-center">
-                        <Col md={7} lg={6}>
+                    <Row>
+                        <Col md={7} lg={5}>
                             {/* the search field is a screen, so it reads as phosphor on glass */}
                             <Form.Control
                                 type="search"

--- a/my-app/src/pages/styleGuidePage.js
+++ b/my-app/src/pages/styleGuidePage.js
@@ -235,14 +235,15 @@ class StyleGuidePage extends React.Component {
                         </div>
 
                         <div className="sg-grid-2">
-                            <div className="g-panel g-panel--tagged g-el-psychic">
+                            <div className="g-panel g-panel--tagged g-el-psychic" data-tag="Psychic">
                                 <div className="g-panel-head">
                                     <span className="g-label">Tagged panel</span>
                                     <span className="g-kicker">keyed to element</span>
                                 </div>
                                 <p className="g-body sg-small-body">
-                                    A band of the element's colour painted along the top edge. Used when a
-                                    panel belongs to a specific creature, planet or type.
+                                    Livery: a corner flash sprayed onto the plate, optionally with the
+                                    designation stencilled beside it. Used when a panel belongs to a
+                                    specific creature, planet or type.
                                 </p>
                             </div>
 


### PR DESCRIPTION
Nick asked whether I'd done a full visual pass. **I hadn't** — the earlier checks were spot screenshots plus programmatic overflow and console checks. Those catch broken pages; they say nothing about rhythm, vertical balance or how prose actually reads. This is the pass I should have done, and what it found.

## Typography leaks

- **The global `h1–h6` rule was applying stencil letter-spacing to every heading tag** — and several places in this codebase use a heading tag to hold a paragraph. The home lore was being tracked out by 1.92px per character. Tracking and uppercase now belong to the display type styles, not the element selector.
- **The home lore panel was still on the old system**: green inset glow, green border, phosphor-green heading — all three break the rule that only screens emit light. It's a matte panel now.
- Species tile names were mixed-case body font sitting next to stencilled caps everywhere else.

## Spacing

- **Planet panels collected a dead band at the bottom**, because the three columns were different heights and top-aligned. Centred; padding now measures 35/33 instead of 25/47.
- **Glossary definitions ran ~140 characters** on a wide monitor with no measure cap, and the search block was centred while the page header was left-aligned, so the two read as belonging to different layouts.

## The tagged panel

The element strip across the top of a card is the house style of every dashboard ever made and said nothing about this machine. It's now **painted livery** — a corner flash sprayed onto the plate, with an optional stencilled designation via `data-tag`. On the planet cards the corner text is omitted, because the element badge below already names it.

## The planet card, rebuilt

It was three columns with no hierarchy: the rendered globe and the landscape art sat at equal weight and competed for the same job, while the spec table floated in the gap between them.

Now it's a **survey record** — one photographic plate in a brass bezel carrying the world, the globe pinned to its corner as a subordinate locator, and the record alongside: designation → name → element → specs (as a real spec grid) → a key to open the history. The italic underlined text link became a proper button. Specs stack on phones instead of squeezing the values into a narrow column.

## Verification

Full-page passes at 1584×940 and 390×844 across home, species, species detail, planets, glossary, generator, duel, training and the style guide. Padding and gaps measured programmatically rather than eyeballed. No horizontal overflow at 390px. 50/50 tests pass; build compiles.