### PR TITLE
Reclamation: UX pass, emphasis and affordances

### DIFF
--- a/my-app/public/assets/css/reclamation.css
+++ b/my-app/public/assets/css/reclamation.css
@@ -699,10 +699,10 @@
 	flex-direction: column;
 	gap: var(--g-2);
 	min-height: 0;
-	/* the orders panel is the working surface during Orders: it takes two thirds of the
-	   rail and the log takes what is left, both scrolling internally rather than pushing
-	   the page taller */
-	flex: 2 1 0;
+	/* the orders panel is the working surface during Orders: it takes three quarters of
+	   the rail and the log takes what is left, both scrolling internally rather than
+	   pushing the page taller */
+	flex: 3 1 0;
 	overflow: hidden;
 }
 
@@ -966,4 +966,443 @@
 
 	.rec-orders-list { padding: var(--g-2); }
 	.rec-log { padding: var(--g-1) var(--g-2); }
+}
+
+/* =========================================================================
+   UX PASS — emphasis, affordances, and what-is-happening
+   ========================================================================= */
+
+/* --- status strip: score as pip tracks, the turn as the loudest thing --- */
+
+.rec-world-dots {
+	display: inline-flex;
+	gap: 4px;
+	align-items: center;
+}
+
+.rec-world-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	border: var(--g-hairline) solid var(--g-ink-low);
+	background: transparent;
+}
+
+.rec-world-dot--done { background: var(--g-ink-low); }
+.rec-world-dot--now { background: var(--g-el); border-color: var(--g-el); }
+
+.rec-score {
+	flex-direction: row;
+	align-items: center;
+	gap: var(--g-2);
+}
+
+.rec-pips {
+	display: inline-flex;
+	gap: 3px;
+}
+
+.rec-pip {
+	width: 14px;
+	height: 14px;
+	border-radius: 2px;
+	border: var(--g-hairline) solid var(--g-seam);
+	background: var(--g-hull-lo);
+	box-shadow: var(--g-recess);
+}
+
+.rec-score--mine .rec-pip--lit { background: var(--g-hazard); border-color: var(--g-hazard); box-shadow: none; }
+.rec-score--theirs .rec-pip--lit { background: var(--g-lamp-red); border-color: var(--g-lamp-red); box-shadow: none; }
+
+.rec-score-value { font-size: var(--g-size-lead); }
+
+.rec-turn--yours .rec-turn-text {
+	color: var(--g-hazard);
+	font-weight: 600;
+}
+
+.rec-turn--waiting .rec-turn-text { color: var(--g-ink-mid); }
+
+.rec-status-hint {
+	font-size: var(--g-size-body);
+	color: var(--g-ink);
+}
+
+.rec-status-hint--yours {
+	color: var(--g-ink);
+	padding-left: var(--g-3);
+	border-left: 3px solid var(--g-hazard);
+}
+
+/* --- sites: the margin band is the biggest number on the site --- */
+
+.rec-site-margin {
+	flex: 0 0 auto;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 1px;
+	padding: var(--g-2);
+	background: var(--g-hull-lo);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-recess);
+	border-left: 3px solid var(--g-seam);
+}
+
+.rec-site-margin-text {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-small);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-ink-low);
+}
+
+.rec-site-margin--mine { border-left-color: var(--g-hazard); }
+.rec-site-margin--mine .rec-site-margin-text { color: var(--g-hazard); }
+.rec-site-margin--theirs { border-left-color: var(--g-lamp-red); }
+.rec-site-margin--theirs .rec-site-margin-text { color: var(--g-lamp-red); }
+
+.rec-site-margin-totals {
+	display: inline-flex;
+	gap: var(--g-2);
+	font-size: var(--g-size-micro);
+	font-variant-numeric: tabular-nums;
+	color: var(--g-ink-mid);
+}
+
+.rec-site-margin-vs {
+	color: var(--g-ink-low);
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	font-size: 0.5625rem;
+}
+
+/* a site you are winning, losing, or that is level: a quiet tint on the panel edge */
+.rec-site--mine { border-top: 3px solid color-mix(in srgb, var(--g-hazard) 60%, var(--g-seam)); }
+.rec-site--theirs { border-top: 3px solid color-mix(in srgb, var(--g-lamp-red) 50%, var(--g-seam)); }
+
+/* a site waiting for the armed creature: an obvious target, not a hairline */
+.rec-site--targeted {
+	border-color: var(--g-hazard);
+	box-shadow: var(--g-relief), 0 0 0 1px color-mix(in srgb, var(--g-hazard) 45%, transparent);
+	cursor: pointer;
+}
+
+.rec-site--targeted:hover { background: color-mix(in srgb, var(--g-hazard) 6%, var(--g-hull)); }
+
+.rec-site-midline { min-height: 30px; }
+
+.rec-ghost {
+	flex-wrap: wrap;
+	justify-content: center;
+	row-gap: 2px;
+}
+
+.rec-ghost-cta {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-micro);
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-wide);
+	color: var(--g-hazard);
+	padding: 1px var(--g-2);
+	border: var(--g-hairline) solid var(--g-hazard);
+	border-radius: 2px;
+}
+
+.rec-ghost-value { font-size: var(--g-size-body); color: var(--g-ink); }
+
+.rec-ghost-outcome {
+	flex-basis: 100%;
+	text-align: center;
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-micro);
+	color: var(--g-ink-mid);
+}
+
+/* --- the hidden rival creature: a banner over the world, not a roster orphan --- */
+
+.rec-world {
+	display: flex;
+	flex-direction: column;
+	gap: var(--g-2);
+}
+
+.rec-sites {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: var(--g-3);
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+.rec-hidden-banner {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	gap: var(--g-3);
+	padding: var(--g-1) var(--g-3);
+	background: var(--g-hull-lo);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-recess);
+	border-left: 3px solid var(--g-lamp-red);
+}
+
+.rec-hidden-banner .rec-figure { zoom: 0.7; }
+
+.rec-hidden-banner-text {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-tiny);
+	color: var(--g-ink);
+}
+
+/* --- figures: hold is big, the element is named, states are labelled --- */
+
+.rec-figure-hold { font-size: var(--g-size-small); }
+
+.rec-figure-element {
+	font-family: var(--g-font-stencil);
+	font-size: 0.5625rem;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+	color: var(--g-el);
+	margin-left: var(--g-1);
+}
+
+.rec-figure-foot {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 2px;
+}
+
+.rec-figure-badge {
+	display: block;
+	font-family: var(--g-font-mono);
+	font-size: 0.5625rem;
+	color: var(--g-brass-light);
+	text-transform: lowercase;
+	letter-spacing: 0;
+}
+
+.rec-tag--staggered { color: var(--g-lamp-red); }
+.rec-tag--hidden { color: var(--g-ink-mid); }
+
+.rec-figure--armed .rec-figure-plate,
+.rec-figure--selected .rec-figure-plate {
+	outline: 2px solid var(--g-hazard);
+	outline-offset: 1px;
+}
+
+.rec-figure--armed { transform: translateY(-4px); }
+
+/* the creature acting, and the creature it lands on */
+.rec-figure { position: relative; }
+
+.rec-figure--acting .rec-figure-plate {
+	outline: 2px solid var(--g-brass-light);
+	outline-offset: 1px;
+}
+
+.rec-figure--hover .rec-figure-plate,
+.rec-figure--hit .rec-figure-plate {
+	outline: 2px dashed var(--g-lamp-red);
+	outline-offset: 1px;
+}
+
+.rec-figure-flash {
+	position: absolute;
+	top: -14px;
+	left: 50%;
+	transform: translateX(-50%);
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-tiny);
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-wide);
+	padding: 0 var(--g-2);
+	border-radius: 2px;
+	background: var(--g-hull-lo);
+	color: var(--g-ink);
+	white-space: nowrap;
+	animation: rec-flash 600ms ease-out both;
+	z-index: 2;
+}
+
+.rec-figure-flash--rout { color: var(--g-lamp-red); }
+.rec-figure-flash--stagger { color: var(--g-hazard); }
+.rec-figure-flash--shrug { color: var(--g-ink-mid); }
+.rec-figure-flash--ward { color: var(--g-brass-light); }
+
+@keyframes rec-flash {
+	from { opacity: 0; transform: translateX(-50%) translateY(6px); }
+	to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+/* --- deploy controls: send is the action, pass is a choice, not a siren --- */
+
+.rec-roster-head { flex-wrap: wrap; }
+
+.rec-roster-help {
+	font-size: var(--g-size-micro);
+	color: var(--g-ink-low);
+	margin-left: auto;
+}
+
+.rec-deploy-controls { flex: 0 0 250px; min-width: 0; }
+.rec-deploy-controls .g-btn { text-align: left; }
+
+.rec-btn-sub {
+	display: block;
+	font-family: var(--g-font-mono);
+	font-size: 0.5625rem;
+	text-transform: none;
+	letter-spacing: 0;
+	opacity: 0.75;
+	margin-top: 1px;
+}
+
+.rec-pass-btn { --btn-face: var(--g-hull-lo); }
+
+.rec-deploy-note {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-micro);
+	color: var(--g-ink-mid);
+	padding: var(--g-1) var(--g-2);
+	border-left: 3px solid var(--g-seam);
+}
+
+.rec-deploy-note--open { border-left-color: var(--g-hazard); color: var(--g-ink); }
+
+/* --- orders: chips, the button that cannot scroll away, the bar on the table --- */
+
+.rec-orders-head {
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--g-2);
+	position: sticky;
+	top: 0;
+	background: var(--g-hull);
+	z-index: 1;
+	padding-bottom: var(--g-2);
+	border-bottom: var(--g-hairline) solid var(--g-rule-faint);
+}
+
+.rec-orders-head > div {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.rec-commit-btn { margin-top: 0; }
+
+.rec-order-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--g-1);
+}
+
+.rec-act-chip {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0;
+	padding: 2px var(--g-2);
+	min-width: 64px;
+	background: var(--g-hull-lo);
+	border: var(--g-hairline) solid var(--g-seam);
+	border-radius: 2px;
+	color: var(--g-ink-mid);
+	cursor: pointer;
+	font: inherit;
+	text-align: left;
+	transition: border-color var(--g-move), color var(--g-move);
+}
+
+.rec-act-chip:hover:not(:disabled) { border-color: var(--g-ink-low); color: var(--g-ink); }
+
+.rec-act-chip--chosen {
+	border-color: var(--g-hazard);
+	color: var(--g-ink);
+	box-shadow: inset 0 0 0 1px var(--g-hazard);
+}
+
+.rec-act-chip:disabled { cursor: default; opacity: 0.6; }
+
+.rec-act-chip-act {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-tiny);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-label);
+}
+
+.rec-act-chip-mag {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-small);
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	color: var(--g-el);
+}
+
+.rec-act-chip-sub {
+	font-family: var(--g-font-mono);
+	font-size: 0.5625rem;
+	color: var(--g-ink-low);
+}
+
+.rec-act-chip--chosen .rec-act-chip-sub { color: var(--g-brass-light); }
+
+.rec-preview-line { cursor: default; }
+.rec-preview-line:hover { color: var(--g-screen-ink-hi, inherit); text-decoration: underline; text-decoration-color: color-mix(in srgb, currentColor 40%, transparent); }
+
+.rec-orders-bar {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--g-3);
+	padding: var(--g-2) var(--g-4);
+	background: var(--g-hull-lo);
+	border-radius: var(--g-radius);
+	box-shadow: var(--g-recess);
+	border-left: 3px solid var(--g-hazard);
+}
+
+.rec-orders-bar-text {
+	font-family: var(--g-font-mono);
+	font-size: var(--g-size-tiny);
+	color: var(--g-ink);
+}
+
+@media (max-width: 1200px) {
+	.rec-sites { gap: var(--g-2); }
+	.rec-site-margin-text { font-size: var(--g-size-micro); }
+	.rec-deploy-controls { min-width: 170px; }
+	.rec-status-hint { font-size: var(--g-size-small); }
+	.rec-act-chip { min-width: 52px; }
+}
+
+/* style.css (the old template) forces `section h3` and `section p` to 1.5em / 1.25em
+   with !important below 1024px, which is exactly the width the site headings must stay
+   small at; matched on specificity and importance rather than restyled */
+@media (max-width: 1200px) {
+	.rec-site h3.rec-site-name { font-size: var(--g-size-micro) !important; }
+	.rec-site p.rec-site-env { font-size: 0.5625rem !important; }
+}
+
+/* at 1024 the roster must not eat the sites: one scrolling row, terse controls */
+@media (max-width: 1200px) {
+	.rec-roster-strip {
+		flex-wrap: nowrap;
+		overflow-x: auto;
+		padding-bottom: var(--g-1);
+	}
+	.rec-roster-help { display: none; }
+	.rec-btn-sub { display: none; }
+	.rec-deploy-controls { flex: 0 0 150px; }
+	.rec-deploy-controls .g-btn { padding: var(--g-2); font-size: var(--g-size-tiny); }
+	.rec-figure-element { display: none; }
+	.rec-hidden-banner-text { font-size: var(--g-size-micro); }
 }

--- a/my-app/src/components/games/reclamation/reclamationFigure.js
+++ b/my-app/src/components/games/reclamation/reclamationFigure.js
@@ -8,10 +8,18 @@ import { speciesLabel, formatHold } from './reclamationNarration';
 	would be if the machine shop made it: the species name stencilled on a small steel
 	plate, standing on a painted disc plinth. The side's paint is the disc (bone/olive for
 	the handler, gunmetal for the rival), the element is a medallion on the front of the
-	disc, and the creature's live hold is stamped at the disc's foot in tabular mono.
+	disc with its name beside it, and the creature's live hold is stamped at the disc's
+	foot in tabular mono, large, because hold is the number the whole game is counted in.
 
 	Every number here is passed in from the engine's own prepare(); this component never
 	computes one.
+
+	Emphasis states, all set by the controller:
+	- armed / selected: the creature the next click will act on
+	- acting / hit: the creature acting or being acted on during resolution playback,
+	  with `flash` naming the outcome over the figure
+	- hover: the target of the preview line under the pointer during Orders
+	- badge: a small tag on the plate (the act ordered, during Orders)
 */
 function ReclamationFigure({
 	record,
@@ -30,6 +38,10 @@ function ReclamationFigure({
 	selected,
 	armed,
 	dimmed,
+	acting,
+	hit,
+	hover,
+	flash,
 	label,
 	badge,
 	onClick,
@@ -61,11 +73,36 @@ function ReclamationFigure({
 	if (dimmed) {
 		classes.push('rec-figure--dimmed');
 	}
+	if (acting) {
+		classes.push('rec-figure--acting');
+	}
+	if (hit) {
+		classes.push('rec-figure--hit');
+	}
+	if (hover) {
+		classes.push('rec-figure--hover');
+	}
 	if (element) {
 		classes.push(`g-el-${element}`);
 	}
 
 	const name = record ? speciesLabel(record) : (label || 'Unknown');
+	const tags = [];
+	if (isHome) {
+		tags.push({ key: 'home', text: 'home' });
+	}
+	if (strainLevel === 'strained') {
+		tags.push({ key: 'strain', text: 'strained' });
+	}
+	if (strainLevel === 'severe') {
+		tags.push({ key: 'severe', text: 'severe strain' });
+	}
+	if (staggered) {
+		tags.push({ key: 'staggered', text: 'staggered' });
+	}
+	if (hidden) {
+		tags.push({ key: 'hidden', text: 'hidden' });
+	}
 
 	return (
 		<button
@@ -77,6 +114,7 @@ function ReclamationFigure({
 			data-record-id={record ? record.id : undefined}
 			data-hold={typeof hold === 'number' ? formatHold(hold) : undefined}
 		>
+			{flash && <span className={`rec-figure-flash rec-figure-flash--${flash.kind}`}>{flash.text}</span>}
 			<span className="rec-figure-plate">
 				<span className="rec-figure-name">{name}</span>
 				{badge && <span className="rec-figure-badge">{badge}</span>}
@@ -90,12 +128,11 @@ function ReclamationFigure({
 				)}
 				{typeof hold === 'number' && <span className="rec-figure-hold">{formatHold(hold)}</span>}
 				{typeof ghostHold === 'number' && <span className="rec-figure-hold rec-figure-hold--ghost">{formatHold(ghostHold)}</span>}
+				{element && <span className="rec-figure-element">{element}</span>}
 			</span>
-			{(strainLevel === 'strained' || strainLevel === 'severe' || isHome) && (
+			{tags.length > 0 && (
 				<span className="rec-figure-tags">
-					{isHome && <span className="rec-tag rec-tag--home">home</span>}
-					{strainLevel === 'strained' && <span className="rec-tag rec-tag--strain">strained</span>}
-					{strainLevel === 'severe' && <span className="rec-tag rec-tag--severe">severe</span>}
+					{tags.map((t) => <span className={`rec-tag rec-tag--${t.key}`} key={t.key}>{t.text}</span>)}
 				</span>
 			)}
 		</button>
@@ -112,7 +149,7 @@ export function ReclamationSilhouette({ count }) {
 			{Array.from({ length: count }).map((_, i) => (
 				<div className="rec-figure rec-figure--theirs rec-figure--silhouette rec-figure--down" key={i}>
 					<span className="rec-figure-plate">
-						<span className="rec-figure-name">something was sent</span>
+						<span className="rec-figure-name">unknown</span>
 					</span>
 					<span className="rec-figure-plinth" />
 					<span className="rec-figure-foot"><span className="rec-figure-hold">?</span></span>

--- a/my-app/src/components/games/reclamation/reclamationMatch.js
+++ b/my-app/src/components/games/reclamation/reclamationMatch.js
@@ -58,6 +58,7 @@ class ReclamationMatch extends React.Component {
 			judgedWorld: null,
 			judgedSnapshot: null,
 			judged: false,
+			hoverRow: null, // the preview line under the pointer, to light its creatures
 		};
 		this.botRngState = createRngState(`${props.seed}-bot`);
 		this.botTimer = null;
@@ -607,8 +608,10 @@ class ReclamationMatch extends React.Component {
 		}
 		const event = playback.events[playback.index];
 		this.narrateEvent(event, playback);
-		this.setState((prev) => ({ playback: { ...prev.playback, index: prev.playback.index + 1 } }));
-		this.playbackTimer = setTimeout(this.stepPlayback, RESOLUTION_STEP_MS);
+		this.setState((prev) => ({ playback: { ...prev.playback, index: prev.playback.index + 1, current: event } }));
+		// dev hook: window.__reclamationStepMs slows playback so it can be watched or captured
+		const stepMs = (typeof window !== 'undefined' && window.__reclamationStepMs) || RESOLUTION_STEP_MS;
+		this.playbackTimer = setTimeout(this.stepPlayback, stepMs);
 	};
 
 	skipPlayback = () => {
@@ -842,7 +845,7 @@ class ReclamationMatch extends React.Component {
 			return 'Expedition over';
 		}
 		if (view.phase === 'orders') {
-			return 'Orders';
+			return view.players[YOU].committed ? 'Orders sealed' : 'Your orders';
 		}
 		if (view.turn === YOU) {
 			return 'Your move';
@@ -853,88 +856,105 @@ class ReclamationMatch extends React.Component {
 	renderStatusStrip(view) {
 		const you = view.players[YOU];
 		const them = view.players[THEM];
-		const yourTurn = view.turn === YOU && view.phase === 'deploy' && !this.state.playback && !this.state.judged;
+		const yourTurn = ((view.turn === YOU && view.phase === 'deploy') || (view.phase === 'orders' && !view.players[YOU].committed)) && !this.state.playback && !this.state.judged;
+		const waiting = view.turn === THEM && view.phase === 'deploy' && !this.state.playback && !this.state.judged;
 		const phaseLabel = this.state.playback ? 'Resolve'
 			: view.phase === 'matchEnd' ? 'Charter'
 				: this.state.judged ? 'Judge'
 					: view.phase === 'orders' ? 'Orders' : 'Deploy';
+		const pips = (n) => Array.from({ length: SITES_TO_CLINCH }).map((_, i) => (
+			<span className={`rec-pip${i < n ? ' rec-pip--lit' : ''}`} key={i} />
+		));
+		const worldDots = Array.from({ length: WORLDS_PER_MATCH }).map((_, i) => (
+			<span className={`rec-world-dot${i === view.worldIndex ? ' rec-world-dot--now' : i < view.worldIndex ? ' rec-world-dot--done' : ''}`} key={i} />
+		));
 		return (
 			<div className={`g-panel rec-status g-el-${view.world.element}`}>
 				<div className="rec-status-world">
-					<span className="g-kicker">World {view.worldIndex + 1} of {WORLDS_PER_MATCH}</span>
+					<span className="rec-world-dots" title={`World ${view.worldIndex + 1} of ${WORLDS_PER_MATCH}`}>{worldDots}</span>
 					<h2 className="rec-status-planet">{view.world.planet}</h2>
 					<span className="g-chip rec-status-element">{view.world.element}</span>
+					<span className="rec-status-next g-mono">
+						{view.nextWorld ? `then ${view.nextWorld.planet}` : 'the last world'}
+					</span>
 				</div>
 
-				<div className="rec-status-score">
+				<div className="rec-status-score" title={`First to ${SITES_TO_CLINCH} sites takes the Charter`}>
 					<span className="rec-score rec-score--mine">
-						<span className="rec-score-label">You hold</span>
+						<span className="rec-score-label">You</span>
+						<span className="rec-pips">{pips(you.sitesWon)}</span>
 						<span className="rec-score-value" data-sites-a>{you.sitesWon}</span>
 					</span>
-					<span className="rec-score-of">of {SITES_TO_CLINCH} to clinch</span>
 					<span className="rec-score rec-score--theirs">
-						<span className="rec-score-label">Rival holds</span>
+						<span className="rec-score-label">Rival</span>
+						<span className="rec-pips">{pips(them.sitesWon)}</span>
 						<span className="rec-score-value" data-sites-b>{them.sitesWon}</span>
 					</span>
+					<span className="rec-score-of">{SITES_TO_CLINCH} sites clinch</span>
 				</div>
 
 				<div className="rec-status-turn">
 					<span className="rec-status-phase">{phaseLabel}</span>
-					<span className={`rec-turn${yourTurn ? ' rec-turn--yours' : ''}`}>
-						<span className={`g-lamp ${yourTurn ? 'g-lamp--amber' : 'g-lamp--off'}`} />
+					<span className={`rec-turn${yourTurn ? ' rec-turn--yours' : ''}${waiting ? ' rec-turn--waiting' : ''}`}>
+						<span className={`g-lamp ${yourTurn ? 'g-lamp--amber' : waiting ? 'g-lamp--red' : 'g-lamp--off'}`} />
 						<span className="rec-turn-text" data-turn-text>{this.turnText(view)}</span>
-					</span>
-					<span className="rec-status-next g-mono">
-						{view.nextWorld ? `Next world: ${view.nextWorld.planet}` : 'The last world'}
 					</span>
 				</div>
 
-				<p className="rec-status-hint g-body" data-hint>{this.whatAClickDoes(view)}</p>
+				<p className={`rec-status-hint g-body${yourTurn ? ' rec-status-hint--yours' : ''}`} data-hint>{this.whatAClickDoes(view)}</p>
 			</div>
 		);
 	}
 
 	renderDeployControls(view) {
 		const me = view.players[YOU];
+		const them = view.players[THEM];
 		const armed = this.state.armedRecordId
 			? me.roster.find((r) => r.id === this.state.armedRecordId)
 			: null;
 		const armedStealthy = armed
 			&& [...(armed.traits.guaranteed || []), ...(armed.traits.rolled || [])].includes('stealthy');
 		const yourTurn = view.turn === YOU && view.phase === 'deploy' && !this.state.playback;
+		const vanguard = me.canRelocateVanguard && me.vanguardRecordId
+			? this.findRecordOnBoard(this.state.match, me.vanguardRecordId)
+			: null;
 
 		return (
 			<div className="rec-deploy-controls">
 				{armedStealthy && (
-					<label className="g-check rec-hidden-toggle">
+					<label className="g-check rec-hidden-toggle" title="A stealthy creature may be sent hidden: the rival learns that you sent something, not what or where, until orders are revealed.">
 						<input type="checkbox" checked={this.state.sendHidden} onChange={this.toggleHidden} data-hidden-toggle />
 						<span className="g-check-box" />
 						<span>Send hidden</span>
 					</label>
 				)}
-				{me.canRelocateVanguard && me.vanguardRecordId && (
+				{them.passed && !me.passed && (
+					<span className="rec-deploy-note rec-deploy-note--open">The rival has passed. Nothing you send now can be answered.</span>
+				)}
+				{vanguard && (
 					<button
 						type="button"
 						className={`g-btn rec-fallback-btn${this.state.relocating ? ' rec-fallback-btn--active' : ''}`}
 						onClick={this.beginRelocate}
 						disabled={!yourTurn}
 						data-fallback
-						title="Your vanguard was placed with no information. Once per world it may fall back to another site, without spending your turn."
+						title="You placed your first creature knowing nothing. Once per world it may fall back to another site, without spending your turn."
 					>
-						Fall back
+						{this.state.relocating ? 'Choose a site' : `Fall back ${speciesLabel(vanguard)}`}
+						<span className="rec-btn-sub">free move, once this world</span>
 					</button>
 				)}
 				<button
 					type="button"
-					className="g-btn g-btn--danger rec-pass-btn"
+					className="g-btn rec-pass-btn"
 					onClick={this.handlePass}
 					disabled={!yourTurn}
 					data-pass
 					title="Pass is permanent for this world."
 				>
-					Pass
+					Pass for this world
+					<span className="rec-btn-sub">permanent, ends your deploy here</span>
 				</button>
-				<span className="rec-pass-warning g-mono">Pass is permanent for this world.</span>
 			</div>
 		);
 	}
@@ -980,6 +1000,28 @@ class ReclamationMatch extends React.Component {
 		const preview = ordering ? orderPreview(view, me.orders, YOU) : [];
 		const holdingIds = [...me.holding, ...them.holding];
 
+		// during Orders every one of your figures wears the act it will perform
+		const badges = {};
+		if (ordering) {
+			units.forEach((u) => {
+				const chosen = (me.orders && me.orders[u.recordId]) || u.prepared.favoredAct.action;
+				const act = u.prepared.acts.find((a) => a.action === chosen);
+				badges[u.recordId] = chosen === 'hold' ? 'hold' : `${chosen}${act ? ` ${act.magnitude}` : ''}`;
+			});
+		}
+		// what to light on the table: the preview line under the pointer, or the event
+		// being narrated during resolution
+		const highlights = {};
+		if (this.state.hoverRow) {
+			highlights.hover = this.state.hoverRow.target ? this.state.hoverRow.target.recordId : null;
+			highlights.acting = this.state.hoverRow.unit.recordId;
+		}
+		if (playback && playback.current && classifyEvent(playback.current) === 'act') {
+			highlights.acting = playback.current.recordId;
+			highlights.hit = playback.current.target || null;
+			highlights.flash = flashFor(playback.current.outcome);
+		}
+
 		return (
 			<div className="rec-match">
 				{this.renderStatusStrip(view)}
@@ -999,8 +1041,12 @@ class ReclamationMatch extends React.Component {
 							verdicts={verdicts}
 							armedRecordId={this.state.armedRecordId}
 							relocating={this.state.relocating}
+							vanguardRecordId={me.vanguardRecordId}
 							clickable={clickable}
 							holdingIds={holdingIds}
+							hiddenEnemyCount={deploying || ordering ? (them.hiddenSentThisRound || 0) : 0}
+							badges={badges}
+							highlights={highlights}
 							onSiteClick={this.handleSiteClick}
 							onFigureClick={(entry, seat, site) => this.inspectRecord(entry.record, site)}
 						/>
@@ -1014,16 +1060,29 @@ class ReclamationMatch extends React.Component {
 									onArm={this.armRecord}
 									onInspect={(record) => this.inspectRecord(record, null)}
 									sendsLeft={Math.max(0, SENDABLE - me.sentCount)}
-									hiddenEnemyCount={them.hiddenSentThisRound || 0}
 									disabled={view.turn !== YOU || me.passed}
+									yourTurn={view.turn === YOU && !me.passed}
 								/>
 								{this.renderDeployControls(view)}
 							</div>
 						)}
 
+						{ordering && (
+							<div className="rec-orders-bar" data-orders-bar>
+								<span className="rec-orders-bar-text">
+									{me.committed
+										? 'Your orders are sealed. The rival is giving its own.'
+										: 'Deploy is over. Every creature on the table has an act by nature; change any in the panel, then give orders.'}
+								</span>
+								<button type="button" className="g-btn g-btn--primary" onClick={this.commitOrders} disabled={me.committed} data-give-orders>
+									{me.committed ? 'Orders given' : 'Give orders'}
+								</button>
+							</div>
+						)}
+
 						{playback && (
 							<div className="rec-resolving">
-								<span className="g-label">Resolving, {playback.index} of {playback.events.length}</span>
+								<span className="g-label">Resolving in initiative order, {playback.index} of {playback.events.length}</span>
 								<button type="button" className="g-btn rec-skip-btn" onClick={this.skipPlayback} data-skip>Skip</button>
 							</div>
 						)}
@@ -1051,6 +1110,7 @@ class ReclamationMatch extends React.Component {
 								committed={me.committed}
 								you={YOU}
 								panelRef={this.ordersPanel}
+								onHoverPreview={(row) => this.setState({ hoverRow: row })}
 							/>
 						)}
 						{inspect && (
@@ -1067,6 +1127,25 @@ class ReclamationMatch extends React.Component {
 			</div>
 		);
 	}
+}
+
+// the word that pops over a creature as an act lands on it during playback
+function flashFor(outcome) {
+	const map = {
+		routed: { kind: 'rout', text: 'routed' },
+		staggered: { kind: 'stagger', text: 'staggered' },
+		shrugged: { kind: 'shrug', text: 'shrugged' },
+		shoved: { kind: 'shrug', text: 'shoved' },
+		snared: { kind: 'stagger', text: 'snared' },
+		terrorized: { kind: 'rout', text: 'withdraws' },
+		'warded-absorbed': { kind: 'ward', text: 'warded' },
+		'warded-ally': { kind: 'ward', text: 'warded' },
+		'warded-self': { kind: 'ward', text: 'warded' },
+		mended: { kind: 'ward', text: 'mended' },
+		'anchored-immune': { kind: 'shrug', text: 'anchored' },
+		'snared-immune': { kind: 'shrug', text: 'held fast' },
+	};
+	return map[outcome] || null;
 }
 
 // "1 site" reads better than "1 sites" on the verdict panel and in the log.

--- a/my-app/src/components/games/reclamation/reclamationOrders.js
+++ b/my-app/src/components/games/reclamation/reclamationOrders.js
@@ -4,11 +4,17 @@ import { speciesLabel } from './reclamationNarration';
 /*
 	ReclamationOrders — the Orders phase panel.
 
-	Every one of your creatures on the table gets an act selector (its acts by name with
-	magnitude, plus Hold). The archetype's favored act is preselected and marked "by
-	nature", exactly as the engine treats an unordered creature. Beside it, the resolution
-	preview: the initiative order of every visible creature and, for each of yours, the
-	target its conduct would pick right now, in words.
+	Every one of your creatures on the table gets a row of act chips (each act by name
+	with its magnitude and class, plus Hold). The archetype's favored act starts chosen
+	and is marked "by nature", exactly as the engine treats an unordered creature. The
+	chips are radio buttons, so the chosen act is visible without opening anything.
+
+	Beneath it, the resolution preview: the initiative order of every visible creature
+	and, for each of yours, the target its conduct would pick right now, in words.
+	Hovering a preview line lights the creatures it names on the table.
+
+	The "Give orders" button is the one action of the phase, so it is pinned at the top
+	of the panel where it cannot scroll away.
 */
 function ReclamationOrders({
 	units,
@@ -17,27 +23,39 @@ function ReclamationOrders({
 	onOrder,
 	onCommit,
 	committed,
-	you,
 	panelRef,
+	onHoverPreview,
 }) {
+	const ordered = units.filter((u) => orders && orders[u.recordId]).length;
 	return (
 		<div className="rec-orders" ref={panelRef} tabIndex={-1} aria-label="Orders">
 			<div className="rec-orders-list">
 				<header className="rec-orders-head">
-					<span className="g-label">Orders</span>
-					<span className="g-mono rec-orders-hint">
-						{committed ? 'Orders sealed. Waiting on the rival.' : 'Choose an act for each creature, then give orders.'}
-					</span>
+					<div>
+						<span className="g-label">Orders</span>
+						<span className="g-mono rec-orders-hint">
+							{committed
+								? 'Orders sealed. Waiting on the rival.'
+								: `${ordered} of ${units.length} chosen; the rest act by nature.`}
+						</span>
+					</div>
+					<button
+						type="button"
+						className="g-btn g-btn--primary rec-commit-btn"
+						onClick={onCommit}
+						disabled={committed}
+						data-commit-orders
+					>
+						{committed ? 'Orders given' : 'Give orders'}
+					</button>
 				</header>
 				{units.map((unit) => {
 					const favored = unit.prepared.favoredAct.action;
 					const chosen = (orders && orders[unit.recordId]) || favored;
 					// A creature can carry two abilities with the SAME action (the roller happily
 					// gives one creature two `drain` acts), and the engine's order() takes an
-					// action name, not an ability. Two options with the same value would collide
-					// as React keys and make the second unpickable, so identical actions are
-					// merged into one option naming both abilities, and the option's value stays
-					// the action name the engine expects.
+					// action name, not an ability. Identical actions are merged into one chip
+					// naming both abilities; the chip's value stays the action name.
 					const byAction = new Map();
 					unit.prepared.acts.forEach((a) => {
 						const existing = byAction.get(a.action);
@@ -45,55 +63,62 @@ function ReclamationOrders({
 							existing.names.push(a.name);
 							existing.magnitude = Math.max(existing.magnitude, a.magnitude);
 						} else {
-							byAction.set(a.action, { action: a.action, names: [a.name], magnitude: a.magnitude });
+							byAction.set(a.action, { action: a.action, names: [a.name], magnitude: a.magnitude, cls: a.class });
 						}
 					});
 					const options = [
 						...[...byAction.values()].map((a) => ({
 							value: a.action,
-							label: `${a.names.join(' / ')} — ${a.action}, magnitude ${a.magnitude}`,
+							act: a.action,
+							name: a.names.join(' / '),
+							magnitude: a.magnitude,
+							cls: a.cls,
 						})),
-						{ value: 'hold', label: 'Hold — keep full hold' },
+						{ value: 'hold', act: 'hold', name: 'Hold', magnitude: null, cls: 'keeps full hold' },
 					];
 					return (
-						<div className={`rec-order-row g-el-${unit.record.element.primary}`} key={unit.recordId}>
+						<div className={`rec-order-row g-el-${unit.record.element.primary}`} key={unit.recordId} data-order-row={unit.recordId}>
 							<div className="rec-order-who">
 								<span className="rec-order-name">{speciesLabel(unit.record)}</span>
-								<span className="rec-order-site g-mono">{unit.site.name}</span>
+								<span className="rec-order-site g-mono">{unit.site.name} · hold {unit.prepared.hold.toFixed(1).replace(/\.0$/, '')}</span>
 							</div>
-							<select
-								className="g-select rec-order-select"
-								value={chosen}
-								disabled={committed}
-								data-order-for={unit.recordId}
-								onChange={(e) => onOrder(unit.recordId, e.target.value)}
-							>
-								{options.map((o) => (
-									<option value={o.value} key={o.value}>
-										{o.label}{o.value === favored ? ' (by nature)' : ''}
-									</option>
-								))}
-							</select>
+							<div className="rec-order-chips" role="radiogroup" aria-label={`Act for ${speciesLabel(unit.record)}`}>
+								{options.map((o) => {
+									const isChosen = o.value === chosen;
+									return (
+										<button
+											type="button"
+											role="radio"
+											aria-checked={isChosen}
+											className={`rec-act-chip${isChosen ? ' rec-act-chip--chosen' : ''}`}
+											key={o.value}
+											disabled={committed}
+											data-order-for={unit.recordId}
+											data-act={o.value}
+											onClick={() => onOrder(unit.recordId, o.value)}
+											title={o.name}
+										>
+											<span className="rec-act-chip-act">{o.act}</span>
+											{o.magnitude !== null && <span className="rec-act-chip-mag">{o.magnitude}</span>}
+											<span className="rec-act-chip-sub">{o.value === favored ? 'by nature' : o.cls}</span>
+										</button>
+									);
+								})}
+							</div>
 						</div>
 					);
 				})}
 				{units.length === 0 && <p className="g-body rec-rank-empty">You sent nothing to this world.</p>}
-				<button
-					type="button"
-					className="g-btn g-btn--primary rec-commit-btn"
-					onClick={onCommit}
-					disabled={committed}
-				>
-					{committed ? 'Orders given' : 'Give orders'}
-				</button>
 			</div>
 
 			<div className="g-screen rec-preview" aria-label="Resolution preview">
-				<div className="g-readout-unit">Resolution preview · initiative order</div>
+				<div className="g-readout-unit">What will happen, in initiative order</div>
 				{preview.map((row, i) => (
 					<div
-						className={`g-screen-line${row.isYours ? '' : ' g-screen-line--dim'}`}
+						className={`g-screen-line rec-preview-line${row.isYours ? '' : ' g-screen-line--dim'}`}
 						key={`${row.unit.recordId}-${i}`}
+						onMouseEnter={onHoverPreview ? () => onHoverPreview(row) : undefined}
+						onMouseLeave={onHoverPreview ? () => onHoverPreview(null) : undefined}
 					>
 						{i + 1}. {row.isYours ? row.sentence : `${speciesLabel(row.unit.record)} (rival) acts here, orders unknown.`}
 					</div>

--- a/my-app/src/components/games/reclamation/reclamationRoster.js
+++ b/my-app/src/components/games/reclamation/reclamationRoster.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import ReclamationFigure, { ReclamationSilhouette } from './reclamationFigure';
+import ReclamationFigure from './reclamationFigure';
 import { baseHold } from '../../../gameplay/expedition/creatureOnTable';
 
 /*
-	ReclamationRoster — the strip of figures waiting to be sent, plus the rival's hidden
-	sends drawn as silhouettes (they are on the table, but the handler is not told where,
-	so the only honest place to show them is the rail).
+	ReclamationRoster — the strip of figures waiting to be sent. Each shows its base
+	hold and element so the twelve can be compared at a glance; the hold it would have
+	at each site appears on the sites themselves once it is armed.
 */
 function ReclamationRoster({
 	roster,
@@ -14,14 +14,17 @@ function ReclamationRoster({
 	onArm,
 	onInspect,
 	sendsLeft,
-	hiddenEnemyCount,
 	disabled,
+	yourTurn,
 }) {
 	return (
 		<div className="rec-roster">
 			<header className="rec-roster-head">
 				<span className="g-label">Your roster</span>
-				<span className="g-mono rec-roster-count">{roster.length} in hand · {sendsLeft} sends left</span>
+				<span className="g-mono rec-roster-count">{roster.length} in hand · {sendsLeft} sends left this expedition</span>
+				<span className="g-mono rec-roster-help">
+					{yourTurn ? 'click one to arm it · shift-click to read its dossier' : 'shift-click to read a dossier'}
+				</span>
 			</header>
 			<div className="rec-roster-strip">
 				{roster.map((record) => (
@@ -49,12 +52,6 @@ function ReclamationRoster({
 				))}
 				{roster.length === 0 && <span className="rec-rank-empty">your roster is empty</span>}
 			</div>
-			{hiddenEnemyCount > 0 && (
-				<div className="rec-roster-hidden">
-					<span className="g-label">Rival, hidden</span>
-					<ReclamationSilhouette count={hiddenEnemyCount} />
-				</div>
-			)}
 		</div>
 	);
 }

--- a/my-app/src/components/games/reclamation/reclamationWorld.js
+++ b/my-app/src/components/games/reclamation/reclamationWorld.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReclamationFigure from './reclamationFigure';
+import ReclamationFigure, { ReclamationSilhouette } from './reclamationFigure';
 import { formatHold } from './reclamationNarration';
 
 /*
@@ -7,11 +7,16 @@ import { formatHold } from './reclamationNarration';
 
 	Each site is a matte panel headed by the site's name and its environment line. The
 	handler's creatures stand below the midline facing up; the rival's stand above it
-	facing down. The live hold total per side sits at the site's shoulders, and the
-	leading side is marked.
+	facing down. The thing a handler most needs from a site is who is winning it and by
+	how much, so that is the site's biggest readout: a margin band under the heading that
+	says "you lead by 4.2", "the rival leads by 3.1" or "level, to the Court", with the
+	two raw totals beside it.
+
+	When a creature is armed, every site says what sending it there would do ("you would
+	lead by 2.1", "still behind by 1.3") so the choice of site is legible before the click.
 
 	Every hold shown is passed in already computed by the engine's prepare(): this
-	component derives nothing.
+	component derives nothing except differences between numbers it was given.
 */
 
 function environmentLine(site) {
@@ -22,6 +27,28 @@ function environmentLine(site) {
 		? `${t.min} to ${t.max} C`
 		: 'unrecorded band';
 	return `${medium} · ${band}`;
+}
+
+function marginText(mine, theirs) {
+	const diff = mine - theirs;
+	if (Math.abs(diff) < 0.05) {
+		return { who: 'level', text: mine === 0 && theirs === 0 ? 'nothing here yet' : 'level, to the Court' };
+	}
+	if (diff > 0) {
+		return { who: 'mine', text: `you lead by ${formatHold(diff)}` };
+	}
+	return { who: 'theirs', text: `rival leads by ${formatHold(-diff)}` };
+}
+
+function ghostText(ghost, mine, theirs) {
+	const after = mine + ghost.hold - theirs;
+	if (Math.abs(after) < 0.05) {
+		return 'would be level';
+	}
+	if (after > 0) {
+		return mine > theirs ? `lead grows to ${formatHold(after)}` : `you would lead by ${formatHold(after)}`;
+	}
+	return `still behind by ${formatHold(-after)}`;
 }
 
 function ReclamationWorld({
@@ -35,137 +62,137 @@ function ReclamationWorld({
 	verdicts,
 	armedRecordId,
 	relocating,
+	vanguardRecordId,
 	onSiteClick,
 	onFigureClick,
 	clickable,
 	holdingIds,
+	hiddenEnemyCount,
+	badges,
+	highlights,
 }) {
 	const opponent = you === 'A' ? 'B' : 'A';
+	const hl = highlights || {};
 
 	return (
 		<div className={`rec-world g-el-${world.element}`}>
-			{world.sites.map((site) => {
-				const theirs = (board[site.id][opponent] || []).filter((e) => e.record);
-				const mine = (board[site.id][you] || []).filter((e) => e.record);
-				const totalMine = totals[site.id] ? totals[site.id][you] : 0;
-				const totalTheirs = totals[site.id] ? totals[site.id][opponent] : 0;
-				const leader = totalMine > totalTheirs ? 'mine' : totalTheirs > totalMine ? 'theirs' : 'level';
-				const ghost = ghosts && ghosts[site.id];
-				const verdict = verdicts && verdicts[site.id];
+			{hiddenEnemyCount > 0 && (
+				<div className="rec-hidden-banner" data-hidden-banner>
+					<ReclamationSilhouette count={hiddenEnemyCount} />
+					<span className="rec-hidden-banner-text">
+						The rival has {hiddenEnemyCount === 1 ? 'a creature' : `${hiddenEnemyCount} creatures`} hidden somewhere on this world. It is revealed when orders are.
+					</span>
+				</div>
+			)}
+			<div className="rec-sites">
+				{world.sites.map((site) => {
+					const theirs = (board[site.id][opponent] || []).filter((e) => e.record);
+					const mine = (board[site.id][you] || []).filter((e) => e.record);
+					const totalMine = totals[site.id] ? totals[site.id][you] : 0;
+					const totalTheirs = totals[site.id] ? totals[site.id][opponent] : 0;
+					const margin = marginText(totalMine, totalTheirs);
+					const ghost = ghosts && ghosts[site.id];
+					const verdict = verdicts && verdicts[site.id];
 
-				const classes = ['g-panel', 'rec-site'];
-				if (clickable) {
-					classes.push('rec-site--clickable');
-				}
-				if (ghost) {
-					classes.push('rec-site--targeted');
-				}
-				if (verdict) {
-					classes.push(`rec-site--verdict-${verdict.who}`);
-				}
+					const classes = ['g-panel', 'rec-site', `rec-site--${margin.who}`];
+					if (clickable) {
+						classes.push('rec-site--clickable');
+					}
+					if (ghost || relocating) {
+						classes.push('rec-site--targeted');
+					}
+					if (verdict) {
+						classes.push(`rec-site--verdict-${verdict.who}`);
+					}
 
-				return (
-					<section
-						className={classes.join(' ')}
-						key={site.id}
-						data-site-id={site.id}
-						onClick={clickable ? () => onSiteClick(site.id) : undefined}
-						role={clickable ? 'button' : undefined}
-						tabIndex={clickable ? 0 : undefined}
-						onKeyDown={clickable ? (e) => {
-							if (e.key === 'Enter' || e.key === ' ') {
-								e.preventDefault();
-								onSiteClick(site.id);
-							}
-						} : undefined}
-					>
-						<header className="rec-site-head">
-							<h3 className="rec-site-name">{site.name}</h3>
-							<p className="rec-site-env g-mono">{environmentLine(site)}</p>
-						</header>
+					const figureProps = (entry, seat, facing) => ({
+						key: entry.recordId,
+						record: entry.record,
+						element: entry.record.element.primary,
+						seat,
+						you,
+						facing,
+						hidden: entry.hidden,
+						hold: holds[entry.recordId] ? holds[entry.recordId].hold : undefined,
+						printedHold: holds[entry.recordId] ? holds[entry.recordId].printed : undefined,
+						staggered: !!(staggered && staggered[entry.recordId]),
+						strainLevel: holds[entry.recordId] ? holds[entry.recordId].strainLevel : undefined,
+						isHome: holds[entry.recordId] ? holds[entry.recordId].isHome : false,
+						selected: armedRecordId === entry.recordId || (relocating && vanguardRecordId === entry.recordId),
+						dimmed: holdingIds && holdingIds.includes(entry.recordId),
+						acting: hl.acting === entry.recordId,
+						hit: hl.hit === entry.recordId,
+						hover: hl.hover === entry.recordId,
+						flash: hl.hit === entry.recordId ? hl.flash : undefined,
+						badge: badges ? badges[entry.recordId] : undefined,
+						onClick: (e) => {
+							e.stopPropagation();
+							onFigureClick(entry, seat, site);
+						},
+						title: 'Inspect this creature',
+					});
 
-						<div className="rec-site-tally">
-							<span className={`rec-tally rec-tally--theirs${leader === 'theirs' ? ' rec-tally--leading' : ''}`}>
-								<span className="rec-tally-label">Rival</span>
-								<span className="rec-tally-value" data-total-seat={opponent} data-site-total={site.id}>{formatHold(totalTheirs)}</span>
-							</span>
-							<span className={`rec-tally rec-tally--mine${leader === 'mine' ? ' rec-tally--leading' : ''}`}>
-								<span className="rec-tally-label">You</span>
-								<span className="rec-tally-value" data-total-seat={you} data-site-total={site.id}>{formatHold(totalMine)}</span>
-							</span>
-						</div>
+					return (
+						<section
+							className={classes.join(' ')}
+							key={site.id}
+							data-site-id={site.id}
+							onClick={clickable ? () => onSiteClick(site.id) : undefined}
+							role={clickable ? 'button' : undefined}
+							tabIndex={clickable ? 0 : undefined}
+							onKeyDown={clickable ? (e) => {
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									onSiteClick(site.id);
+								}
+							} : undefined}
+						>
+							<header className="rec-site-head">
+								<h3 className="rec-site-name">{site.name}</h3>
+								<p className="rec-site-env g-mono">{environmentLine(site)}</p>
+							</header>
 
-						<div className="rec-site-field">
-							<div className="rec-rank rec-rank--theirs">
-								{theirs.map((entry) => (
-									<ReclamationFigure
-										key={entry.recordId}
-										record={entry.record}
-										element={entry.record.element.primary}
-										seat={opponent}
-										you={you}
-										facing="down"
-										hold={holds[entry.recordId] ? holds[entry.recordId].hold : undefined}
-										printedHold={holds[entry.recordId] ? holds[entry.recordId].printed : undefined}
-										staggered={!!(staggered && staggered[entry.recordId])}
-										strainLevel={holds[entry.recordId] ? holds[entry.recordId].strainLevel : undefined}
-										isHome={holds[entry.recordId] ? holds[entry.recordId].isHome : false}
-										dimmed={holdingIds && holdingIds.includes(entry.recordId)}
-										onClick={(e) => {
-											e.stopPropagation();
-											onFigureClick(entry, opponent, site);
-										}}
-										title="Inspect this creature"
-									/>
-								))}
-								{theirs.length === 0 && <span className="rec-rank-empty">no rival creatures</span>}
+							<div className={`rec-site-margin rec-site-margin--${margin.who}`} data-site-margin={site.id}>
+								<span className="rec-site-margin-text">{margin.text}</span>
+								<span className="rec-site-margin-totals g-mono">
+									<span data-total-seat={opponent} data-site-total={site.id}>{formatHold(totalTheirs)}</span>
+									<span className="rec-site-margin-vs">rival · you</span>
+									<span data-total-seat={you} data-site-total={site.id}>{formatHold(totalMine)}</span>
+								</span>
 							</div>
 
-							<div className="rec-site-midline">
-								{ghost && (
-									<span className="rec-ghost">
-										<span className="rec-ghost-value">{formatHold(ghost.hold)}</span>
-										{ghost.isHome && <span className="rec-tag rec-tag--home">home</span>}
-										{ghost.strainLevel === 'strained' && <span className="rec-tag rec-tag--strain">strained</span>}
-										{ghost.strainLevel === 'severe' && <span className="rec-tag rec-tag--severe">severe</span>}
-									</span>
-								)}
-								{!ghost && relocating && <span className="rec-ghost rec-ghost--relocate">fall back here</span>}
-								{!ghost && !relocating && verdict && (
-									<span className={`rec-stamp rec-stamp--${verdict.who}`}>{verdict.text}</span>
-								)}
-							</div>
+							<div className="rec-site-field">
+								<div className="rec-rank rec-rank--theirs">
+									{theirs.map((entry) => <ReclamationFigure {...figureProps(entry, opponent, 'down')} />)}
+									{theirs.length === 0 && <span className="rec-rank-empty">no rival creatures</span>}
+								</div>
 
-							<div className="rec-rank rec-rank--mine">
-								{mine.map((entry) => (
-									<ReclamationFigure
-										key={entry.recordId}
-										record={entry.record}
-										element={entry.record.element.primary}
-										seat={you}
-										you={you}
-										facing="up"
-										hidden={entry.hidden}
-										hold={holds[entry.recordId] ? holds[entry.recordId].hold : undefined}
-										printedHold={holds[entry.recordId] ? holds[entry.recordId].printed : undefined}
-										staggered={!!(staggered && staggered[entry.recordId])}
-										strainLevel={holds[entry.recordId] ? holds[entry.recordId].strainLevel : undefined}
-										isHome={holds[entry.recordId] ? holds[entry.recordId].isHome : false}
-										selected={armedRecordId === entry.recordId}
-										dimmed={holdingIds && holdingIds.includes(entry.recordId)}
-										onClick={(e) => {
-											e.stopPropagation();
-											onFigureClick(entry, you, site);
-										}}
-										title="Inspect this creature"
-									/>
-								))}
-								{mine.length === 0 && <span className="rec-rank-empty">no creatures sent here</span>}
+								<div className="rec-site-midline">
+									{ghost && (
+										<span className="rec-ghost">
+											<span className="rec-ghost-cta">send here</span>
+											<span className="rec-ghost-value">{formatHold(ghost.hold)}</span>
+											{ghost.isHome && <span className="rec-tag rec-tag--home">home</span>}
+											{ghost.strainLevel === 'strained' && <span className="rec-tag rec-tag--strain">strained</span>}
+											{ghost.strainLevel === 'severe' && <span className="rec-tag rec-tag--severe">severe</span>}
+											<span className="rec-ghost-outcome">{ghostText(ghost, totalMine, totalTheirs)}</span>
+										</span>
+									)}
+									{!ghost && relocating && <span className="rec-ghost rec-ghost--relocate">fall back here</span>}
+									{!ghost && !relocating && verdict && (
+										<span className={`rec-stamp rec-stamp--${verdict.who}`}>{verdict.text}</span>
+									)}
+								</div>
+
+								<div className="rec-rank rec-rank--mine">
+									{mine.map((entry) => <ReclamationFigure {...figureProps(entry, you, 'up')} />)}
+									{mine.length === 0 && <span className="rec-rank-empty">no creatures sent here</span>}
+								</div>
 							</div>
-						</div>
-					</section>
-				);
-			})}
+						</section>
+					);
+				})}
+			</div>
 		</div>
 	);
 }

--- a/my-app/src/pages/games/reclamationPage.js
+++ b/my-app/src/pages/games/reclamationPage.js
@@ -104,6 +104,7 @@ class ReclamationPage extends React.Component {
 							<div className="g-screen-line">In Orders you assign each of your creatures an act, in secret. A creature you leave alone performs the act its archetype favors. You choose the creature, the site and the act; the creature chooses its own target, by its conduct.</div>
 							<div className="g-screen-line">At the Judge each site goes to the side with the greater surviving hold. A tie reverts the site to the Court. Creatures at a won site stay to hold the claim; the rest withdraw. Either way they are out of the expedition.</div>
 							<div className="g-screen-line">You bring {ROSTER_SIZE} creatures and may send {SENDABLE}. The two you never send are your reserve, chosen as you go.</div>
+							<div className="g-screen-line">Two small rules. The side that moves first on a world may, once, fall its first creature back to another site without spending a turn. And a stealthy creature may be sent hidden: the rival learns that you sent something, not what or where.</div>
 							<div className="g-screen-line--dim">Match seed: {seed}. Add ?seed=NUMBER to the address to replay an expedition.</div>
 						</div>
 


### PR DESCRIPTION
## Summary

A pass over the Reclamation table for legibility: what is happening, what matters, and what to click.

- **Status strip:** score as two five-pip tracks with world dots; the turn lamp and the instruction line are the loudest thing on the strip.
- **Sites:** each leads with a margin band ("you lead by 4.2", "rival leads by 3.1", "level, to the Court"), tinted by side. With a creature armed, every site shows "send here", the hold it would have, and what that does to the margin.
- **Figures:** element named beside the medallion, hold printed large, states tagged (strained, staggered, hidden, home), the ordered act worn as a badge during Orders.
- **Orders:** act chips instead of a select, with magnitude and class; the give button pinned at the top of the panel and echoed in a bar under the table; hovering a preview line lights the creatures it names.
- **Resolution:** the actor and target light up and the outcome pops over the target.
- **Deploy controls:** pass is a plain choice with its consequence in small print; fall back names the creature and says it is free; a note when the rival has passed; the rival's hidden send is a banner over the world.
- **Intro:** explains fall back and hidden sends.
- **1024 wide:** the template's forced heading sizes overridden, roster scrolls in one row.

## Verification

- `yarn test --run`: 305 tests pass.
- Played on the local table at 1440x900 and 1024x768: no page scroll, no overlapping panels, zero console errors beyond the app-wide Amplify line. Screenshots at deploy (armed), orders, mid-resolution and judge reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)