### PR TITLE
Reclamation: simple mode shows one hold per creature

### DIFF
--- a/my-app/public/assets/css/reclamation.css
+++ b/my-app/public/assets/css/reclamation.css
@@ -3526,3 +3526,20 @@
 	letter-spacing: var(--g-track-label);
 	font-family: var(--g-font-stencil);
 }
+
+/* simple mode: one hold on this world per slot, three only when the sites differ */
+.rec-slot-here,
+.rec-chosen-here {
+	display: grid;
+	grid-template-columns: 44px minmax(0, 1fr) 30px;
+	align-items: center;
+	gap: var(--g-2);
+}
+.rec-chosen-here { padding: var(--g-2) var(--g-3) 0; }
+.rec-chosen-here-note {
+	grid-column: 1 / -1;
+	font-family: var(--g-font-mono);
+	font-size: 0.5625rem;
+	color: var(--g-ink-low);
+}
+.rec-chosen-sites--hidden { display: none; }

--- a/my-app/src/components/games/reclamation/reclamationDeploy.js
+++ b/my-app/src/components/games/reclamation/reclamationDeploy.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReclamationRoster, { siteHoldsFor } from './reclamationRoster';
+import ReclamationRoster, { siteHoldsFor, holdsAgree } from './reclamationRoster';
 import XalianImage from '../../xalianImage';
 import { HoldMeter } from './reclamationFigure';
 import { speciesLabel, formatHold } from './reclamationNarration';
@@ -104,7 +104,9 @@ function ReclamationDeploy({
 		heading = 'Choose a creature';
 		lead = sendsLeft === 0
 			? `You have sent all ${SENDABLE} this expedition allows. The rest are your reserve.`
-			: 'Each slot shows what the creature would hold at every site of this world.';
+			: advanced
+				? 'Each slot shows what the creature would hold at every site of this world.'
+				: 'Each slot shows how firmly the creature would hold a site on this world.';
 	}
 
 	return (
@@ -126,7 +128,7 @@ function ReclamationDeploy({
 				{step === 1 && (
 					<span className="rec-hold-legend" title="Hold is how firmly a creature keeps a site: acts strike at it, and the Court gives the site to the side that still holds more.">
 						<HoldMeter hold={12} unstrained={16} strainLevel="strained" mine small />
-						<span className="rec-hold-legend-text">hold, and what a site would take from it</span>
+						<span className="rec-hold-legend-text">the strip is hold; the hatched tail is what the site takes</span>
 					</span>
 				)}
 			</header>
@@ -139,7 +141,7 @@ function ReclamationDeploy({
 						</span>
 						<span className="rec-chosen-body">
 							<span className="rec-chosen-name">{speciesLabel(armed)}</span>
-							<span className="rec-chosen-sub g-mono">{elementName(armed.element.primary).toLowerCase()} · {archetypeLabel(armed.archetype).toLowerCase()} · base hold {formatHold(baseHold(armed))}</span>
+							<span className="rec-chosen-sub g-mono">{elementName(armed.element.primary).toLowerCase()} · {archetypeLabel(armed.archetype).toLowerCase()}{advanced ? ` · base hold ${formatHold(baseHold(armed))}` : ''}</span>
 						</span>
 						<button type="button" className="g-btn rec-chosen-change" onClick={onDisarm} data-change-creature>Change</button>
 					</div>
@@ -147,7 +149,15 @@ function ReclamationDeploy({
 					<p className="rec-deploy-lead g-body rec-chosen-cue">
 						Press a site on the table. Each one shows what {speciesLabel(armed)} would hold there and how the balance would shift.
 					</p>
-					<span className="rec-slot-sites rec-chosen-sites" aria-label="Hold at each site of this world">
+					{!advanced && holdsAgree(holds) && (
+						<span className="rec-chosen-here">
+							<span className="rec-slot-meter-label">hold here</span>
+							<HoldMeter hold={holds[0].hold} unstrained={holds[0].unstrained} isHome={holds[0].isHome} strainLevel={holds[0].strainLevel} mine />
+							<span className="rec-slot-meter-value">{formatHold(holds[0].hold)}</span>
+							<span className="rec-chosen-here-note">the same at every site of this world</span>
+						</span>
+					)}
+					<span className={`rec-slot-sites rec-chosen-sites${!advanced && holdsAgree(holds) ? ' rec-chosen-sites--hidden' : ''}`} aria-label="Hold at each site of this world">
 						{holds.map((h) => (
 							<button
 								type="button"
@@ -188,6 +198,7 @@ function ReclamationDeploy({
 					onInspect={onInspect}
 					onHover={onHoverRecord}
 					disabled={!yourTurn || me.passed || sendsLeft === 0}
+					simple={!advanced}
 				/>
 			)}
 

--- a/my-app/src/components/games/reclamation/reclamationRoster.js
+++ b/my-app/src/components/games/reclamation/reclamationRoster.js
@@ -48,6 +48,26 @@ export function siteHoldsFor(record, view, you) {
 	});
 }
 
+// the three sites agree on a creature's hold more often than not; when they do, one
+// strip says it and three would only repeat it (Nick, 2026-09-04)
+export function holdsAgree(holds) {
+	if (!holds || holds.length === 0) {
+		return true;
+	}
+	const first = holds[0];
+	return holds.every((h) => Math.abs(h.hold - first.hold) < 0.05 && h.strainLevel === first.strainLevel && h.isHome === first.isHome);
+}
+
+function HoldHere({ h, label }) {
+	return (
+		<span className="rec-slot-here" title={`Holds ${formatHold(h.hold)} on this world${h.strainLevel !== 'none' ? `; the sites take ${formatHold(h.unstrained - h.hold)} of it` : ''}${h.isHome ? '; home ground' : ''}`}>
+			<span className="rec-slot-meter-label">{label || 'hold here'}</span>
+			<HoldMeter hold={h.hold} unstrained={h.unstrained} isHome={h.isHome} strainLevel={h.strainLevel} mine />
+			<span className="rec-slot-meter-value">{formatHold(h.hold)}</span>
+		</span>
+	);
+}
+
 function BaseHoldRow({ value }) {
 	return (
 		<span className="rec-slot-meter-row">
@@ -71,6 +91,7 @@ export function RosterSlot({
 	onInspect,
 	onHover,
 	compact,
+	simple,
 }) {
 	const el = record.element.primary;
 	const classes = ['rec-slot', `rec-slot--${slot.state}`, `g-el-${el}`];
@@ -109,8 +130,9 @@ export function RosterSlot({
 						{inHand && suggested && <span className="rec-slot-tag rec-slot-tag--suggested">suggested</span>}
 						{inHand && stealthy && <span className="rec-slot-tag rec-slot-tag--stealthy" title="Can be sent hidden">stealthy</span>}
 					</span>
-					<BaseHoldRow value={baseHold(record)} />
-					{inHand && holds && (
+					{(!simple || !inHand || !holds) && <BaseHoldRow value={baseHold(record)} />}
+					{simple && inHand && holds && holdsAgree(holds) && <HoldHere h={holds[0]} />}
+					{inHand && holds && (!simple || !holdsAgree(holds)) && (
 						<span className="rec-slot-sites" aria-label="Hold at each site of this world">
 							{holds.map((h) => (
 								<span
@@ -151,6 +173,7 @@ function ReclamationRoster({
 	onHover,
 	disabled,
 	compact,
+	simple,
 }) {
 	const inHand = (view.players[you].roster || []).length;
 	return (
@@ -173,6 +196,7 @@ function ReclamationRoster({
 							onInspect={onInspect}
 							onHover={onHover}
 							compact={compact}
+							simple={simple}
 						/>
 					);
 				})}


### PR DESCRIPTION
## Summary

Nick (2026-09-04): in simple mode the three per-site holds usually repeat the same value, the base hold number above them disagrees with them, and a bar plus a number for the same thing is one too many.

- **One strip per creature in simple mode.** A slot shows "hold here": how firmly the creature holds a site on this world, the strip and one number being the same quantity, the hatched tail being what the site takes. Three per-site strips appear only when the sites actually differ (Scalatto: 21 / 10.5 / 21).
- **Base hold leaves simple mode**, from the slots and from the chosen creature's card. Advanced mode keeps the base hold row, the three chips and the base hold in the card.
- Head lead and legend copy updated to say what the strip is.

Rule recorded for the mode: one number per concept; show three only when they differ; a bar and its number are the same quantity.

## Verification

380 tests pass. Headless play at 1440x900 in simple mode: slots show one strip (three only for the creature whose sites differ), sends go through the sites, orders and judge as before. No errors, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)