### PR TITLE
Reclamation: the intro fits one desktop screen

### DIFF
--- a/my-app/public/assets/css/reclamation.css
+++ b/my-app/public/assets/css/reclamation.css
@@ -70,23 +70,141 @@
 }
 
 /* -------------------------------------------------------------------------
-   START SCREEN
+   START SCREEN. One screen on a desktop: a compact masthead, then a panel split
+   between the briefing on the CRT and a charter card of the numbers, the small
+   rules and the button. Nothing here needs to scroll on a laptop.
    ------------------------------------------------------------------------- */
 
-.rec-intro-panel {
-	padding: var(--g-6);
+.rec-shell--intro {
+	width: 100%;
 	display: flex;
 	flex-direction: column;
-	gap: var(--g-5);
+	gap: var(--g-3);
+	padding: var(--g-3) var(--g-4) var(--g-4);
+}
+
+.rec-intro-panel {
+	padding: var(--g-4);
+	display: grid;
+	grid-template-columns: minmax(0, 3fr) minmax(300px, 2fr);
+	gap: var(--g-4);
+	align-items: stretch;
 }
 
 .rec-rules-screen {
 	display: flex;
 	flex-direction: column;
 	gap: var(--g-3);
+	min-width: 0;
 }
 
-.rec-rules-screen .g-screen-line { max-width: var(--g-measure); }
+.rec-rules-screen .g-screen-line { max-width: none; }
+
+.rec-rules-phases {
+	display: grid;
+	grid-template-columns: max-content minmax(0, 1fr);
+	column-gap: var(--g-3);
+	row-gap: var(--g-2);
+	margin: var(--g-1) 0 0;
+	padding-top: var(--g-3);
+	border-top: 1px solid var(--g-phosphor-dim);
+}
+
+.rec-rules-phases dt {
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-wide);
+}
+
+.rec-rules-phases dd { margin: 0; }
+
+.rec-intro-charter {
+	display: flex;
+	flex-direction: column;
+	gap: var(--g-4);
+	min-width: 0;
+}
+
+.rec-charter-figures {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: var(--g-2);
+}
+
+.rec-charter-figure {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--g-1);
+	padding: var(--g-3) var(--g-2);
+	border: 1px solid var(--g-rule);
+	background: var(--g-hull-lo);
+}
+
+.rec-charter-figure--key { border-color: var(--g-brass); }
+
+.rec-charter-number {
+	font-size: var(--g-size-h3);
+	font-weight: 600;
+	line-height: 1;
+	color: var(--g-ink);
+}
+
+.rec-charter-figure--key .rec-charter-number { color: var(--g-brass); }
+
+.rec-charter-sub {
+	font-size: var(--g-size-small);
+	color: var(--g-ink-low);
+}
+
+.rec-charter-label {
+	font-family: var(--g-font-stencil);
+	font-size: var(--g-size-micro);
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-wide);
+	color: var(--g-ink-low);
+	white-space: nowrap;
+}
+
+.rec-charter-rules {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--g-2);
+	font-size: var(--g-size-small);
+	line-height: 1.5;
+	color: var(--g-ink-mid);
+}
+
+.rec-charter-rules strong {
+	font-family: var(--g-font-stencil);
+	font-weight: 600;
+	font-size: var(--g-size-micro);
+	text-transform: uppercase;
+	letter-spacing: var(--g-track-wide);
+	color: var(--g-ink);
+	margin-right: var(--g-1);
+}
+
+.rec-intro-actions {
+	margin-top: auto;
+	display: flex;
+	flex-direction: column;
+	gap: var(--g-2);
+}
+
+.rec-intro-actions .g-btn { align-self: stretch; justify-content: center; }
+
+.rec-intro-seed {
+	font-size: var(--g-size-micro);
+	color: var(--g-ink-low);
+}
+
+@media (max-width: 900px) {
+	.rec-intro-panel { grid-template-columns: minmax(0, 1fr); }
+	.rec-charter-figures { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
 
 /* -------------------------------------------------------------------------
    MATCH SHELL

--- a/my-app/src/pages/games/reclamationPage.js
+++ b/my-app/src/pages/games/reclamationPage.js
@@ -90,29 +90,62 @@ class ReclamationPage extends React.Component {
 		return (
 			<div className="g-console rec-console rec-console--intro">
 				<XalianNavbar />
-				<div className="g-shell page-shell rec-shell">
-					<header className="page-header">
-						<p className="g-kicker">Kozrak's Charter</p>
-						<h1 className="g-title">Reclamation</h1>
+				<div className="g-shell rec-shell rec-shell--intro">
+					<header className="rec-masthead">
+						<span className="g-kicker">Kozrak's Charter</span>
+						<h1 className="rec-masthead-title">Reclamation</h1>
+						<span className="g-mono rec-masthead-seed">seed {seed}</span>
 					</header>
 
 					<div className="g-panel rec-intro-panel">
 						<div className="g-screen rec-rules-screen">
-							<div className="g-screen-line">The worlds were lost to war and plague. An expedition takes them back, site by site, and the Court's Charter is the acknowledgment of what you already hold.</div>
-							<div className="g-screen-line">A match crosses {WORLDS_PER_MATCH} worlds. Each world opens {3} sites. Hold {SITES_TO_CLINCH} sites and the Charter is clinched.</div>
-							<div className="g-screen-line">Each world runs Deploy, Orders, Resolve, Judge. In Deploy you alternate sending one creature to one site, or passing. Passing is permanent for that world.</div>
-							<div className="g-screen-line">In Orders you assign each of your creatures an act, in secret. A creature you leave alone performs the act its archetype favors. You choose the creature, the site and the act; the creature chooses its own target, by its conduct.</div>
-							<div className="g-screen-line">At the Judge each site goes to the side with the greater surviving hold. A tie reverts the site to the Court. Creatures at a won site stay to hold the claim; the rest withdraw. Either way they are out of the expedition.</div>
-							<div className="g-screen-line">You bring {ROSTER_SIZE} creatures and may send {SENDABLE}. The two you never send are your reserve, chosen as you go.</div>
-							<div className="g-screen-line">Two small rules. The side that moves first on a world may, once, fall its first creature back to another site without spending a turn. And a stealthy creature may be sent hidden: the rival learns that you sent something, not what or where.</div>
-							<div className="g-screen-line--dim">Match seed: {seed}. Add ?seed=NUMBER to the address to replay an expedition.</div>
+							<div className="g-screen-line">The worlds were lost to war and plague. An expedition takes them back, site by site. The Court's Charter is the acknowledgment of what you already hold.</div>
+							<div className="g-screen-line">A match crosses {WORLDS_PER_MATCH} worlds of {3} sites each. Hold {SITES_TO_CLINCH} sites and the Charter is clinched. Every world runs four phases.</div>
+							<dl className="rec-rules-phases">
+								<dt className="g-screen-line">Deploy</dt>
+								<dd className="g-screen-line">You and the rival alternate sending one creature to one site, or passing. A pass is permanent for that world.</dd>
+								<dt className="g-screen-line">Orders</dt>
+								<dd className="g-screen-line">Give each creature an act, in secret. Left alone, it performs the act its archetype favors. You choose the creature, the site and the act; the creature chooses its own target, by its conduct.</dd>
+								<dt className="g-screen-line">Resolve</dt>
+								<dd className="g-screen-line">The acts play out, and each creature's hold on its site is struck down, warded or kept.</dd>
+								<dt className="g-screen-line">Judge</dt>
+								<dd className="g-screen-line">Each site goes to the side with the greater surviving hold. A tie reverts it to the Court. Creatures at a won site stay to hold the claim; the rest withdraw. Either way they are out of the expedition.</dd>
+							</dl>
 						</div>
 
-						<div className="rec-intro-actions">
-							<button type="button" className="g-btn g-btn--primary" onClick={this.startMatch}>
-								Mount the expedition
-							</button>
-						</div>
+						<aside className="rec-intro-charter">
+							<div className="rec-charter-figures">
+								<div className="rec-charter-figure">
+									<span className="rec-charter-number g-mono">{WORLDS_PER_MATCH}</span>
+									<span className="rec-charter-label">worlds</span>
+								</div>
+								<div className="rec-charter-figure">
+									<span className="rec-charter-number g-mono">{WORLDS_PER_MATCH * 3}</span>
+									<span className="rec-charter-label">sites</span>
+								</div>
+								<div className="rec-charter-figure rec-charter-figure--key">
+									<span className="rec-charter-number g-mono">{SITES_TO_CLINCH}</span>
+									<span className="rec-charter-label">to clinch</span>
+								</div>
+								<div className="rec-charter-figure">
+									<span className="rec-charter-number g-mono">{ROSTER_SIZE}<span className="rec-charter-sub">/{SENDABLE}</span></span>
+									<span className="rec-charter-label">bring / send</span>
+								</div>
+							</div>
+
+							<ul className="rec-charter-rules">
+								<li><strong>Reserve.</strong> The {ROSTER_SIZE - SENDABLE} creatures you never send are your reserve, chosen as you go.</li>
+								<li><strong>Fall back.</strong> The side that moves first on a world may, once, move its first creature to another site without spending a turn.</li>
+								<li><strong>Hidden.</strong> A stealthy creature may be sent hidden. The rival learns that you sent something, not what or where.</li>
+							</ul>
+
+							<div className="rec-intro-actions">
+								<button type="button" className="g-btn g-btn--primary" onClick={this.startMatch}>
+									Mount the expedition
+								</button>
+								<span className="rec-intro-seed g-mono">Add ?seed={seed} to the address to replay this expedition.</span>
+							</div>
+						</aside>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
The start screen no longer needs a scroll on a laptop and the briefing text no longer sits in a narrow column inside a wide screen.

- Compact masthead (kicker, title, seed) instead of the page-sized title.
- The panel splits into the CRT briefing on the left (story, match shape, and the four phases as a labeled list) and a charter card on the right (worlds / sites / to clinch / bring-send readouts, the reserve, fall back and hidden rules, and the mount button).
- Screen lines fill their width instead of stopping at the prose measure.
- Under 900px wide the columns stack; the phone layout is unchanged otherwise.

Verified with playwright at 1536x730, 1440x900 and 1024x700: page height equals the viewport, the mount button is on screen without scrolling. 390px mobile still renders with no horizontal overflow. 305 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)