### PR TITLE
Reclamation: first-match fixes

### DIFF
--- a/my-app/src/components/games/reclamation/__tests__/reclamationNarration.test.js
+++ b/my-app/src/components/games/reclamation/__tests__/reclamationNarration.test.js
@@ -143,16 +143,16 @@ describe('narrateJudge', () => {
 describe('narrateMatchEnd', () => {
 	it('names the reason a clinch ended it', () => {
 		expect(narrateMatchEnd({ winner: 'A', you: 'A', sitesYou: 5, sitesThem: 2, reason: 'clinched' }))
-			.toBe('You take the Charter, 5 sites to 2, with clinched at five sites.');
+			.toBe('You take the Charter, 5 sites to 2, clinched at five sites.');
 	});
 
 	it('says "1 site", not "1 sites"', () => {
 		expect(narrateMatchEnd({ winner: 'A', you: 'A', sitesYou: 1, sitesThem: 0, reason: 'worlds-exhausted' }))
-			.toBe('You take the Charter, 1 site to 0, with the third world exhausted.');
+			.toBe('You take the Charter, 1 site to 0, after the third world.');
 	});
 
 	it('names the loss', () => {
 		expect(narrateMatchEnd({ winner: 'B', you: 'A', sitesYou: 3, sitesThem: 4, reason: 'worlds-exhausted' }))
-			.toBe('The rival takes the Charter, 4 sites to 3, with the third world exhausted.');
+			.toBe('The rival takes the Charter, 4 sites to 3, after the third world.');
 	});
 });

--- a/my-app/src/components/games/reclamation/__tests__/reclamationPreview.test.js
+++ b/my-app/src/components/games/reclamation/__tests__/reclamationPreview.test.js
@@ -181,7 +181,7 @@ describe('area acts', () => {
 			magnitude: 8,
 			publicState: view,
 		});
-		expect(sentence).toContain('catching everything standing there, both sides');
+		expect(sentence).toMatch(/catching [0-9]+ enem(y|ies)/);
 		expect(sentence).toContain(view.world.sites[0].name);
 		expect(sentence).not.toMatch(/undefined/);
 	});

--- a/my-app/src/components/games/reclamation/reclamationLog.js
+++ b/my-app/src/components/games/reclamation/reclamationLog.js
@@ -8,7 +8,7 @@ function ReclamationLog({ lines }) {
 	return (
 		<div className="g-screen rec-log" aria-label="Expedition log">
 			<div className="g-readout-unit">Log</div>
-			{lines.length === 0 && <div className="g-screen-line--dim">The expedition has not begun.</div>}
+			{lines.length === 0 && <div className="g-screen-line--dim">Nothing has happened yet. The first send opens the record.</div>}
 			{lines.slice().reverse().map((line, i) => (
 				<div className={`g-screen-line${i === 0 ? '' : ' g-screen-line--dim'}`} key={`${lines.length - i}`}>{line}</div>
 			))}

--- a/my-app/src/components/games/reclamation/reclamationMatch.js
+++ b/my-app/src/components/games/reclamation/reclamationMatch.js
@@ -946,7 +946,7 @@ class ReclamationMatch extends React.Component {
 			? 'clinched at five sites'
 			: view.players[YOU].sitesWon === view.players[THEM].sitesWon
 				? 'level on sites and settled on the tiebreak'
-				: 'the third world exhausted';
+				: 'after the third world';
 		return (
 			<div className={`g-panel rec-verdict ${won ? 'rec-verdict--won' : 'rec-verdict--lost'}`} data-verdict>
 				<span className="g-kicker">The Charter</span>

--- a/my-app/src/components/games/reclamation/reclamationNarration.js
+++ b/my-app/src/components/games/reclamation/reclamationNarration.js
@@ -211,13 +211,13 @@ export function narrateMatchEnd(ctx = {}) {
 		? 'clinched at five sites'
 		: reason === 'tiebreak'
 			? 'settled on the tiebreak'
-			: 'the third world exhausted';
+			: 'after the third world';
 	const sites = (n) => `${n} site${n === 1 ? '' : 's'}`;
 	if (winner === you) {
-		return `You take the Charter, ${sites(sitesYou)} to ${sitesThem}, with ${why}.`;
+		return `You take the Charter, ${sites(sitesYou)} to ${sitesThem}, ${why}.`;
 	}
 	if (winner) {
-		return `The rival takes the Charter, ${sites(sitesThem)} to ${sitesYou}, with ${why}.`;
+		return `The rival takes the Charter, ${sites(sitesThem)} to ${sitesYou}, ${why}.`;
 	}
 	return `The expedition ends level, ${sitesYou} to ${sitesThem}.`;
 }

--- a/my-app/src/components/games/reclamation/reclamationPreview.js
+++ b/my-app/src/components/games/reclamation/reclamationPreview.js
@@ -354,15 +354,33 @@ export function previewSentence({ unit, action, act, actClass, target, magnitude
 		return `${who} would ${action}, but finds ${clause} nowhere ${where}.`;
 	}
 	const targetHold = formatHold(livingHold(target, publicState));
-	const forN = typeof magnitude === 'number' ? ` for ${magnitude}` : '';
+	// the orders panel prints the act's own magnitude; against this target the matchup
+	// may scale it, so say both or the two numbers look like a contradiction
+	const base = act && typeof act.magnitude === 'number' ? act.magnitude : null;
+	const scaled = typeof magnitude === 'number' && base !== null && base !== magnitude ? ` (${base} before the matchup)` : '';
+	const forN = typeof magnitude === 'number' ? ` for ${magnitude}${scaled}` : '';
 	// an area act does not choose a creature, it chooses the site with the most standing
 	// on it and catches both sides there (expeditionRules.pickAreaTargetSite), so the
 	// sentence has to name the site rather than a target.
 	if (AREA_ACTIONS.includes(action)) {
 		const siteName = pickAreaSitePreview(publicState, unit);
-		return siteName
-			? `${who} ${actVerbPhrase(action)} ${siteName}, catching everything standing there, both sides, for ${magnitude}.`
-			: `${who} would ${action}, but there is nothing on the world to catch.`;
+		if (!siteName) {
+			return `${who} would ${action}, but there is nothing on the world to catch.`;
+		}
+		// name your own creatures in the blast: the cost of an area act is the thing a
+		// handler most needs to see before giving the order
+		const site = publicState.world.sites.find((s) => s.name === siteName);
+		const opponent = OTHER[unit.seat];
+		const enemies = (publicState.board[site.id][opponent] || []).filter((e) => e.record).length;
+		const allies = (publicState.board[site.id][unit.seat] || [])
+			.filter((e) => e.record && e.record.id !== unit.record.id)
+			.map((e) => speciesLabel(e.record));
+		const enemyClause = `${enemies} enem${enemies === 1 ? 'y' : 'ies'}`;
+		const allyClause = allies.length > 0 ? ` and your own ${allies.join(', ')}` : '';
+		// magnitude scales per creature caught, so the area sentence gives the act's own
+		// number rather than one victim's
+		const baseMag = act && typeof act.magnitude === 'number' ? act.magnitude : magnitude;
+		return `${who} ${actVerbPhrase(action)} ${siteName}, catching ${enemyClause}${allyClause}, at magnitude ${baseMag} before each matchup.`;
 	}
 	return `${who} ${actVerbPhrase(action)} ${clause} ${where}: ${speciesLabel(target.record)}, hold ${targetHold}${forN}.`;
 }

--- a/my-app/src/components/games/reclamation/reclamationRoster.js
+++ b/my-app/src/components/games/reclamation/reclamationRoster.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReclamationFigure, { ReclamationSilhouette } from './reclamationFigure';
+import { baseHold } from '../../../gameplay/expedition/creatureOnTable';
 
 /*
 	ReclamationRoster — the strip of figures waiting to be sent, plus the rival's hidden
@@ -32,6 +33,7 @@ function ReclamationRoster({
 						you={you}
 						facing="up"
 						size="small"
+						hold={baseHold(record)}
 						armed={armedRecordId === record.id}
 						dimmed={disabled}
 						onClick={(e) => {


### PR DESCRIPTION
## Summary

Fixes from playing a full match at /reclamation as a handler:

- Roster figures print their base hold, so creatures can be compared at a glance.
- The resolution preview notes when the matchup scales an act's magnitude, names your own creatures caught in an area act, and quotes the act's own magnitude for areas instead of one victim's.
- The match-end sentence no longer reads "with clinched at five sites".
- The empty log says the first send opens the record instead of claiming the expedition has not begun.

## Verification

- `yarn test --run`: 305 tests pass.
- Checked on the local table: roster holds render, the area preview names the enemies caught, the log opens cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)