### PR TITLE
Chore: point CI/CD workflows and docs at main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -2,7 +2,7 @@ name: Deploy backend
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "lambda/**"
       - "main.tf"
@@ -13,7 +13,7 @@ on:
   # no paths filter on PRs: "Terraform plan" is a required status check for
   # auto-merge, so it must run (and pass) on every PR
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -2,7 +2,7 @@ name: Deploy frontend
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "my-app/**"
       - "lambda/src/json/**"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ There is no test suite for the `lambda/` engine — verification is done by runn
 - File out-of-scope findings as issues immediately (labels: one of `P1`/`P2`/`P3` + type + area); don't park them in chat or docs.
 - Reference tickets from PRs with `Fixes #N` so merges auto-close them.
 - "Work the backlog" means P1s first; `question`-labeled issues need Nick's answer before implementation.
-- CI/CD is fully automated: PRs run frontend build + terraform plan (both required checks on `master`); merging auto-deploys frontend (S3+CloudFront) and backend (terraform apply). Auto-merge on green is enabled — open the PR, run `gh pr merge <n> --auto --merge`, done. Never run `aws s3 sync` or `terraform apply` manually unless CI is broken.
+- CI/CD is fully automated: PRs run frontend build + terraform plan (both required checks on `main`); merging auto-deploys frontend (S3+CloudFront) and backend (terraform apply). Auto-merge on green is enabled — open the PR, run `gh pr merge <n> --auto --merge`, done. Never run `aws s3 sync` or `terraform apply` manually unless CI is broken.
 - `docs/AUDIT_FINDINGS.md` is a historical record of the 2026-08-29 audit; its open items were migrated to issues.
 
 ## Architecture


### PR DESCRIPTION
Follow-up to renaming the repository's default branch from \`master\` to \`main\`.

The branch rename itself was done through GitHub's branch-rename API, which moved the branch, carried the protection rules and both required status checks (\`Build frontend\`, \`Terraform plan\`) across, retargeted the open PRs (#62, #63), and set the repo default to \`main\`. This PR updates the things the rename does not touch: the workflow triggers and the docs.

## Changes

- \`.github/workflows/ci.yml\` — \`pull_request\` filter now \`[main]\`
- \`.github/workflows/deploy-backend.yml\` — both \`push\` and \`pull_request\` filters now \`[main]\`
- \`.github/workflows/deploy-frontend.yml\` — \`push\` filter now \`[main]\`
- \`CLAUDE.md\` — the operational line about required checks now says \`main\`

## Deliberately unchanged

- The \`Project status (2026)\` paragraph in \`CLAUDE.md\` still says \`master\`. It narrates what happened to the branch in Aug 2026, when it was in fact named \`master\`; rewriting it would make the historical record wrong.
- \`docs/design/vite-migration-plan.md\` — a completed plan doc describing work already merged, so its \`master\` references are likewise historical.
- \`master\` as ordinary English elsewhere in the tree ("master limited partnership" in \`planets.json\`, "game master" in the duel sources).

## Verification

Merging this is itself the test: this PR runs against the \`main\` base, so both required checks firing and passing here confirms the new triggers are wired correctly.