### PR TITLE
CI: trigger backend deploy on any root-level .tf file

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -5,9 +5,10 @@ on:
     branches: [main]
     paths:
       - "lambda/**"
-      - "main.tf"
-      - "variables.tf"
-      - "outputs.tf"
+      # glob rather than a list of filenames: a new root-level .tf file must
+      # trigger the apply that manages it. github-oidc.tf was added in #66 and
+      # would not have deployed under the old explicit list.
+      - "*.tf"
       - "terraform/**"
       - ".github/workflows/deploy-backend.yml"
   # no paths filter on PRs: "Terraform plan" is a required status check for


### PR DESCRIPTION
Found while verifying #66. A gap that PR introduced.

## The problem

`deploy-backend.yml`'s push `paths` filter listed the Terraform files by name:

```yaml
- "main.tf"
- "variables.tf"
- "outputs.tf"
```

`github-oidc.tf`, added in #66, matches none of them. So that file — which manages the IAM role CI authenticates with — was invisible to the deploy trigger. A change to it would merge and never apply.

That is the same class of problem that broke deploys during the `master` -> `main` rename: configuration that governs CI, living somewhere CI does not look.

## The fix

Replaces the explicit list with a `*.tf` glob. GitHub path globs are **not** recursive, so `*.tf` matches root-level files only — the same scope as the three names it replaces, plus any new one. All four current root files (`main.tf`, `variables.tf`, `outputs.tf`, `github-oidc.tf`) are covered.

`terraform/**` and `lambda/**` are unchanged.

## Note

#66 itself did not strand anything: `github-oidc.tf` is on `main` and I dispatched a manual `Deploy backend` to confirm the state reconciles. This PR only ensures the *next* change to a root `.tf` file deploys on its own.