### PR TITLE
Encyclopedia: how the names are said

### DIFF
--- a/docs/encyclopedia/ENCYCLOPEDIA-INTERNAL.md
+++ b/docs/encyclopedia/ENCYCLOPEDIA-INTERNAL.md
@@ -44,6 +44,22 @@ The Luminax dark-side rebellion; the Zolto network-building underground; Kozrak'
 - American English. No em-dashes.
 - New entries append to `encyclopedia.json` with the same schema; definitions written for the Encyclopedia are canonical from the moment Nick ratifies them. After any change run `node scripts/bundleLore.js` and `yarn copy-json`. `glossary.json` no longer has a reader; it is kept only until the lambda side stops shipping it, so there is no need to back-port fixes to it.
 
+## Pronunciation (ratified 2026-09-04)
+
+Coined names carry an optional `pronunciation` object on their entry: `{ "respelling": "fan-TEER-ee", "ipa": "fænˈtɪəri" }`. The respelling is what the site prints, under the designation in mono, on entry, species and world records alike (`my-app/src/components/encyclopedia/Pronunciation.js`); the IPA rides along in the data for anything that wants it later (an audio pass, a screen reader) and is exposed only as the element's title attribute.
+
+Nick's rulings:
+
+- **The Vallerii sound Roman.** Names the Vallerii coined take a classical Latin reading: Vallerii is val-LEH-ree-eye, Grimedes is gri-MEE-deez, Poseidas is po-SY-das, Mercurius is mer-KOO-ree-us, Luminarii is loo-mih-NAH-ree-eye. This is a fact about the Empire's language, so it applies to anything they named.
+- **The classical rule stops at Vallerii coinages and does not reach creature names.** A Xalian is not a Vallerii artifact, so Luceras is loo-SEH-rus with the soft English c, not the classical hard k, despite the Latin root. Apply the plain English reading to species names.
+- **Transparent names carry no pronunciation at all.** Death Tide, Drilltail, World Trees and the like are left unmarked rather than respelled to no purpose; an absent field means "reads as written." 18 entries are deliberately unmarked.
+- **Real-world names take their real readings.** Cybele (the Phrygian goddess) is SIB-uh-lee and Bacillota Requiem is scientific Latin, bah-sih-LOH-tuh REK-wee-em. Neither is an invention, so neither is ours to respell freely.
+- **Algael is AL-gale**, hard g, keeping the algae etymology the definition states audible to a reader meeting the word cold.
+- **Xalia is ZAY-lee-uh and Xalians is ZAY-lee-unz.**
+- Saigill (SAY-gill) is a default rather than a ruling; Nick did not recognize the word, and nothing in the lore anchors it. Revisit if it ever matters.
+
+A name that appears in more than one entry is pronounced identically in each (Phantiri the world, Operation Phantiri, and the Phantiri Xalians all read fan-TEER-ee). `my-app/src/lore/__tests__/lore.pronunciation.test.js` asserts that, the ratified readings above, and that the respelling actually paints under the title.
+
 ## Relationship to the shipped bundle
 
 `encyclopedia.json` is the public structured file. The flip happened on 2026-09-02: `scripts/bundleLore.js` copies it, `chronicle.json`, `docs/species-templates/registries.json`, and the species records listed in `docs/species-templates/RATIFIED.json` (as `speciesRecords.json`, mechanical template fields only) into `lambda/src/json/`, and `copy-json` mirrors them into the frontend, where `my-app/src/lore/` is the only reader and the `/encyclopedia` page renders them (contract: `docs/design/xalian-encyclopedia-page.md`). Per Nick's ruling on 2026-09-03 (one source location per kind of data), species encyclopedia entries live only in `encyclopedia.json` under category `xalians`, written straight into `entries` during migration; `speciesRecords.json` carries no entries at all, and there is no per-species side file. `tour.json` (the First Survey) is bundled the same way; it is derived prose, outranked by the histories and by this file's entries, and is edited only with Nick's sign-off. The demonym entries (`magmuthites`, `grimedites`, `luminarii`, `the-zolto`, `krystians`, `veridians`, `phantiri-xalians`) stay in category `factions` (append-only) and the Powers page regroups them under Xalian Peoples. The old `/glossary`, `/planets`, and `/species` pages were retired (2026-09-03); their routes now redirect into the Encyclopedia. This companion file stays out of the bundle permanently.

--- a/docs/encyclopedia/README.md
+++ b/docs/encyclopedia/README.md
@@ -18,7 +18,8 @@ The single public canon reference for the world of Xalia. Ratified 2026-09-01: t
   "definition": "…verbatim canonical prose…",
   "related": ["mercurius-machine", "king-kozrak"],
   "element": "(planet entries only)",
-  "aliases": "(optional string[]) -- other proper names that unambiguously mean this entry, e.g. [\"Kozrak\"]"
+  "aliases": "(optional string[]) -- other proper names that unambiguously mean this entry, e.g. [\"Kozrak\"]",
+  "pronunciation": "(optional) { respelling, ipa } -- coined names only; absent means the name reads as written"
 }
 ```
 

--- a/docs/encyclopedia/encyclopedia.json
+++ b/docs/encyclopedia/encyclopedia.json
@@ -29,6 +29,10 @@
       "title": "Akinza",
       "category": "xalians",
       "definition": "The Akinza is an upright nocturnal Xalian of Krystos, generated after the impact winter, with outsized fringed ears, light-gathering eyes, and a spread of plumed tail fronds. It belongs to the feral stock of the arctic wastelands outside the planet's prison complexes and moves through open snow without sound or track.",
+      "pronunciation": {
+        "respelling": "uh-KIN-zuh",
+        "ipa": "əˈkɪnzə"
+      },
       "related": [
         "krystos"
       ]
@@ -38,6 +42,10 @@
       "title": "Algael",
       "category": "substances",
       "definition": "A blue-green, gel-like substance of sulfated polysaccharides formed from the decomposed algae found in Poseidas' oceans, which is known for its remarkable healing properties.",
+      "pronunciation": {
+        "respelling": "AL-gale",
+        "ipa": "ˈælgeɪl"
+      },
       "related": [
         "poseidas"
       ]
@@ -47,6 +55,10 @@
       "title": "APEX",
       "category": "factions",
       "definition": "The Automated Protocol for Enforcement on Xalians. An artificial intelligence designed to regulate the use of Xalian Generators and prevent their use in warfare, who later turned on the Vallerii, beginning the End Wars.",
+      "pronunciation": {
+        "respelling": "AY-peks",
+        "ipa": "ˈeɪpɛks"
+      },
       "related": [
         "the-end-wars",
         "vallerii",
@@ -58,6 +70,10 @@
       "title": "APEX Accords",
       "category": "history",
       "definition": "A treaty spearheaded by ECHELON and signed by the Thousand Families, agreeing to place the Xalian Generators under the control of APEX in order to prevent their use in warfare.",
+      "pronunciation": {
+        "respelling": "AY-peks",
+        "ipa": "ˈeɪpɛks"
+      },
       "related": [
         "apex",
         "echelon",
@@ -69,6 +85,10 @@
       "title": "Avilily",
       "category": "xalians",
       "definition": "The Avilily is a small carnivorous bird of Floria whose beak opens into a false flower, luring insects with sweet sedative saliva that paralyzes whatever it touches. Once carried by Vallerii explorers as living insect control, Avililies now gather in swarms that guard the most sacred parts of Floria's jungles.",
+      "pronunciation": {
+        "respelling": "AV-ih-lil-ee",
+        "ipa": "ˈævɪlɪli"
+      },
       "related": [
         "floria",
         "vallerii"
@@ -82,6 +102,10 @@
       "title": "Bacillota Requiem",
       "category": "substances",
       "definition": "The scientific name for the microorganism that produces Nightcap, a biochemical present only on Endessa that is necessary to induce stasis for sub-light space travel.",
+      "pronunciation": {
+        "respelling": "bah-sih-LOH-tuh REK-wee-em",
+        "ipa": "bɑsɪˈloʊtə ˈrɛkwiɛm"
+      },
       "related": [
         "endessa",
         "nightcap"
@@ -101,6 +125,10 @@
       "title": "Battle of Grimedes",
       "category": "history",
       "definition": "The final battle of the End Wars, in which APEX was repelled into dark space.",
+      "pronunciation": {
+        "respelling": "gri-MEE-deez",
+        "ipa": "grɪˈmiːdiːz"
+      },
       "related": [
         "apex",
         "the-end-wars"
@@ -111,6 +139,10 @@
       "title": "Benthane",
       "category": "substances",
       "definition": "A rarified gas found only on Saiphus that is used as a valuable heat sink for laser weapons. The gas is most commonly refined and processed into several derivative gases that serve as effective Tachyon Drive Core coolants necessary for contiguous lightspeed journeys.",
+      "pronunciation": {
+        "respelling": "BEN-thane",
+        "ipa": "ˈbɛnθeɪn"
+      },
       "related": [
         "saiphus",
         "tachyon-drive-core"
@@ -121,6 +153,10 @@
       "title": "Bioflim",
       "category": "xalians",
       "definition": "The Bioflim is a slime-bodied Xalian of Drainov sheathed in a thick rocky exoskeleton that its own slime continually regenerates. It is built for the planet's acid swamps and corrosive rain.",
+      "pronunciation": {
+        "respelling": "BY-oh-flim",
+        "ipa": "ˈbaɪoʊflɪm"
+      },
       "related": [
         "drainov"
       ]
@@ -139,6 +175,10 @@
       "title": "Bloodstorm",
       "category": "phenomena",
       "definition": "A weather phenomenon on Zolton identifiable by the frequent occurrence of dark-red lightning and crimson lightning sprites, whose quantum entangling effects can be carefully channeled into a Quantum Entanglement Device",
+      "pronunciation": {
+        "respelling": "BLUD-storm",
+        "ipa": "ˈblʌdstɔːrm"
+      },
       "related": [
         "zolton"
       ]
@@ -148,6 +188,10 @@
       "title": "Carbide-1",
       "category": "technology",
       "definition": "A factoryscape on Drainov which underwent a plant-wide melt down, setting off a chain reaction which led to the world-ending Drainov Disaster.",
+      "pronunciation": {
+        "respelling": "KAR-bide ONE",
+        "ipa": "ˈkɑːrbaɪd ˈwʌn"
+      },
       "related": [
         "drainov",
         "drainov-disaster"
@@ -158,6 +202,10 @@
       "title": "Cherenkov radiation",
       "category": "phenomena",
       "definition": "A form of radiation given off by Tachyon drive cores which rendered the spacefaring Vallerii population sterile, beginning the Age of Unbirth.",
+      "pronunciation": {
+        "respelling": "chuh-RENG-kof",
+        "ipa": "tʃəˈrɛŋkɒf"
+      },
       "related": [
         "age-of-unbirth",
         "vallerii"
@@ -171,6 +219,10 @@
       "title": "Chromocat",
       "category": "xalians",
       "definition": "The Chromocat is a large albino feline of Luminax, generated to harvest the planet's crop fields with a pair of sickle-shaped blades of ionized radiation that extend backwards from its front paws. It can enter a photonic state and cross ground at the speed of light, and it now turns that speed and those blades on opponents in rapid cuts.",
+      "pronunciation": {
+        "respelling": "KROH-moh-kat",
+        "ipa": "ˈkroʊmoʊkæt"
+      },
       "related": [
         "luminax"
       ]
@@ -191,6 +243,10 @@
       "title": "Codazzo",
       "category": "xalians",
       "definition": "The Codazzo is an upright burrowing Xalian of Stonera whose raised tail carries a fan of explosive barbs. Startled, it digs its body underground and leaves only the tail above the surface, firing barbs at anything that provokes it and regrowing them.",
+      "pronunciation": {
+        "respelling": "koh-DAZ-oh",
+        "ipa": "koʊˈdæzoʊ"
+      },
       "related": [
         "stonera"
       ]
@@ -210,6 +266,10 @@
       "title": "Crystorn",
       "category": "xalians",
       "definition": "The Crystorn is a heavy, long-haired Xalian of Luminax that sits upright on folded legs and carries a pair of crystal horns on its head, which transmit powerful light energy. It was generated among the crystal-bearing Xalians that worked the planet's fields and oases of translucent flora.",
+      "pronunciation": {
+        "respelling": "KRIS-torn",
+        "ipa": "ˈkrɪstɔːrn"
+      },
       "related": [
         "luminax",
         "xalians"
@@ -220,6 +280,10 @@
       "title": "Cybele",
       "category": "places",
       "definition": "The star system that is home to Stonera, the Jorian Belt, and the now defunct APEX superweapon known as the Terracannon.",
+      "pronunciation": {
+        "respelling": "SIB-uh-lee",
+        "ipa": "ˈsɪbəliː"
+      },
       "related": [
         "apex",
         "jorian-belt",
@@ -254,6 +318,10 @@
       "title": "Drainov",
       "category": "places",
       "definition": "A planet-wide chemical disaster site that was once the industrial powerhouse of the Vallerii Empire.",
+      "pronunciation": {
+        "respelling": "DRAY-nov",
+        "ipa": "ˈdreɪnɒv"
+      },
       "related": [
         "vallerii"
       ],
@@ -264,6 +332,10 @@
       "title": "Drainov Disaster",
       "category": "history",
       "definition": "A chain reaction beginning at the Carbide-1 factoryscape on Drainov which vented world-ending levels of poisonous gas into the atmosphere in a planet-killing event.",
+      "pronunciation": {
+        "respelling": "DRAY-nov",
+        "ipa": "ˈdreɪnɒv"
+      },
       "related": [
         "carbide-1",
         "drainov"
@@ -274,6 +346,10 @@
       "title": "Dreadscape",
       "category": "places",
       "definition": "The vast wasteland blanketing Phantiri, formed from the piled remains of the countless Xalians its Generator produced only for them to die on sight. Their bodies have compressed into islands of corpses crowned with macabre forests of splayed limbs, divided by deep, tarry oceans of the fluids that seep from a planetwide mass grave.",
+      "pronunciation": {
+        "respelling": "DRED-skape",
+        "ipa": "ˈdrɛdskeɪp"
+      },
       "related": [
         "phantiri",
         "xalians"
@@ -294,6 +370,10 @@
       "title": "Dromeus",
       "category": "xalians",
       "definition": "The Dromeus is a running ground bird of Magmuth, partially feathered and lizard featured, generated by the planet's mining corporations for the transient mineral islands. It runs down what it eats and spreads its wings for a few seconds of flight to finish the strike with its teeth.",
+      "pronunciation": {
+        "respelling": "droh-MEE-us",
+        "ipa": "droʊˈmiːəs"
+      },
       "related": [
         "magmuth"
       ]
@@ -303,6 +383,10 @@
       "title": "ECHELON",
       "category": "factions",
       "definition": "A consortium of Vallerii corporations formed to present a united front against the aristocratic Thousand Families with the primary goal of ending the use of Xalian Generators in warfare.",
+      "pronunciation": {
+        "respelling": "ESH-uh-lon",
+        "ipa": "ˈɛʃəlɒn"
+      },
       "related": [
         "thousand-families",
         "vallerii"
@@ -313,6 +397,10 @@
       "title": "Ectoghoul",
       "category": "xalians",
       "definition": "The Ectoghoul is a drifting phantom of Phantiri, formed of green mist gathered into a grinning skull above a trailing tail, that passes through solid surfaces and vanishes and returns at will. It ranges the Dreadscape harassing other Xalians with its cackle and with blasts of gooey ectoplasm.",
+      "pronunciation": {
+        "respelling": "EK-toh-gool",
+        "ipa": "ˈɛktoʊguːl"
+      },
       "related": [
         "dreadscape",
         "phantiri",
@@ -324,6 +412,10 @@
       "title": "Endessa",
       "category": "places",
       "definition": "An aquatic world known for being the sole source of Nightcap in the universe, which has since been reduced to a desert wasteland after a world-ending orbital bombardment campaign.",
+      "pronunciation": {
+        "respelling": "en-DESS-uh",
+        "ipa": "ɛnˈdɛsə"
+      },
       "related": [
         "nightcap"
       ],
@@ -334,6 +426,10 @@
       "title": "Figzy",
       "category": "xalians",
       "definition": "The Figzy is a small antlered Xalian generated on Telypso to counterbalance the unstable auras of the Vallerii prisoners marooned in the planet's fungal forests. It is deceptively smart, docile toward what it trusts, and projects force from its raised hands.",
+      "pronunciation": {
+        "respelling": "FIG-zee",
+        "ipa": "ˈfɪgzi"
+      },
       "related": [
         "telypso",
         "vallerii"
@@ -344,6 +440,10 @@
       "title": "Floria",
       "category": "places",
       "definition": "An inhospitable world of apocalyptic weather patterns which has since been terraformed into a vibrant forest planet by the first Xalian Generator.",
+      "pronunciation": {
+        "respelling": "FLOR-ee-uh",
+        "ipa": "ˈflɔːriə"
+      },
       "related": [
         "xalian-generator"
       ],
@@ -354,6 +454,10 @@
       "title": "Foromeer",
       "category": "xalians",
       "definition": "The Foromeer is an upright two-legged Xalian of Veridium whose hands are long drill-like horns, able to break through the strongest of material. It carries a metallic exoskeleton on its limbs and is thought to once have been used for mineral excavation.",
+      "pronunciation": {
+        "respelling": "FOR-uh-meer",
+        "ipa": "ˈfɔːrəmɪər"
+      },
       "related": [
         "veridium"
       ]
@@ -363,6 +467,10 @@
       "title": "Genesis Prototype",
       "category": "technology",
       "definition": "The first Xalian Generator, which was responsible for terraforming the planet Floria.",
+      "pronunciation": {
+        "respelling": "JEN-uh-sis",
+        "ipa": "ˈdʒɛnəsɪs"
+      },
       "related": [
         "floria",
         "xalian-generator"
@@ -385,6 +493,10 @@
       "title": "Graviclaw",
       "category": "xalians",
       "definition": "The Graviclaw is a black-shelled crustacean Xalian of Grimedes, centaur-like in build, which lurks beneath the planet's foggy wetlands and intensifies gravitational waves to open miniature black holes in the water. It draws prey into its massive claws, which snap shut with a force far heavier than their size implies, and it can root itself to the ground as an immovable wall of chitin.",
+      "pronunciation": {
+        "respelling": "GRAV-ih-klaw",
+        "ipa": "ˈgrævɪklɔː"
+      },
       "related": [
         "grimedes"
       ]
@@ -394,6 +506,10 @@
       "title": "Grimedes",
       "category": "places",
       "definition": "A planet of perpetual night on the outer rim of Xalia, which borders a black hole and is known for having been the last bastion of APEX's forces during the End Wars.",
+      "pronunciation": {
+        "respelling": "gri-MEE-deez",
+        "ipa": "grɪˈmiːdiːz"
+      },
       "related": [
         "apex",
         "the-end-wars",
@@ -406,6 +522,10 @@
       "title": "Hippochamp",
       "category": "xalians",
       "definition": "The Hippochamp is a four-legged, seahorse-shaped Xalian of Poseidas whose long snout works as a high-pressure water cannon. It was designed to answer the electrical and chemical fires that occur on the hydro-processing rigs and to defend the rigs' Algael against pirates.",
+      "pronunciation": {
+        "respelling": "HIP-uh-champ",
+        "ipa": "ˈhɪpətʃæmp"
+      },
       "related": [
         "algael",
         "poseidas"
@@ -416,6 +536,10 @@
       "title": "Hypnopet",
       "category": "xalians",
       "definition": "The Hypnopet is a small, golden-furred creature of Telypso bearing a single color-changing horn, generated by the Telypso Generator as a service animal and therapist for the deranged Vallerii imprisoned on that world. Its horn pulses through shifting color to lock a subject in a trance, a sedative once used on patients in bouts of mania and now used by King Kozrak for crowd control on rebellious worlds.",
+      "pronunciation": {
+        "respelling": "HIP-noh-pet",
+        "ipa": "ˈhɪpnoʊpɛt"
+      },
       "related": [
         "king-kozrak",
         "telypso",
@@ -437,6 +561,10 @@
       "title": "Imprit",
       "category": "xalians",
       "definition": "The Imprit is a small horned Xalian of Magmuth, furred against the flammable oils it secretes and so burning continuously, designed by the Vallerii as a tinkerer and released into the mining shafts to repair the equipment sent down into the planet. Freed onto the surface it swings by its scythe-tipped tail and sets fires where they do not belong.",
+      "pronunciation": {
+        "respelling": "IM-prit",
+        "ipa": "ˈɪmprɪt"
+      },
       "related": [
         "magmuth",
         "vallerii"
@@ -447,6 +575,10 @@
       "title": "ION-9",
       "category": "technology",
       "definition": "The 'Divine Light' solar cannon which was constructed as a superweapon from the Stellaris Superstructure. A system by which the panels of the Dyson sphere could be angled like a mirror to concentrate the solar energy of one of Luminax's stars into a deadly beam of energy.",
+      "pronunciation": {
+        "respelling": "EYE-on NINE",
+        "ipa": "ˈaɪɒn ˈnaɪn"
+      },
       "related": [
         "luminax",
         "stellaris-superstructure"
@@ -457,6 +589,10 @@
       "title": "Jorian Belt",
       "category": "places",
       "definition": "An asteroid belt in the Cybele System, which collides with the planet Stonera once a year. The home of the now defunct APEX superweapon known as the Terracannon.",
+      "pronunciation": {
+        "respelling": "JOR-ee-un",
+        "ipa": "ˈdʒɔːriən"
+      },
       "related": [
         "apex",
         "cybele",
@@ -469,6 +605,10 @@
       "title": "Kelpan-5",
       "category": "places",
       "definition": "The original name of Endessa when it was still a vibrant aquatic breadbasket in the early days of the Vallerii Empire.",
+      "pronunciation": {
+        "respelling": "KEL-pan FIVE",
+        "ipa": "ˈkɛlpæn ˈfaɪv"
+      },
       "related": [
         "endessa",
         "vallerii"
@@ -479,6 +619,10 @@
       "title": "King Kozrak",
       "category": "people",
       "definition": "One of the last surviving members of the Vallerii race, who has used his knowledge of the Mercurius Machine to amass tyrannical power over the galaxy and institute the tournament for Scrambler Tokens.",
+      "pronunciation": {
+        "respelling": "KOZ-rak",
+        "ipa": "ˈkɒzræk"
+      },
       "related": [
         "mercurius-machine",
         "vallerii"
@@ -492,6 +636,10 @@
       "title": "Kosanos",
       "category": "xalians",
       "definition": "The Kosanos is a heavy four-legged Xalian of Floria with a broad blade at the end of its trunk, thought to have been designed to clear the planet's thick brush. It fells standing growth in the underforests below the World Trees.",
+      "pronunciation": {
+        "respelling": "koh-SAH-nos",
+        "ipa": "koʊˈsɑːnoʊs"
+      },
       "related": [
         "floria",
         "world-trees"
@@ -502,6 +650,10 @@
       "title": "Krystos",
       "category": "places",
       "definition": "A warmwater paradise that served as a vacation destination for Vallerii high society until it was plunged into an arctic apocalypse caused by an asteroid impact and converted into a frozen prison world and planetary cold-storage facility for APEX.",
+      "pronunciation": {
+        "respelling": "KRIS-tos",
+        "ipa": "ˈkrɪstɒs"
+      },
       "related": [
         "apex",
         "vallerii"
@@ -513,6 +665,10 @@
       "title": "Leviticus Overdrive",
       "category": "technology",
       "definition": "The name given to the Phantiri Generator's unprecedented act of re-writing its own code after centuries of watching its creations die on arrival. Under this new programming it abandoned organic life entirely, learning instead to produce ghost-like Xalians formed of spectral energy with no corporeal bodies at all.",
+      "pronunciation": {
+        "respelling": "leh-VIT-ih-kus",
+        "ipa": "ləˈvɪtɪkəs"
+      },
       "related": [
         "phantiri",
         "xalians"
@@ -523,6 +679,10 @@
       "title": "Luceras",
       "category": "xalians",
       "definition": "The Luceras is a small long-eared, curve-horned leaping animal of Saiphus, one of the great leaping animals that bound between the planet's floating islands. It jumps so high that at times it seems as if it is flying, and comes down on what it strikes like a battering ram.",
+      "pronunciation": {
+        "respelling": "loo-SEH-rus",
+        "ipa": "luːˈsɛrəs"
+      },
       "related": [
         "saiphus"
       ]
@@ -532,6 +692,10 @@
       "title": "Luminax",
       "category": "places",
       "definition": "A planet with binary stars that is subject to immense radiation, therefore serving as the solar energy capital of Xalia.",
+      "pronunciation": {
+        "respelling": "LOO-mih-naks",
+        "ipa": "ˈluːmɪnæks"
+      },
       "related": [
         "xalia"
       ],
@@ -542,6 +706,10 @@
       "title": "Magmuth",
       "category": "places",
       "definition": "A fiery hellscape of a planet known for containing valuable minerals.",
+      "pronunciation": {
+        "respelling": "MAG-muth",
+        "ipa": "ˈmægməθ"
+      },
       "related": [],
       "element": "fire"
     },
@@ -550,6 +718,10 @@
       "title": "Magmuth Massacre",
       "category": "history",
       "definition": "A massacre of Xalian laborers that took part at a mining camp on Magmuth as part of a corporate power struggle which led to the planet-wide revolt of Magmuth's Xalian population against the Vallerii.",
+      "pronunciation": {
+        "respelling": "MAG-muth",
+        "ipa": "ˈmægməθ"
+      },
       "related": [
         "magmuth",
         "vallerii"
@@ -559,6 +731,10 @@
       "title": "Magmuthites",
       "category": "factions",
       "definition": "The people of Magmuth. Stereotyped by other Xalians as the most aggressive, rebellious, and warlike of their kind, they remain wracked by internecine warfare fueled by old blood feuds from the company wars, and the rest of Xalia quietly counts itself fortunate that they have never united.",
+      "pronunciation": {
+        "respelling": "MAG-muth-ites",
+        "ipa": "ˈmægməθaɪts"
+      },
       "key": "magmuthites",
       "related": [
         "company-wars",
@@ -572,6 +748,10 @@
       "title": "Mercurius Machine",
       "category": "technology",
       "definition": "A unique device controlled by King Kozrak on Valleron, which prints Scrambler Tokens that can be used to breed new Xalians that are immune to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "mer-KOO-ree-us",
+        "ipa": "mɜrˈkjʊəriəs"
+      },
       "related": [
         "king-kozrak",
         "nemesis-plague",
@@ -584,6 +764,10 @@
       "title": "Nemesis Plague",
       "category": "phenomena",
       "definition": "A galaxy-killing virus built by APEX which targets the genomes of the Vallerii and Xalians alike.",
+      "pronunciation": {
+        "respelling": "NEM-uh-sis",
+        "ipa": "ˈnɛməsɪs"
+      },
       "related": [
         "apex",
         "vallerii",
@@ -595,6 +779,10 @@
       "title": "Neph",
       "category": "xalians",
       "definition": "The Neph is a colossal hydrogen jellyfish of Saiphus, drifting in flocks through the lower atmosphere and drawing Benthane and atmospheric plankton up through long trailing tentacles. Generated for the Benthane industry, it is shepherded and milked for the coolant gas that keeps Tachyon Drive Cores from superheating.",
+      "pronunciation": {
+        "respelling": "nef",
+        "ipa": "nɛf"
+      },
       "related": [
         "benthane",
         "saiphus"
@@ -605,6 +793,10 @@
       "title": "Newtapede",
       "category": "xalians",
       "definition": "The Newtapede is a sixteen legged amphibious Xalian of Poseidas, long and segmented, with a slender frame and webbed feet that make it a formidable opponent in water. It lives among the water-breathing Xalians of the planet's rigs.",
+      "pronunciation": {
+        "respelling": "NOOT-uh-peed",
+        "ipa": "ˈnuːtəpiːd"
+      },
       "related": [
         "poseidas",
         "xalians"
@@ -615,6 +807,10 @@
       "title": "Nightcap",
       "category": "substances",
       "definition": "A biochemical present only on Endessa that is necessary to induce stasis for sub-light space travel.",
+      "pronunciation": {
+        "respelling": "NITE-kap",
+        "ipa": "ˈnaɪtkæp"
+      },
       "related": [
         "endessa"
       ]
@@ -623,6 +819,10 @@
       "title": "Operation Phantiri",
       "category": "history",
       "definition": "The codename under which top secret Vallerii excavations of Shadharam IV continued for decades, termed after the nickname xenoarchaeologists gave the planet's original inhabitants. Its findings were sealed and classified after the reawakening of the moon-weapon that followed the discovery of the City of Wraiths.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "key": "operation-phantiri",
       "related": [
         "city-of-wraiths",
@@ -635,6 +835,10 @@
       "title": "Phantiri",
       "category": "places",
       "definition": "A tomb world whose lifeforms are under constant assault from an unknown energy source emanating from its orbital moon and whose Xalian Generator has responded by creating Xalians of a spectral, undead nature. Alternatively, the name of the extinct ancient alien species who once inhabited the planet and the top secret operation which uncovered their remains.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "related": [
         "xalian-generator",
         "xalians"
@@ -646,6 +850,10 @@
       "title": "Poseidas",
       "category": "places",
       "definition": "An ocean world that is subject to toxic algae blooms, torrential hurricanes, and immense tsunamis. The only known source of Algael in Xalia.",
+      "pronunciation": {
+        "respelling": "po-SY-das",
+        "ipa": "poʊˈsaɪdəs"
+      },
       "related": [
         "algael",
         "xalia"
@@ -657,6 +865,10 @@
       "title": "QED",
       "category": "technology",
       "definition": "Quantum Entanglement Device. A specially engineered computer chip exposed to a Bloodstorm on Zolton, which can be used to link communications equipment across the galaxy.",
+      "pronunciation": {
+        "respelling": "cue-ee-DEE",
+        "ipa": "kjuː iː ˈdiː"
+      },
       "related": [
         "bloodstorm",
         "zolton"
@@ -671,6 +883,10 @@
       "title": "Saigill Combines",
       "category": "factions",
       "definition": "The largest agricorp in the Vallerii Empire, which was driven to bankruptcy in its attempt to terraform Luminax before the invention of the Xalian Generators.",
+      "pronunciation": {
+        "respelling": "SAY-gill",
+        "ipa": "ˈseɪgɪl"
+      },
       "related": [
         "luminax",
         "vallerii"
@@ -681,6 +897,10 @@
       "title": "Saiphus",
       "category": "places",
       "definition": "A hydrogen-helium gas giant that is home to the only known source of Benthane in Xalia.",
+      "pronunciation": {
+        "respelling": "SIGH-fus",
+        "ipa": "ˈsaɪfəs"
+      },
       "related": [
         "benthane",
         "xalia"
@@ -692,6 +912,10 @@
       "title": "Scalatto",
       "category": "xalians",
       "definition": "The Scalatto is a plated two-legged Xalian of Endessa shielded by a scaly exoskeleton that lets it roll into a ball to protect itself. It lives in the sand and cavern networks of its homeworld.",
+      "pronunciation": {
+        "respelling": "skuh-LAT-oh",
+        "ipa": "skəˈlætoʊ"
+      },
       "related": [
         "endessa"
       ]
@@ -701,6 +925,10 @@
       "title": "Scrambler Token",
       "category": "technology",
       "definition": "A special chip printed by the Mercurius Machine which possesses a randomly generated and encrypted Xalian genome that can be used by a Xalian Generator to create new, unique Xalians that are immune to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "SKRAM-blur",
+        "ipa": "ˈskræmblər"
+      },
       "related": [
         "nemesis-plague",
         "xalian-generator",
@@ -712,6 +940,10 @@
       "title": "Shadharam IV",
       "category": "places",
       "definition": "The original Vallerii name for the planet Phantiri, before the discovery the extinct alien species now known as the Phantiri after the name of the top secret operation under which they were discovered.",
+      "pronunciation": {
+        "respelling": "SHAD-uh-ram the FOURTH",
+        "ipa": "ˈʃædərɑm ðə ˈfɔːrθ"
+      },
       "related": [
         "phantiri",
         "vallerii"
@@ -722,6 +954,10 @@
       "title": "Smokat",
       "category": "xalians",
       "definition": "The Smokat is a clever upright feline generated on Phantiri to work the dig sites the Imperial Houses opened there, able to atomize into a cloud of smoke at will and gather itself again. It now hunts the haze above the Dreadscape.",
+      "pronunciation": {
+        "respelling": "SMOH-kat",
+        "ipa": "ˈsmoʊkæt"
+      },
       "related": [
         "dreadscape",
         "imperial-houses",
@@ -752,6 +988,10 @@
       "title": "Stellaris Superstructure",
       "category": "places",
       "definition": "A Dyson sphere which was constructed around one of Luminax's stars in order to capture over a hundred-quadrillion gigawatts per second of solar energy.",
+      "pronunciation": {
+        "respelling": "steh-LAH-ris",
+        "ipa": "stəˈlɑːrɪs"
+      },
       "related": [
         "luminax"
       ],
@@ -764,6 +1004,10 @@
       "title": "Stonera",
       "category": "places",
       "definition": "A rocky planet with an incredibly thin atmosphere that is subjected to annual planetary bombardments as it passes through its star system's asteroid belt, leading to an immense saturation of valuable minerals and rare earth metals.",
+      "pronunciation": {
+        "respelling": "stoh-NAIR-uh",
+        "ipa": "stoʊˈnɛərə"
+      },
       "related": [],
       "element": "rock"
     },
@@ -785,6 +1029,10 @@
       "title": "Tachyon Drive Core",
       "category": "technology",
       "definition": "The only engine known to be able to achieve faster than light space travel, but which emits sterilizing Cherenkov radiation.",
+      "pronunciation": {
+        "respelling": "TAK-ee-on",
+        "ipa": "ˈtækiɒn"
+      },
       "related": [
         "cherenkov-radiation"
       ]
@@ -794,6 +1042,10 @@
       "title": "Telypso",
       "category": "places",
       "definition": "A psychedelic world at the center of Xalia used by the Vallerii as a planetary asylum and believed to be the origin of all life in the galaxy. The planet disobeys the laws of physics and is believed to contain a sort of psychosphere or planetary consciousness that drives its inhabitants mad.",
+      "pronunciation": {
+        "respelling": "teh-LIP-so",
+        "ipa": "təˈlɪpsoʊ"
+      },
       "related": [
         "vallerii",
         "xalia"
@@ -805,6 +1057,10 @@
       "title": "Terracannon",
       "category": "technology",
       "definition": "A now defunct superweapon built by APEX which used a reverse-tractor beam to propel supermassive asteroids from the Jorian Belt at its targets.",
+      "pronunciation": {
+        "respelling": "TERR-uh-kan-un",
+        "ipa": "ˈtɛrəkænən"
+      },
       "related": [
         "apex",
         "jorian-belt"
@@ -818,6 +1074,10 @@
       "title": "Terragoyle",
       "category": "xalians",
       "definition": "The Terragoyle is a horned, winged sentry of Stonera that lines the edges of the Chasm, holding a stone aloft at the tip of its tail. Generated to airlift debris from the strip mines, it now hibernates in a statue-like state along the perimeter and, when roused, rises above the Chasm to fling boulders and rake intruders with falling gravel.",
+      "pronunciation": {
+        "respelling": "TERR-uh-goyl",
+        "ipa": "ˈtɛrəgɔɪl"
+      },
       "related": [
         "stonera",
         "the-chasm"
@@ -828,6 +1088,10 @@
       "title": "Tetrahive",
       "category": "xalians",
       "definition": "The Tetrahive is a small winged Xalian of Grimedes with a long whipping tail that fights by conjuring a swarm of little flying familiars with teeth like piranhas, holding every one of them in its mind and moving them as a single unit to attack or defend. It was generated as a test subject rather than a laborer, and hunts the planet's thick, stalky undergrowth in perpetual night.",
+      "pronunciation": {
+        "respelling": "TET-ruh-hive",
+        "ipa": "ˈtɛtrəhaɪv"
+      },
       "related": [
         "grimedes"
       ]
@@ -861,6 +1125,10 @@
       "title": "The Zolto",
       "category": "factions",
       "definition": "The people of Zolton. Freed from APEX's control by Source Code 606, the Zolto now work to re-establish the connection between worlds, hoping to prevent the extinction of Xalian-kind; King Kozrak has labeled those who form such networks galactic enemies and cracked down on the planet to control the manufacture of and access to QEDs.",
+      "pronunciation": {
+        "respelling": "ZOL-toh",
+        "ipa": "ˈzoʊltoʊ"
+      },
       "key": "the-zolto",
       "related": [
         "apex",
@@ -874,6 +1142,10 @@
       "title": "Thirstaserp",
       "category": "xalians",
       "definition": "The Thirstaserp is a large hooded serpent of Endessa that lies buried in the dunes and draws opponents in with a subsonic vibration from the rattles on its tail. Its bite carries a venom that drains the water from what it bites, killing by extreme dehydration on a world whose oceans were vaporized by the Thousand Families.",
+      "pronunciation": {
+        "respelling": "THURST-uh-serp",
+        "ipa": "ˈθɜrstəsɜrp"
+      },
       "related": [
         "endessa",
         "thousand-families"
@@ -893,6 +1165,10 @@
       "title": "Tizzie",
       "category": "xalians",
       "definition": "The Tizzie is a small furred Xalian of Telypso that hangs from the branches by its hands, distinguished by a long tail tipped in a flat spiral disc and by spiral-patterned eyes that fill much of its face. It waves the disc to win a subject's attention, and once eye contact is made it works on that subject from inside its mind rather than through its body.",
+      "pronunciation": {
+        "respelling": "TIZ-ee",
+        "ipa": "ˈtɪzi"
+      },
       "related": [
         "telypso"
       ]
@@ -902,6 +1178,10 @@
       "title": "Vallerii",
       "category": "people",
       "definition": "An ancient, hyper-capitalistic and imperialistic spacefaring race which created both Xalians and APEX.",
+      "pronunciation": {
+        "respelling": "val-LEH-ree-eye",
+        "ipa": "vaˈlɛriaɪ"
+      },
       "related": [
         "apex",
         "xalians"
@@ -915,6 +1195,10 @@
       "title": "Valleron",
       "category": "places",
       "definition": "The last bastion of the Vallerii race, where Vallerii scientists developed the Mercurius Machine over which King Kozrak has established his stronghold.",
+      "pronunciation": {
+        "respelling": "VAL-uh-ron",
+        "ipa": "ˈvælərɒn"
+      },
       "related": [
         "king-kozrak",
         "mercurius-machine",
@@ -926,6 +1210,10 @@
       "title": "Venemist",
       "category": "xalians",
       "definition": "The Venemist is a shaggy four-legged hunter of Drainov that expels a dissolving mist from a tube seated in its jaws. Carrying only two teeth, it takes its food by breaking it down outside the body rather than by biting.",
+      "pronunciation": {
+        "respelling": "VEN-uh-mist",
+        "ipa": "ˈvɛnəmɪst"
+      },
       "related": [
         "drainov"
       ]
@@ -935,6 +1223,10 @@
       "title": "Veridians",
       "category": "factions",
       "definition": "The people of Veridium. During the End Wars, APEX drove the planet's ancient drones and robotic servants as a single hive mind and corralled the Veridians into a formidable fighting force, supplied by starship foundries large enough to spread its menace across the galaxy.",
+      "pronunciation": {
+        "respelling": "veh-RID-ee-unz",
+        "ipa": "vəˈrɪdiənz"
+      },
       "related": [
         "apex",
         "the-end-wars",
@@ -946,6 +1238,10 @@
       "title": "Veridium",
       "category": "places",
       "definition": "A metallic world filled with dilapidated drones and believed to be a superstructure or worldship leftover from a now extinct alien race, which served as the lynchpin of Vallerii industry and technological advancement throughout galactic history.",
+      "pronunciation": {
+        "respelling": "veh-RID-ee-um",
+        "ipa": "vəˈrɪdiəm"
+      },
       "related": [
         "vallerii"
       ],
@@ -956,6 +1252,10 @@
       "title": "Voltish",
       "category": "xalians",
       "definition": "The Voltish is a shaggy, long-limbed Xalian of Zolton whose bones and claws are a tough conductive alloy. It takes in electrical energy from its surroundings and releases the shock into its enemies.",
+      "pronunciation": {
+        "respelling": "VOL-tish",
+        "ipa": "ˈvoʊltɪʃ"
+      },
       "related": [
         "zolton"
       ]
@@ -965,6 +1265,10 @@
       "title": "Windsailor",
       "category": "factions",
       "definition": "Rogueish and rugged pilots who were once paid high sums to scour Saiphus for Benthane squalls.",
+      "pronunciation": {
+        "respelling": "WIND-say-lur",
+        "ipa": "ˈwɪndseɪlər"
+      },
       "related": [
         "benthane",
         "saiphus"
@@ -984,6 +1288,10 @@
       "title": "Wraithix",
       "category": "places",
       "definition": "The star system which contained the ghost fleet that led to Operation Phantiri, the discovery of Shadharam IV, and the discovery of the extinct alien species now known as the Phantiri",
+      "pronunciation": {
+        "respelling": "RAY-thiks",
+        "ipa": "ˈreɪθɪks"
+      },
       "related": [
         "ghost-fleet",
         "operation-phantiri",
@@ -999,6 +1307,10 @@
       "title": "Xalia",
       "category": "places",
       "definition": "The galaxy in which Xalians live.",
+      "pronunciation": {
+        "respelling": "ZAY-lee-uh",
+        "ipa": "ˈzeɪliə"
+      },
       "related": [
         "xalians"
       ]
@@ -1028,6 +1340,10 @@
       "title": "Xalians",
       "category": "xalians",
       "definition": "Bio-engineered organisms created by the Vallerii to serve as soldiers and laborers, who are specially adapted to the extreme environments of Xalia due to the incredible science of the Xalian Generators.",
+      "pronunciation": {
+        "respelling": "ZAY-lee-unz",
+        "ipa": "ˈzeɪliənz"
+      },
       "related": [
         "vallerii",
         "xalia"
@@ -1038,6 +1354,10 @@
       "title": "Xylum",
       "category": "xalians",
       "definition": "The Xylum is a giant rooted organism of the Floria underforests, a mass of thick intertwined limbs that act as tentacles. It lives mostly underground, where it absorbs its power.",
+      "pronunciation": {
+        "respelling": "ZY-lum",
+        "ipa": "ˈzaɪləm"
+      },
       "related": [
         "floria"
       ]
@@ -1047,6 +1367,10 @@
       "title": "Yetimoth",
       "category": "xalians",
       "definition": "The Yetimoth is a hulking, white-furred ape of Krystos with the head of a mammoth and a pair of frozen tusks, generated to serve as the rank and file of the planet's high-security prison complexes. It conjures thick sheets of frost from nothing to armor itself, wall off escape routes, and encase what it means to reach, then closes and pummels with its heavy fists.",
+      "pronunciation": {
+        "respelling": "YET-ee-moth",
+        "ipa": "ˈjɛtimɒθ"
+      },
       "related": [
         "krystos"
       ]
@@ -1056,6 +1380,10 @@
       "title": "Zolton",
       "category": "places",
       "definition": "A mountainous, storm-wracked world whose unique weather allows for the generation of immense sums of electricity, plasma energy, and Quantum Entanglement Devices.",
+      "pronunciation": {
+        "respelling": "ZOL-ton",
+        "ipa": "ˈzoʊltɒn"
+      },
       "related": [],
       "element": "electric"
     },
@@ -1064,6 +1392,10 @@
       "title": "Grimedites",
       "category": "factions",
       "definition": "The people of Grimedes. Stigmatized for the gravity, shadow, and time-bending abilities their Generator was made to produce, they now stand watch at the edge of the galaxy against APEX's possible return, their numbers replenished only by those who win Scrambler Tokens in King Kozrak's tournament.",
+      "pronunciation": {
+        "respelling": "GRIM-uh-dites",
+        "ipa": "ˈgrɪmədaɪts"
+      },
       "related": [
         "grimedes",
         "apex",
@@ -1076,6 +1408,10 @@
       "title": "Luminarii",
       "category": "factions",
       "definition": "The people of Luminax. Held under King Kozrak's martial law to protect his monopoly, they labor to earn Scrambler Tokens to maintain the misfiring Stellaris Superstructure, while some among them study the mutations caused by its ION-9 cannon in secret, hoping for a cure that answers to no Token.",
+      "pronunciation": {
+        "respelling": "loo-mih-NAH-ree-eye",
+        "ipa": "luːmɪˈnɑːriaɪ"
+      },
       "related": [
         "luminax",
         "king-kozrak",
@@ -1089,6 +1425,10 @@
       "title": "Krystians",
       "category": "factions",
       "definition": "The people of Krystos. A divided people who shoulder the blame for a war-scarred world that once served as APEX's cold-storage core, the Krystians must replenish their numbers through King Kozrak's Scrambler Tokens before they can search APEX's old techno-labyrinth for any answer to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "KRIS-tee-unz",
+        "ipa": "ˈkrɪstiənz"
+      },
       "related": [
         "krystos",
         "apex",
@@ -1102,6 +1442,10 @@
       "title": "Phantiri (Xalians of)",
       "category": "factions",
       "definition": "The Xalians of Phantiri. Non-corporeal ghost Xalians produced after their Generator rewrote itself in the Leviticus Overdrive, they compete for Scrambler Tokens to resurrect themselves and the original Phantiri buried in the City of Wraiths beneath the Dreadscape.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "related": [
         "phantiri",
         "leviticus-overdrive",

--- a/lambda/src/json/encyclopedia.json
+++ b/lambda/src/json/encyclopedia.json
@@ -29,6 +29,10 @@
       "title": "Akinza",
       "category": "xalians",
       "definition": "The Akinza is an upright nocturnal Xalian of Krystos, generated after the impact winter, with outsized fringed ears, light-gathering eyes, and a spread of plumed tail fronds. It belongs to the feral stock of the arctic wastelands outside the planet's prison complexes and moves through open snow without sound or track.",
+      "pronunciation": {
+        "respelling": "uh-KIN-zuh",
+        "ipa": "əˈkɪnzə"
+      },
       "related": [
         "krystos"
       ]
@@ -38,6 +42,10 @@
       "title": "Algael",
       "category": "substances",
       "definition": "A blue-green, gel-like substance of sulfated polysaccharides formed from the decomposed algae found in Poseidas' oceans, which is known for its remarkable healing properties.",
+      "pronunciation": {
+        "respelling": "AL-gale",
+        "ipa": "ˈælgeɪl"
+      },
       "related": [
         "poseidas"
       ]
@@ -47,6 +55,10 @@
       "title": "APEX",
       "category": "factions",
       "definition": "The Automated Protocol for Enforcement on Xalians. An artificial intelligence designed to regulate the use of Xalian Generators and prevent their use in warfare, who later turned on the Vallerii, beginning the End Wars.",
+      "pronunciation": {
+        "respelling": "AY-peks",
+        "ipa": "ˈeɪpɛks"
+      },
       "related": [
         "the-end-wars",
         "vallerii",
@@ -58,6 +70,10 @@
       "title": "APEX Accords",
       "category": "history",
       "definition": "A treaty spearheaded by ECHELON and signed by the Thousand Families, agreeing to place the Xalian Generators under the control of APEX in order to prevent their use in warfare.",
+      "pronunciation": {
+        "respelling": "AY-peks",
+        "ipa": "ˈeɪpɛks"
+      },
       "related": [
         "apex",
         "echelon",
@@ -69,6 +85,10 @@
       "title": "Avilily",
       "category": "xalians",
       "definition": "The Avilily is a small carnivorous bird of Floria whose beak opens into a false flower, luring insects with sweet sedative saliva that paralyzes whatever it touches. Once carried by Vallerii explorers as living insect control, Avililies now gather in swarms that guard the most sacred parts of Floria's jungles.",
+      "pronunciation": {
+        "respelling": "AV-ih-lil-ee",
+        "ipa": "ˈævɪlɪli"
+      },
       "related": [
         "floria",
         "vallerii"
@@ -82,6 +102,10 @@
       "title": "Bacillota Requiem",
       "category": "substances",
       "definition": "The scientific name for the microorganism that produces Nightcap, a biochemical present only on Endessa that is necessary to induce stasis for sub-light space travel.",
+      "pronunciation": {
+        "respelling": "bah-sih-LOH-tuh REK-wee-em",
+        "ipa": "bɑsɪˈloʊtə ˈrɛkwiɛm"
+      },
       "related": [
         "endessa",
         "nightcap"
@@ -101,6 +125,10 @@
       "title": "Battle of Grimedes",
       "category": "history",
       "definition": "The final battle of the End Wars, in which APEX was repelled into dark space.",
+      "pronunciation": {
+        "respelling": "gri-MEE-deez",
+        "ipa": "grɪˈmiːdiːz"
+      },
       "related": [
         "apex",
         "the-end-wars"
@@ -111,6 +139,10 @@
       "title": "Benthane",
       "category": "substances",
       "definition": "A rarified gas found only on Saiphus that is used as a valuable heat sink for laser weapons. The gas is most commonly refined and processed into several derivative gases that serve as effective Tachyon Drive Core coolants necessary for contiguous lightspeed journeys.",
+      "pronunciation": {
+        "respelling": "BEN-thane",
+        "ipa": "ˈbɛnθeɪn"
+      },
       "related": [
         "saiphus",
         "tachyon-drive-core"
@@ -121,6 +153,10 @@
       "title": "Bioflim",
       "category": "xalians",
       "definition": "The Bioflim is a slime-bodied Xalian of Drainov sheathed in a thick rocky exoskeleton that its own slime continually regenerates. It is built for the planet's acid swamps and corrosive rain.",
+      "pronunciation": {
+        "respelling": "BY-oh-flim",
+        "ipa": "ˈbaɪoʊflɪm"
+      },
       "related": [
         "drainov"
       ]
@@ -139,6 +175,10 @@
       "title": "Bloodstorm",
       "category": "phenomena",
       "definition": "A weather phenomenon on Zolton identifiable by the frequent occurrence of dark-red lightning and crimson lightning sprites, whose quantum entangling effects can be carefully channeled into a Quantum Entanglement Device",
+      "pronunciation": {
+        "respelling": "BLUD-storm",
+        "ipa": "ˈblʌdstɔːrm"
+      },
       "related": [
         "zolton"
       ]
@@ -148,6 +188,10 @@
       "title": "Carbide-1",
       "category": "technology",
       "definition": "A factoryscape on Drainov which underwent a plant-wide melt down, setting off a chain reaction which led to the world-ending Drainov Disaster.",
+      "pronunciation": {
+        "respelling": "KAR-bide ONE",
+        "ipa": "ˈkɑːrbaɪd ˈwʌn"
+      },
       "related": [
         "drainov",
         "drainov-disaster"
@@ -158,6 +202,10 @@
       "title": "Cherenkov radiation",
       "category": "phenomena",
       "definition": "A form of radiation given off by Tachyon drive cores which rendered the spacefaring Vallerii population sterile, beginning the Age of Unbirth.",
+      "pronunciation": {
+        "respelling": "chuh-RENG-kof",
+        "ipa": "tʃəˈrɛŋkɒf"
+      },
       "related": [
         "age-of-unbirth",
         "vallerii"
@@ -171,6 +219,10 @@
       "title": "Chromocat",
       "category": "xalians",
       "definition": "The Chromocat is a large albino feline of Luminax, generated to harvest the planet's crop fields with a pair of sickle-shaped blades of ionized radiation that extend backwards from its front paws. It can enter a photonic state and cross ground at the speed of light, and it now turns that speed and those blades on opponents in rapid cuts.",
+      "pronunciation": {
+        "respelling": "KROH-moh-kat",
+        "ipa": "ˈkroʊmoʊkæt"
+      },
       "related": [
         "luminax"
       ]
@@ -191,6 +243,10 @@
       "title": "Codazzo",
       "category": "xalians",
       "definition": "The Codazzo is an upright burrowing Xalian of Stonera whose raised tail carries a fan of explosive barbs. Startled, it digs its body underground and leaves only the tail above the surface, firing barbs at anything that provokes it and regrowing them.",
+      "pronunciation": {
+        "respelling": "koh-DAZ-oh",
+        "ipa": "koʊˈdæzoʊ"
+      },
       "related": [
         "stonera"
       ]
@@ -210,6 +266,10 @@
       "title": "Crystorn",
       "category": "xalians",
       "definition": "The Crystorn is a heavy, long-haired Xalian of Luminax that sits upright on folded legs and carries a pair of crystal horns on its head, which transmit powerful light energy. It was generated among the crystal-bearing Xalians that worked the planet's fields and oases of translucent flora.",
+      "pronunciation": {
+        "respelling": "KRIS-torn",
+        "ipa": "ˈkrɪstɔːrn"
+      },
       "related": [
         "luminax",
         "xalians"
@@ -220,6 +280,10 @@
       "title": "Cybele",
       "category": "places",
       "definition": "The star system that is home to Stonera, the Jorian Belt, and the now defunct APEX superweapon known as the Terracannon.",
+      "pronunciation": {
+        "respelling": "SIB-uh-lee",
+        "ipa": "ˈsɪbəliː"
+      },
       "related": [
         "apex",
         "jorian-belt",
@@ -254,6 +318,10 @@
       "title": "Drainov",
       "category": "places",
       "definition": "A planet-wide chemical disaster site that was once the industrial powerhouse of the Vallerii Empire.",
+      "pronunciation": {
+        "respelling": "DRAY-nov",
+        "ipa": "ˈdreɪnɒv"
+      },
       "related": [
         "vallerii"
       ],
@@ -264,6 +332,10 @@
       "title": "Drainov Disaster",
       "category": "history",
       "definition": "A chain reaction beginning at the Carbide-1 factoryscape on Drainov which vented world-ending levels of poisonous gas into the atmosphere in a planet-killing event.",
+      "pronunciation": {
+        "respelling": "DRAY-nov",
+        "ipa": "ˈdreɪnɒv"
+      },
       "related": [
         "carbide-1",
         "drainov"
@@ -274,6 +346,10 @@
       "title": "Dreadscape",
       "category": "places",
       "definition": "The vast wasteland blanketing Phantiri, formed from the piled remains of the countless Xalians its Generator produced only for them to die on sight. Their bodies have compressed into islands of corpses crowned with macabre forests of splayed limbs, divided by deep, tarry oceans of the fluids that seep from a planetwide mass grave.",
+      "pronunciation": {
+        "respelling": "DRED-skape",
+        "ipa": "ˈdrɛdskeɪp"
+      },
       "related": [
         "phantiri",
         "xalians"
@@ -294,6 +370,10 @@
       "title": "Dromeus",
       "category": "xalians",
       "definition": "The Dromeus is a running ground bird of Magmuth, partially feathered and lizard featured, generated by the planet's mining corporations for the transient mineral islands. It runs down what it eats and spreads its wings for a few seconds of flight to finish the strike with its teeth.",
+      "pronunciation": {
+        "respelling": "droh-MEE-us",
+        "ipa": "droʊˈmiːəs"
+      },
       "related": [
         "magmuth"
       ]
@@ -303,6 +383,10 @@
       "title": "ECHELON",
       "category": "factions",
       "definition": "A consortium of Vallerii corporations formed to present a united front against the aristocratic Thousand Families with the primary goal of ending the use of Xalian Generators in warfare.",
+      "pronunciation": {
+        "respelling": "ESH-uh-lon",
+        "ipa": "ˈɛʃəlɒn"
+      },
       "related": [
         "thousand-families",
         "vallerii"
@@ -313,6 +397,10 @@
       "title": "Ectoghoul",
       "category": "xalians",
       "definition": "The Ectoghoul is a drifting phantom of Phantiri, formed of green mist gathered into a grinning skull above a trailing tail, that passes through solid surfaces and vanishes and returns at will. It ranges the Dreadscape harassing other Xalians with its cackle and with blasts of gooey ectoplasm.",
+      "pronunciation": {
+        "respelling": "EK-toh-gool",
+        "ipa": "ˈɛktoʊguːl"
+      },
       "related": [
         "dreadscape",
         "phantiri",
@@ -324,6 +412,10 @@
       "title": "Endessa",
       "category": "places",
       "definition": "An aquatic world known for being the sole source of Nightcap in the universe, which has since been reduced to a desert wasteland after a world-ending orbital bombardment campaign.",
+      "pronunciation": {
+        "respelling": "en-DESS-uh",
+        "ipa": "ɛnˈdɛsə"
+      },
       "related": [
         "nightcap"
       ],
@@ -334,6 +426,10 @@
       "title": "Figzy",
       "category": "xalians",
       "definition": "The Figzy is a small antlered Xalian generated on Telypso to counterbalance the unstable auras of the Vallerii prisoners marooned in the planet's fungal forests. It is deceptively smart, docile toward what it trusts, and projects force from its raised hands.",
+      "pronunciation": {
+        "respelling": "FIG-zee",
+        "ipa": "ˈfɪgzi"
+      },
       "related": [
         "telypso",
         "vallerii"
@@ -344,6 +440,10 @@
       "title": "Floria",
       "category": "places",
       "definition": "An inhospitable world of apocalyptic weather patterns which has since been terraformed into a vibrant forest planet by the first Xalian Generator.",
+      "pronunciation": {
+        "respelling": "FLOR-ee-uh",
+        "ipa": "ˈflɔːriə"
+      },
       "related": [
         "xalian-generator"
       ],
@@ -354,6 +454,10 @@
       "title": "Foromeer",
       "category": "xalians",
       "definition": "The Foromeer is an upright two-legged Xalian of Veridium whose hands are long drill-like horns, able to break through the strongest of material. It carries a metallic exoskeleton on its limbs and is thought to once have been used for mineral excavation.",
+      "pronunciation": {
+        "respelling": "FOR-uh-meer",
+        "ipa": "ˈfɔːrəmɪər"
+      },
       "related": [
         "veridium"
       ]
@@ -363,6 +467,10 @@
       "title": "Genesis Prototype",
       "category": "technology",
       "definition": "The first Xalian Generator, which was responsible for terraforming the planet Floria.",
+      "pronunciation": {
+        "respelling": "JEN-uh-sis",
+        "ipa": "ˈdʒɛnəsɪs"
+      },
       "related": [
         "floria",
         "xalian-generator"
@@ -385,6 +493,10 @@
       "title": "Graviclaw",
       "category": "xalians",
       "definition": "The Graviclaw is a black-shelled crustacean Xalian of Grimedes, centaur-like in build, which lurks beneath the planet's foggy wetlands and intensifies gravitational waves to open miniature black holes in the water. It draws prey into its massive claws, which snap shut with a force far heavier than their size implies, and it can root itself to the ground as an immovable wall of chitin.",
+      "pronunciation": {
+        "respelling": "GRAV-ih-klaw",
+        "ipa": "ˈgrævɪklɔː"
+      },
       "related": [
         "grimedes"
       ]
@@ -394,6 +506,10 @@
       "title": "Grimedes",
       "category": "places",
       "definition": "A planet of perpetual night on the outer rim of Xalia, which borders a black hole and is known for having been the last bastion of APEX's forces during the End Wars.",
+      "pronunciation": {
+        "respelling": "gri-MEE-deez",
+        "ipa": "grɪˈmiːdiːz"
+      },
       "related": [
         "apex",
         "the-end-wars",
@@ -406,6 +522,10 @@
       "title": "Hippochamp",
       "category": "xalians",
       "definition": "The Hippochamp is a four-legged, seahorse-shaped Xalian of Poseidas whose long snout works as a high-pressure water cannon. It was designed to answer the electrical and chemical fires that occur on the hydro-processing rigs and to defend the rigs' Algael against pirates.",
+      "pronunciation": {
+        "respelling": "HIP-uh-champ",
+        "ipa": "ˈhɪpətʃæmp"
+      },
       "related": [
         "algael",
         "poseidas"
@@ -416,6 +536,10 @@
       "title": "Hypnopet",
       "category": "xalians",
       "definition": "The Hypnopet is a small, golden-furred creature of Telypso bearing a single color-changing horn, generated by the Telypso Generator as a service animal and therapist for the deranged Vallerii imprisoned on that world. Its horn pulses through shifting color to lock a subject in a trance, a sedative once used on patients in bouts of mania and now used by King Kozrak for crowd control on rebellious worlds.",
+      "pronunciation": {
+        "respelling": "HIP-noh-pet",
+        "ipa": "ˈhɪpnoʊpɛt"
+      },
       "related": [
         "king-kozrak",
         "telypso",
@@ -437,6 +561,10 @@
       "title": "Imprit",
       "category": "xalians",
       "definition": "The Imprit is a small horned Xalian of Magmuth, furred against the flammable oils it secretes and so burning continuously, designed by the Vallerii as a tinkerer and released into the mining shafts to repair the equipment sent down into the planet. Freed onto the surface it swings by its scythe-tipped tail and sets fires where they do not belong.",
+      "pronunciation": {
+        "respelling": "IM-prit",
+        "ipa": "ˈɪmprɪt"
+      },
       "related": [
         "magmuth",
         "vallerii"
@@ -447,6 +575,10 @@
       "title": "ION-9",
       "category": "technology",
       "definition": "The 'Divine Light' solar cannon which was constructed as a superweapon from the Stellaris Superstructure. A system by which the panels of the Dyson sphere could be angled like a mirror to concentrate the solar energy of one of Luminax's stars into a deadly beam of energy.",
+      "pronunciation": {
+        "respelling": "EYE-on NINE",
+        "ipa": "ˈaɪɒn ˈnaɪn"
+      },
       "related": [
         "luminax",
         "stellaris-superstructure"
@@ -457,6 +589,10 @@
       "title": "Jorian Belt",
       "category": "places",
       "definition": "An asteroid belt in the Cybele System, which collides with the planet Stonera once a year. The home of the now defunct APEX superweapon known as the Terracannon.",
+      "pronunciation": {
+        "respelling": "JOR-ee-un",
+        "ipa": "ˈdʒɔːriən"
+      },
       "related": [
         "apex",
         "cybele",
@@ -469,6 +605,10 @@
       "title": "Kelpan-5",
       "category": "places",
       "definition": "The original name of Endessa when it was still a vibrant aquatic breadbasket in the early days of the Vallerii Empire.",
+      "pronunciation": {
+        "respelling": "KEL-pan FIVE",
+        "ipa": "ˈkɛlpæn ˈfaɪv"
+      },
       "related": [
         "endessa",
         "vallerii"
@@ -479,6 +619,10 @@
       "title": "King Kozrak",
       "category": "people",
       "definition": "One of the last surviving members of the Vallerii race, who has used his knowledge of the Mercurius Machine to amass tyrannical power over the galaxy and institute the tournament for Scrambler Tokens.",
+      "pronunciation": {
+        "respelling": "KOZ-rak",
+        "ipa": "ˈkɒzræk"
+      },
       "related": [
         "mercurius-machine",
         "vallerii"
@@ -492,6 +636,10 @@
       "title": "Kosanos",
       "category": "xalians",
       "definition": "The Kosanos is a heavy four-legged Xalian of Floria with a broad blade at the end of its trunk, thought to have been designed to clear the planet's thick brush. It fells standing growth in the underforests below the World Trees.",
+      "pronunciation": {
+        "respelling": "koh-SAH-nos",
+        "ipa": "koʊˈsɑːnoʊs"
+      },
       "related": [
         "floria",
         "world-trees"
@@ -502,6 +650,10 @@
       "title": "Krystos",
       "category": "places",
       "definition": "A warmwater paradise that served as a vacation destination for Vallerii high society until it was plunged into an arctic apocalypse caused by an asteroid impact and converted into a frozen prison world and planetary cold-storage facility for APEX.",
+      "pronunciation": {
+        "respelling": "KRIS-tos",
+        "ipa": "ˈkrɪstɒs"
+      },
       "related": [
         "apex",
         "vallerii"
@@ -513,6 +665,10 @@
       "title": "Leviticus Overdrive",
       "category": "technology",
       "definition": "The name given to the Phantiri Generator's unprecedented act of re-writing its own code after centuries of watching its creations die on arrival. Under this new programming it abandoned organic life entirely, learning instead to produce ghost-like Xalians formed of spectral energy with no corporeal bodies at all.",
+      "pronunciation": {
+        "respelling": "leh-VIT-ih-kus",
+        "ipa": "ləˈvɪtɪkəs"
+      },
       "related": [
         "phantiri",
         "xalians"
@@ -523,6 +679,10 @@
       "title": "Luceras",
       "category": "xalians",
       "definition": "The Luceras is a small long-eared, curve-horned leaping animal of Saiphus, one of the great leaping animals that bound between the planet's floating islands. It jumps so high that at times it seems as if it is flying, and comes down on what it strikes like a battering ram.",
+      "pronunciation": {
+        "respelling": "loo-SEH-rus",
+        "ipa": "luːˈsɛrəs"
+      },
       "related": [
         "saiphus"
       ]
@@ -532,6 +692,10 @@
       "title": "Luminax",
       "category": "places",
       "definition": "A planet with binary stars that is subject to immense radiation, therefore serving as the solar energy capital of Xalia.",
+      "pronunciation": {
+        "respelling": "LOO-mih-naks",
+        "ipa": "ˈluːmɪnæks"
+      },
       "related": [
         "xalia"
       ],
@@ -542,6 +706,10 @@
       "title": "Magmuth",
       "category": "places",
       "definition": "A fiery hellscape of a planet known for containing valuable minerals.",
+      "pronunciation": {
+        "respelling": "MAG-muth",
+        "ipa": "ˈmægməθ"
+      },
       "related": [],
       "element": "fire"
     },
@@ -550,6 +718,10 @@
       "title": "Magmuth Massacre",
       "category": "history",
       "definition": "A massacre of Xalian laborers that took part at a mining camp on Magmuth as part of a corporate power struggle which led to the planet-wide revolt of Magmuth's Xalian population against the Vallerii.",
+      "pronunciation": {
+        "respelling": "MAG-muth",
+        "ipa": "ˈmægməθ"
+      },
       "related": [
         "magmuth",
         "vallerii"
@@ -559,6 +731,10 @@
       "title": "Magmuthites",
       "category": "factions",
       "definition": "The people of Magmuth. Stereotyped by other Xalians as the most aggressive, rebellious, and warlike of their kind, they remain wracked by internecine warfare fueled by old blood feuds from the company wars, and the rest of Xalia quietly counts itself fortunate that they have never united.",
+      "pronunciation": {
+        "respelling": "MAG-muth-ites",
+        "ipa": "ˈmægməθaɪts"
+      },
       "key": "magmuthites",
       "related": [
         "company-wars",
@@ -572,6 +748,10 @@
       "title": "Mercurius Machine",
       "category": "technology",
       "definition": "A unique device controlled by King Kozrak on Valleron, which prints Scrambler Tokens that can be used to breed new Xalians that are immune to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "mer-KOO-ree-us",
+        "ipa": "mɜrˈkjʊəriəs"
+      },
       "related": [
         "king-kozrak",
         "nemesis-plague",
@@ -584,6 +764,10 @@
       "title": "Nemesis Plague",
       "category": "phenomena",
       "definition": "A galaxy-killing virus built by APEX which targets the genomes of the Vallerii and Xalians alike.",
+      "pronunciation": {
+        "respelling": "NEM-uh-sis",
+        "ipa": "ˈnɛməsɪs"
+      },
       "related": [
         "apex",
         "vallerii",
@@ -595,6 +779,10 @@
       "title": "Neph",
       "category": "xalians",
       "definition": "The Neph is a colossal hydrogen jellyfish of Saiphus, drifting in flocks through the lower atmosphere and drawing Benthane and atmospheric plankton up through long trailing tentacles. Generated for the Benthane industry, it is shepherded and milked for the coolant gas that keeps Tachyon Drive Cores from superheating.",
+      "pronunciation": {
+        "respelling": "nef",
+        "ipa": "nɛf"
+      },
       "related": [
         "benthane",
         "saiphus"
@@ -605,6 +793,10 @@
       "title": "Newtapede",
       "category": "xalians",
       "definition": "The Newtapede is a sixteen legged amphibious Xalian of Poseidas, long and segmented, with a slender frame and webbed feet that make it a formidable opponent in water. It lives among the water-breathing Xalians of the planet's rigs.",
+      "pronunciation": {
+        "respelling": "NOOT-uh-peed",
+        "ipa": "ˈnuːtəpiːd"
+      },
       "related": [
         "poseidas",
         "xalians"
@@ -615,6 +807,10 @@
       "title": "Nightcap",
       "category": "substances",
       "definition": "A biochemical present only on Endessa that is necessary to induce stasis for sub-light space travel.",
+      "pronunciation": {
+        "respelling": "NITE-kap",
+        "ipa": "ˈnaɪtkæp"
+      },
       "related": [
         "endessa"
       ]
@@ -623,6 +819,10 @@
       "title": "Operation Phantiri",
       "category": "history",
       "definition": "The codename under which top secret Vallerii excavations of Shadharam IV continued for decades, termed after the nickname xenoarchaeologists gave the planet's original inhabitants. Its findings were sealed and classified after the reawakening of the moon-weapon that followed the discovery of the City of Wraiths.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "key": "operation-phantiri",
       "related": [
         "city-of-wraiths",
@@ -635,6 +835,10 @@
       "title": "Phantiri",
       "category": "places",
       "definition": "A tomb world whose lifeforms are under constant assault from an unknown energy source emanating from its orbital moon and whose Xalian Generator has responded by creating Xalians of a spectral, undead nature. Alternatively, the name of the extinct ancient alien species who once inhabited the planet and the top secret operation which uncovered their remains.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "related": [
         "xalian-generator",
         "xalians"
@@ -646,6 +850,10 @@
       "title": "Poseidas",
       "category": "places",
       "definition": "An ocean world that is subject to toxic algae blooms, torrential hurricanes, and immense tsunamis. The only known source of Algael in Xalia.",
+      "pronunciation": {
+        "respelling": "po-SY-das",
+        "ipa": "poʊˈsaɪdəs"
+      },
       "related": [
         "algael",
         "xalia"
@@ -657,6 +865,10 @@
       "title": "QED",
       "category": "technology",
       "definition": "Quantum Entanglement Device. A specially engineered computer chip exposed to a Bloodstorm on Zolton, which can be used to link communications equipment across the galaxy.",
+      "pronunciation": {
+        "respelling": "cue-ee-DEE",
+        "ipa": "kjuː iː ˈdiː"
+      },
       "related": [
         "bloodstorm",
         "zolton"
@@ -671,6 +883,10 @@
       "title": "Saigill Combines",
       "category": "factions",
       "definition": "The largest agricorp in the Vallerii Empire, which was driven to bankruptcy in its attempt to terraform Luminax before the invention of the Xalian Generators.",
+      "pronunciation": {
+        "respelling": "SAY-gill",
+        "ipa": "ˈseɪgɪl"
+      },
       "related": [
         "luminax",
         "vallerii"
@@ -681,6 +897,10 @@
       "title": "Saiphus",
       "category": "places",
       "definition": "A hydrogen-helium gas giant that is home to the only known source of Benthane in Xalia.",
+      "pronunciation": {
+        "respelling": "SIGH-fus",
+        "ipa": "ˈsaɪfəs"
+      },
       "related": [
         "benthane",
         "xalia"
@@ -692,6 +912,10 @@
       "title": "Scalatto",
       "category": "xalians",
       "definition": "The Scalatto is a plated two-legged Xalian of Endessa shielded by a scaly exoskeleton that lets it roll into a ball to protect itself. It lives in the sand and cavern networks of its homeworld.",
+      "pronunciation": {
+        "respelling": "skuh-LAT-oh",
+        "ipa": "skəˈlætoʊ"
+      },
       "related": [
         "endessa"
       ]
@@ -701,6 +925,10 @@
       "title": "Scrambler Token",
       "category": "technology",
       "definition": "A special chip printed by the Mercurius Machine which possesses a randomly generated and encrypted Xalian genome that can be used by a Xalian Generator to create new, unique Xalians that are immune to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "SKRAM-blur",
+        "ipa": "ˈskræmblər"
+      },
       "related": [
         "nemesis-plague",
         "xalian-generator",
@@ -712,6 +940,10 @@
       "title": "Shadharam IV",
       "category": "places",
       "definition": "The original Vallerii name for the planet Phantiri, before the discovery the extinct alien species now known as the Phantiri after the name of the top secret operation under which they were discovered.",
+      "pronunciation": {
+        "respelling": "SHAD-uh-ram the FOURTH",
+        "ipa": "ˈʃædərɑm ðə ˈfɔːrθ"
+      },
       "related": [
         "phantiri",
         "vallerii"
@@ -722,6 +954,10 @@
       "title": "Smokat",
       "category": "xalians",
       "definition": "The Smokat is a clever upright feline generated on Phantiri to work the dig sites the Imperial Houses opened there, able to atomize into a cloud of smoke at will and gather itself again. It now hunts the haze above the Dreadscape.",
+      "pronunciation": {
+        "respelling": "SMOH-kat",
+        "ipa": "ˈsmoʊkæt"
+      },
       "related": [
         "dreadscape",
         "imperial-houses",
@@ -752,6 +988,10 @@
       "title": "Stellaris Superstructure",
       "category": "places",
       "definition": "A Dyson sphere which was constructed around one of Luminax's stars in order to capture over a hundred-quadrillion gigawatts per second of solar energy.",
+      "pronunciation": {
+        "respelling": "steh-LAH-ris",
+        "ipa": "stəˈlɑːrɪs"
+      },
       "related": [
         "luminax"
       ],
@@ -764,6 +1004,10 @@
       "title": "Stonera",
       "category": "places",
       "definition": "A rocky planet with an incredibly thin atmosphere that is subjected to annual planetary bombardments as it passes through its star system's asteroid belt, leading to an immense saturation of valuable minerals and rare earth metals.",
+      "pronunciation": {
+        "respelling": "stoh-NAIR-uh",
+        "ipa": "stoʊˈnɛərə"
+      },
       "related": [],
       "element": "rock"
     },
@@ -785,6 +1029,10 @@
       "title": "Tachyon Drive Core",
       "category": "technology",
       "definition": "The only engine known to be able to achieve faster than light space travel, but which emits sterilizing Cherenkov radiation.",
+      "pronunciation": {
+        "respelling": "TAK-ee-on",
+        "ipa": "ˈtækiɒn"
+      },
       "related": [
         "cherenkov-radiation"
       ]
@@ -794,6 +1042,10 @@
       "title": "Telypso",
       "category": "places",
       "definition": "A psychedelic world at the center of Xalia used by the Vallerii as a planetary asylum and believed to be the origin of all life in the galaxy. The planet disobeys the laws of physics and is believed to contain a sort of psychosphere or planetary consciousness that drives its inhabitants mad.",
+      "pronunciation": {
+        "respelling": "teh-LIP-so",
+        "ipa": "təˈlɪpsoʊ"
+      },
       "related": [
         "vallerii",
         "xalia"
@@ -805,6 +1057,10 @@
       "title": "Terracannon",
       "category": "technology",
       "definition": "A now defunct superweapon built by APEX which used a reverse-tractor beam to propel supermassive asteroids from the Jorian Belt at its targets.",
+      "pronunciation": {
+        "respelling": "TERR-uh-kan-un",
+        "ipa": "ˈtɛrəkænən"
+      },
       "related": [
         "apex",
         "jorian-belt"
@@ -818,6 +1074,10 @@
       "title": "Terragoyle",
       "category": "xalians",
       "definition": "The Terragoyle is a horned, winged sentry of Stonera that lines the edges of the Chasm, holding a stone aloft at the tip of its tail. Generated to airlift debris from the strip mines, it now hibernates in a statue-like state along the perimeter and, when roused, rises above the Chasm to fling boulders and rake intruders with falling gravel.",
+      "pronunciation": {
+        "respelling": "TERR-uh-goyl",
+        "ipa": "ˈtɛrəgɔɪl"
+      },
       "related": [
         "stonera",
         "the-chasm"
@@ -828,6 +1088,10 @@
       "title": "Tetrahive",
       "category": "xalians",
       "definition": "The Tetrahive is a small winged Xalian of Grimedes with a long whipping tail that fights by conjuring a swarm of little flying familiars with teeth like piranhas, holding every one of them in its mind and moving them as a single unit to attack or defend. It was generated as a test subject rather than a laborer, and hunts the planet's thick, stalky undergrowth in perpetual night.",
+      "pronunciation": {
+        "respelling": "TET-ruh-hive",
+        "ipa": "ˈtɛtrəhaɪv"
+      },
       "related": [
         "grimedes"
       ]
@@ -861,6 +1125,10 @@
       "title": "The Zolto",
       "category": "factions",
       "definition": "The people of Zolton. Freed from APEX's control by Source Code 606, the Zolto now work to re-establish the connection between worlds, hoping to prevent the extinction of Xalian-kind; King Kozrak has labeled those who form such networks galactic enemies and cracked down on the planet to control the manufacture of and access to QEDs.",
+      "pronunciation": {
+        "respelling": "ZOL-toh",
+        "ipa": "ˈzoʊltoʊ"
+      },
       "key": "the-zolto",
       "related": [
         "apex",
@@ -874,6 +1142,10 @@
       "title": "Thirstaserp",
       "category": "xalians",
       "definition": "The Thirstaserp is a large hooded serpent of Endessa that lies buried in the dunes and draws opponents in with a subsonic vibration from the rattles on its tail. Its bite carries a venom that drains the water from what it bites, killing by extreme dehydration on a world whose oceans were vaporized by the Thousand Families.",
+      "pronunciation": {
+        "respelling": "THURST-uh-serp",
+        "ipa": "ˈθɜrstəsɜrp"
+      },
       "related": [
         "endessa",
         "thousand-families"
@@ -893,6 +1165,10 @@
       "title": "Tizzie",
       "category": "xalians",
       "definition": "The Tizzie is a small furred Xalian of Telypso that hangs from the branches by its hands, distinguished by a long tail tipped in a flat spiral disc and by spiral-patterned eyes that fill much of its face. It waves the disc to win a subject's attention, and once eye contact is made it works on that subject from inside its mind rather than through its body.",
+      "pronunciation": {
+        "respelling": "TIZ-ee",
+        "ipa": "ˈtɪzi"
+      },
       "related": [
         "telypso"
       ]
@@ -902,6 +1178,10 @@
       "title": "Vallerii",
       "category": "people",
       "definition": "An ancient, hyper-capitalistic and imperialistic spacefaring race which created both Xalians and APEX.",
+      "pronunciation": {
+        "respelling": "val-LEH-ree-eye",
+        "ipa": "vaˈlɛriaɪ"
+      },
       "related": [
         "apex",
         "xalians"
@@ -915,6 +1195,10 @@
       "title": "Valleron",
       "category": "places",
       "definition": "The last bastion of the Vallerii race, where Vallerii scientists developed the Mercurius Machine over which King Kozrak has established his stronghold.",
+      "pronunciation": {
+        "respelling": "VAL-uh-ron",
+        "ipa": "ˈvælərɒn"
+      },
       "related": [
         "king-kozrak",
         "mercurius-machine",
@@ -926,6 +1210,10 @@
       "title": "Venemist",
       "category": "xalians",
       "definition": "The Venemist is a shaggy four-legged hunter of Drainov that expels a dissolving mist from a tube seated in its jaws. Carrying only two teeth, it takes its food by breaking it down outside the body rather than by biting.",
+      "pronunciation": {
+        "respelling": "VEN-uh-mist",
+        "ipa": "ˈvɛnəmɪst"
+      },
       "related": [
         "drainov"
       ]
@@ -935,6 +1223,10 @@
       "title": "Veridians",
       "category": "factions",
       "definition": "The people of Veridium. During the End Wars, APEX drove the planet's ancient drones and robotic servants as a single hive mind and corralled the Veridians into a formidable fighting force, supplied by starship foundries large enough to spread its menace across the galaxy.",
+      "pronunciation": {
+        "respelling": "veh-RID-ee-unz",
+        "ipa": "vəˈrɪdiənz"
+      },
       "related": [
         "apex",
         "the-end-wars",
@@ -946,6 +1238,10 @@
       "title": "Veridium",
       "category": "places",
       "definition": "A metallic world filled with dilapidated drones and believed to be a superstructure or worldship leftover from a now extinct alien race, which served as the lynchpin of Vallerii industry and technological advancement throughout galactic history.",
+      "pronunciation": {
+        "respelling": "veh-RID-ee-um",
+        "ipa": "vəˈrɪdiəm"
+      },
       "related": [
         "vallerii"
       ],
@@ -956,6 +1252,10 @@
       "title": "Voltish",
       "category": "xalians",
       "definition": "The Voltish is a shaggy, long-limbed Xalian of Zolton whose bones and claws are a tough conductive alloy. It takes in electrical energy from its surroundings and releases the shock into its enemies.",
+      "pronunciation": {
+        "respelling": "VOL-tish",
+        "ipa": "ˈvoʊltɪʃ"
+      },
       "related": [
         "zolton"
       ]
@@ -965,6 +1265,10 @@
       "title": "Windsailor",
       "category": "factions",
       "definition": "Rogueish and rugged pilots who were once paid high sums to scour Saiphus for Benthane squalls.",
+      "pronunciation": {
+        "respelling": "WIND-say-lur",
+        "ipa": "ˈwɪndseɪlər"
+      },
       "related": [
         "benthane",
         "saiphus"
@@ -984,6 +1288,10 @@
       "title": "Wraithix",
       "category": "places",
       "definition": "The star system which contained the ghost fleet that led to Operation Phantiri, the discovery of Shadharam IV, and the discovery of the extinct alien species now known as the Phantiri",
+      "pronunciation": {
+        "respelling": "RAY-thiks",
+        "ipa": "ˈreɪθɪks"
+      },
       "related": [
         "ghost-fleet",
         "operation-phantiri",
@@ -999,6 +1307,10 @@
       "title": "Xalia",
       "category": "places",
       "definition": "The galaxy in which Xalians live.",
+      "pronunciation": {
+        "respelling": "ZAY-lee-uh",
+        "ipa": "ˈzeɪliə"
+      },
       "related": [
         "xalians"
       ]
@@ -1028,6 +1340,10 @@
       "title": "Xalians",
       "category": "xalians",
       "definition": "Bio-engineered organisms created by the Vallerii to serve as soldiers and laborers, who are specially adapted to the extreme environments of Xalia due to the incredible science of the Xalian Generators.",
+      "pronunciation": {
+        "respelling": "ZAY-lee-unz",
+        "ipa": "ˈzeɪliənz"
+      },
       "related": [
         "vallerii",
         "xalia"
@@ -1038,6 +1354,10 @@
       "title": "Xylum",
       "category": "xalians",
       "definition": "The Xylum is a giant rooted organism of the Floria underforests, a mass of thick intertwined limbs that act as tentacles. It lives mostly underground, where it absorbs its power.",
+      "pronunciation": {
+        "respelling": "ZY-lum",
+        "ipa": "ˈzaɪləm"
+      },
       "related": [
         "floria"
       ]
@@ -1047,6 +1367,10 @@
       "title": "Yetimoth",
       "category": "xalians",
       "definition": "The Yetimoth is a hulking, white-furred ape of Krystos with the head of a mammoth and a pair of frozen tusks, generated to serve as the rank and file of the planet's high-security prison complexes. It conjures thick sheets of frost from nothing to armor itself, wall off escape routes, and encase what it means to reach, then closes and pummels with its heavy fists.",
+      "pronunciation": {
+        "respelling": "YET-ee-moth",
+        "ipa": "ˈjɛtimɒθ"
+      },
       "related": [
         "krystos"
       ]
@@ -1056,6 +1380,10 @@
       "title": "Zolton",
       "category": "places",
       "definition": "A mountainous, storm-wracked world whose unique weather allows for the generation of immense sums of electricity, plasma energy, and Quantum Entanglement Devices.",
+      "pronunciation": {
+        "respelling": "ZOL-ton",
+        "ipa": "ˈzoʊltɒn"
+      },
       "related": [],
       "element": "electric"
     },
@@ -1064,6 +1392,10 @@
       "title": "Grimedites",
       "category": "factions",
       "definition": "The people of Grimedes. Stigmatized for the gravity, shadow, and time-bending abilities their Generator was made to produce, they now stand watch at the edge of the galaxy against APEX's possible return, their numbers replenished only by those who win Scrambler Tokens in King Kozrak's tournament.",
+      "pronunciation": {
+        "respelling": "GRIM-uh-dites",
+        "ipa": "ˈgrɪmədaɪts"
+      },
       "related": [
         "grimedes",
         "apex",
@@ -1076,6 +1408,10 @@
       "title": "Luminarii",
       "category": "factions",
       "definition": "The people of Luminax. Held under King Kozrak's martial law to protect his monopoly, they labor to earn Scrambler Tokens to maintain the misfiring Stellaris Superstructure, while some among them study the mutations caused by its ION-9 cannon in secret, hoping for a cure that answers to no Token.",
+      "pronunciation": {
+        "respelling": "loo-mih-NAH-ree-eye",
+        "ipa": "luːmɪˈnɑːriaɪ"
+      },
       "related": [
         "luminax",
         "king-kozrak",
@@ -1089,6 +1425,10 @@
       "title": "Krystians",
       "category": "factions",
       "definition": "The people of Krystos. A divided people who shoulder the blame for a war-scarred world that once served as APEX's cold-storage core, the Krystians must replenish their numbers through King Kozrak's Scrambler Tokens before they can search APEX's old techno-labyrinth for any answer to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "KRIS-tee-unz",
+        "ipa": "ˈkrɪstiənz"
+      },
       "related": [
         "krystos",
         "apex",
@@ -1102,6 +1442,10 @@
       "title": "Phantiri (Xalians of)",
       "category": "factions",
       "definition": "The Xalians of Phantiri. Non-corporeal ghost Xalians produced after their Generator rewrote itself in the Leviticus Overdrive, they compete for Scrambler Tokens to resurrect themselves and the original Phantiri buried in the City of Wraiths beneath the Dreadscape.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "related": [
         "phantiri",
         "leviticus-overdrive",

--- a/my-app/src/components/encyclopedia/EntryView.js
+++ b/my-app/src/components/encyclopedia/EntryView.js
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import * as lore from '../../lore';
 import Prose from './Prose';
 import Connections from './Connections';
+import Pronunciation from './Pronunciation';
 import { useVisit } from './trail';
 import './EntryView.css';
 
@@ -59,6 +60,7 @@ export default function EntryView() {
             <article className="enc-entry-doc">
                 <header className="enc-designation">
                     <h1 className="g-title">{entry.title}</h1>
+                    <Pronunciation pronunciation={entry.pronunciation} />
                     <div className="enc-chips">
                         <span className="g-chip">{entry.category}</span>
                         {entry.element && <span className="g-chip">{entry.element}</span>}

--- a/my-app/src/components/encyclopedia/Pronunciation.css
+++ b/my-app/src/components/encyclopedia/Pronunciation.css
@@ -1,0 +1,8 @@
+/* the respelled reading, printed under the designation like a reference work.
+   Machine output, so mono and slightly recessed from the title above it. */
+.enc-pronunciation {
+	margin: 0.15rem 0 0;
+	color: var(--g-ink-mid);
+	font-size: 0.85rem;
+	letter-spacing: 0.04em;
+}

--- a/my-app/src/components/encyclopedia/Pronunciation.js
+++ b/my-app/src/components/encyclopedia/Pronunciation.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import './Pronunciation.css';
+
+/**
+ * Pronunciation: the respelled reading of a coined name, printed under the
+ * designation the way a reference work prints it. Renders nothing when an
+ * entry carries no pronunciation -- transparent English names (Death Tide,
+ * Drilltail) are deliberately left unmarked rather than respelled to no
+ * purpose.
+ *
+ * The respelling is what a reader needs; the IPA rides along in the data for
+ * anything that wants it (a future audio pass, a screen reader) and is
+ * exposed here only as the title attribute.
+ */
+export default function Pronunciation({ pronunciation }) {
+    if (!pronunciation || !pronunciation.respelling) return null;
+
+    return (
+        <p className="g-mono enc-pronunciation" title={pronunciation.ipa || undefined}>
+            {pronunciation.respelling}
+        </p>
+    );
+}

--- a/my-app/src/components/encyclopedia/SpeciesView.js
+++ b/my-app/src/components/encyclopedia/SpeciesView.js
@@ -4,6 +4,7 @@ import * as lore from '../../lore';
 import Prose from './Prose';
 import XalianImage from '../xalianImage';
 import Connections from './Connections';
+import Pronunciation from './Pronunciation';
 import { useVisit } from './trail';
 import './SpeciesView.css';
 
@@ -261,6 +262,7 @@ export default function SpeciesView() {
 
             <header className="enc-designation">
                 <h1 className="g-title">{view.name}</h1>
+                <Pronunciation pronunciation={(lore.getEntry(view.key) || {}).pronunciation} />
                 <div className="enc-chips">
                     <span className="g-chip">{view.element}</span>
                     <Link to={lore.routeFor('world', view.homePlanet)} className={`g-chip g-el-${view.element}`}>

--- a/my-app/src/components/encyclopedia/WorldView.js
+++ b/my-app/src/components/encyclopedia/WorldView.js
@@ -4,6 +4,7 @@ import * as lore from '../../lore';
 import Prose from './Prose';
 import XalianImage from '../xalianImage';
 import Connections from './Connections';
+import Pronunciation from './Pronunciation';
 import { useVisit, useReadMark, markRead } from './trail';
 import './WorldView.css';
 
@@ -163,6 +164,7 @@ export default function WorldView() {
 
             <header className="enc-designation">
                 <h1 className="g-title">{world.name}</h1>
+                <Pronunciation pronunciation={(lore.getEntry(world.key) || {}).pronunciation} />
                 <div className="enc-chips">
                     <span className="g-chip">{world.element}</span>
                     <span className="g-chip g-chip--outline">Survey Record</span>

--- a/my-app/src/json/encyclopedia.json
+++ b/my-app/src/json/encyclopedia.json
@@ -29,6 +29,10 @@
       "title": "Akinza",
       "category": "xalians",
       "definition": "The Akinza is an upright nocturnal Xalian of Krystos, generated after the impact winter, with outsized fringed ears, light-gathering eyes, and a spread of plumed tail fronds. It belongs to the feral stock of the arctic wastelands outside the planet's prison complexes and moves through open snow without sound or track.",
+      "pronunciation": {
+        "respelling": "uh-KIN-zuh",
+        "ipa": "əˈkɪnzə"
+      },
       "related": [
         "krystos"
       ]
@@ -38,6 +42,10 @@
       "title": "Algael",
       "category": "substances",
       "definition": "A blue-green, gel-like substance of sulfated polysaccharides formed from the decomposed algae found in Poseidas' oceans, which is known for its remarkable healing properties.",
+      "pronunciation": {
+        "respelling": "AL-gale",
+        "ipa": "ˈælgeɪl"
+      },
       "related": [
         "poseidas"
       ]
@@ -47,6 +55,10 @@
       "title": "APEX",
       "category": "factions",
       "definition": "The Automated Protocol for Enforcement on Xalians. An artificial intelligence designed to regulate the use of Xalian Generators and prevent their use in warfare, who later turned on the Vallerii, beginning the End Wars.",
+      "pronunciation": {
+        "respelling": "AY-peks",
+        "ipa": "ˈeɪpɛks"
+      },
       "related": [
         "the-end-wars",
         "vallerii",
@@ -58,6 +70,10 @@
       "title": "APEX Accords",
       "category": "history",
       "definition": "A treaty spearheaded by ECHELON and signed by the Thousand Families, agreeing to place the Xalian Generators under the control of APEX in order to prevent their use in warfare.",
+      "pronunciation": {
+        "respelling": "AY-peks",
+        "ipa": "ˈeɪpɛks"
+      },
       "related": [
         "apex",
         "echelon",
@@ -69,6 +85,10 @@
       "title": "Avilily",
       "category": "xalians",
       "definition": "The Avilily is a small carnivorous bird of Floria whose beak opens into a false flower, luring insects with sweet sedative saliva that paralyzes whatever it touches. Once carried by Vallerii explorers as living insect control, Avililies now gather in swarms that guard the most sacred parts of Floria's jungles.",
+      "pronunciation": {
+        "respelling": "AV-ih-lil-ee",
+        "ipa": "ˈævɪlɪli"
+      },
       "related": [
         "floria",
         "vallerii"
@@ -82,6 +102,10 @@
       "title": "Bacillota Requiem",
       "category": "substances",
       "definition": "The scientific name for the microorganism that produces Nightcap, a biochemical present only on Endessa that is necessary to induce stasis for sub-light space travel.",
+      "pronunciation": {
+        "respelling": "bah-sih-LOH-tuh REK-wee-em",
+        "ipa": "bɑsɪˈloʊtə ˈrɛkwiɛm"
+      },
       "related": [
         "endessa",
         "nightcap"
@@ -101,6 +125,10 @@
       "title": "Battle of Grimedes",
       "category": "history",
       "definition": "The final battle of the End Wars, in which APEX was repelled into dark space.",
+      "pronunciation": {
+        "respelling": "gri-MEE-deez",
+        "ipa": "grɪˈmiːdiːz"
+      },
       "related": [
         "apex",
         "the-end-wars"
@@ -111,6 +139,10 @@
       "title": "Benthane",
       "category": "substances",
       "definition": "A rarified gas found only on Saiphus that is used as a valuable heat sink for laser weapons. The gas is most commonly refined and processed into several derivative gases that serve as effective Tachyon Drive Core coolants necessary for contiguous lightspeed journeys.",
+      "pronunciation": {
+        "respelling": "BEN-thane",
+        "ipa": "ˈbɛnθeɪn"
+      },
       "related": [
         "saiphus",
         "tachyon-drive-core"
@@ -121,6 +153,10 @@
       "title": "Bioflim",
       "category": "xalians",
       "definition": "The Bioflim is a slime-bodied Xalian of Drainov sheathed in a thick rocky exoskeleton that its own slime continually regenerates. It is built for the planet's acid swamps and corrosive rain.",
+      "pronunciation": {
+        "respelling": "BY-oh-flim",
+        "ipa": "ˈbaɪoʊflɪm"
+      },
       "related": [
         "drainov"
       ]
@@ -139,6 +175,10 @@
       "title": "Bloodstorm",
       "category": "phenomena",
       "definition": "A weather phenomenon on Zolton identifiable by the frequent occurrence of dark-red lightning and crimson lightning sprites, whose quantum entangling effects can be carefully channeled into a Quantum Entanglement Device",
+      "pronunciation": {
+        "respelling": "BLUD-storm",
+        "ipa": "ˈblʌdstɔːrm"
+      },
       "related": [
         "zolton"
       ]
@@ -148,6 +188,10 @@
       "title": "Carbide-1",
       "category": "technology",
       "definition": "A factoryscape on Drainov which underwent a plant-wide melt down, setting off a chain reaction which led to the world-ending Drainov Disaster.",
+      "pronunciation": {
+        "respelling": "KAR-bide ONE",
+        "ipa": "ˈkɑːrbaɪd ˈwʌn"
+      },
       "related": [
         "drainov",
         "drainov-disaster"
@@ -158,6 +202,10 @@
       "title": "Cherenkov radiation",
       "category": "phenomena",
       "definition": "A form of radiation given off by Tachyon drive cores which rendered the spacefaring Vallerii population sterile, beginning the Age of Unbirth.",
+      "pronunciation": {
+        "respelling": "chuh-RENG-kof",
+        "ipa": "tʃəˈrɛŋkɒf"
+      },
       "related": [
         "age-of-unbirth",
         "vallerii"
@@ -171,6 +219,10 @@
       "title": "Chromocat",
       "category": "xalians",
       "definition": "The Chromocat is a large albino feline of Luminax, generated to harvest the planet's crop fields with a pair of sickle-shaped blades of ionized radiation that extend backwards from its front paws. It can enter a photonic state and cross ground at the speed of light, and it now turns that speed and those blades on opponents in rapid cuts.",
+      "pronunciation": {
+        "respelling": "KROH-moh-kat",
+        "ipa": "ˈkroʊmoʊkæt"
+      },
       "related": [
         "luminax"
       ]
@@ -191,6 +243,10 @@
       "title": "Codazzo",
       "category": "xalians",
       "definition": "The Codazzo is an upright burrowing Xalian of Stonera whose raised tail carries a fan of explosive barbs. Startled, it digs its body underground and leaves only the tail above the surface, firing barbs at anything that provokes it and regrowing them.",
+      "pronunciation": {
+        "respelling": "koh-DAZ-oh",
+        "ipa": "koʊˈdæzoʊ"
+      },
       "related": [
         "stonera"
       ]
@@ -210,6 +266,10 @@
       "title": "Crystorn",
       "category": "xalians",
       "definition": "The Crystorn is a heavy, long-haired Xalian of Luminax that sits upright on folded legs and carries a pair of crystal horns on its head, which transmit powerful light energy. It was generated among the crystal-bearing Xalians that worked the planet's fields and oases of translucent flora.",
+      "pronunciation": {
+        "respelling": "KRIS-torn",
+        "ipa": "ˈkrɪstɔːrn"
+      },
       "related": [
         "luminax",
         "xalians"
@@ -220,6 +280,10 @@
       "title": "Cybele",
       "category": "places",
       "definition": "The star system that is home to Stonera, the Jorian Belt, and the now defunct APEX superweapon known as the Terracannon.",
+      "pronunciation": {
+        "respelling": "SIB-uh-lee",
+        "ipa": "ˈsɪbəliː"
+      },
       "related": [
         "apex",
         "jorian-belt",
@@ -254,6 +318,10 @@
       "title": "Drainov",
       "category": "places",
       "definition": "A planet-wide chemical disaster site that was once the industrial powerhouse of the Vallerii Empire.",
+      "pronunciation": {
+        "respelling": "DRAY-nov",
+        "ipa": "ˈdreɪnɒv"
+      },
       "related": [
         "vallerii"
       ],
@@ -264,6 +332,10 @@
       "title": "Drainov Disaster",
       "category": "history",
       "definition": "A chain reaction beginning at the Carbide-1 factoryscape on Drainov which vented world-ending levels of poisonous gas into the atmosphere in a planet-killing event.",
+      "pronunciation": {
+        "respelling": "DRAY-nov",
+        "ipa": "ˈdreɪnɒv"
+      },
       "related": [
         "carbide-1",
         "drainov"
@@ -274,6 +346,10 @@
       "title": "Dreadscape",
       "category": "places",
       "definition": "The vast wasteland blanketing Phantiri, formed from the piled remains of the countless Xalians its Generator produced only for them to die on sight. Their bodies have compressed into islands of corpses crowned with macabre forests of splayed limbs, divided by deep, tarry oceans of the fluids that seep from a planetwide mass grave.",
+      "pronunciation": {
+        "respelling": "DRED-skape",
+        "ipa": "ˈdrɛdskeɪp"
+      },
       "related": [
         "phantiri",
         "xalians"
@@ -294,6 +370,10 @@
       "title": "Dromeus",
       "category": "xalians",
       "definition": "The Dromeus is a running ground bird of Magmuth, partially feathered and lizard featured, generated by the planet's mining corporations for the transient mineral islands. It runs down what it eats and spreads its wings for a few seconds of flight to finish the strike with its teeth.",
+      "pronunciation": {
+        "respelling": "droh-MEE-us",
+        "ipa": "droʊˈmiːəs"
+      },
       "related": [
         "magmuth"
       ]
@@ -303,6 +383,10 @@
       "title": "ECHELON",
       "category": "factions",
       "definition": "A consortium of Vallerii corporations formed to present a united front against the aristocratic Thousand Families with the primary goal of ending the use of Xalian Generators in warfare.",
+      "pronunciation": {
+        "respelling": "ESH-uh-lon",
+        "ipa": "ˈɛʃəlɒn"
+      },
       "related": [
         "thousand-families",
         "vallerii"
@@ -313,6 +397,10 @@
       "title": "Ectoghoul",
       "category": "xalians",
       "definition": "The Ectoghoul is a drifting phantom of Phantiri, formed of green mist gathered into a grinning skull above a trailing tail, that passes through solid surfaces and vanishes and returns at will. It ranges the Dreadscape harassing other Xalians with its cackle and with blasts of gooey ectoplasm.",
+      "pronunciation": {
+        "respelling": "EK-toh-gool",
+        "ipa": "ˈɛktoʊguːl"
+      },
       "related": [
         "dreadscape",
         "phantiri",
@@ -324,6 +412,10 @@
       "title": "Endessa",
       "category": "places",
       "definition": "An aquatic world known for being the sole source of Nightcap in the universe, which has since been reduced to a desert wasteland after a world-ending orbital bombardment campaign.",
+      "pronunciation": {
+        "respelling": "en-DESS-uh",
+        "ipa": "ɛnˈdɛsə"
+      },
       "related": [
         "nightcap"
       ],
@@ -334,6 +426,10 @@
       "title": "Figzy",
       "category": "xalians",
       "definition": "The Figzy is a small antlered Xalian generated on Telypso to counterbalance the unstable auras of the Vallerii prisoners marooned in the planet's fungal forests. It is deceptively smart, docile toward what it trusts, and projects force from its raised hands.",
+      "pronunciation": {
+        "respelling": "FIG-zee",
+        "ipa": "ˈfɪgzi"
+      },
       "related": [
         "telypso",
         "vallerii"
@@ -344,6 +440,10 @@
       "title": "Floria",
       "category": "places",
       "definition": "An inhospitable world of apocalyptic weather patterns which has since been terraformed into a vibrant forest planet by the first Xalian Generator.",
+      "pronunciation": {
+        "respelling": "FLOR-ee-uh",
+        "ipa": "ˈflɔːriə"
+      },
       "related": [
         "xalian-generator"
       ],
@@ -354,6 +454,10 @@
       "title": "Foromeer",
       "category": "xalians",
       "definition": "The Foromeer is an upright two-legged Xalian of Veridium whose hands are long drill-like horns, able to break through the strongest of material. It carries a metallic exoskeleton on its limbs and is thought to once have been used for mineral excavation.",
+      "pronunciation": {
+        "respelling": "FOR-uh-meer",
+        "ipa": "ˈfɔːrəmɪər"
+      },
       "related": [
         "veridium"
       ]
@@ -363,6 +467,10 @@
       "title": "Genesis Prototype",
       "category": "technology",
       "definition": "The first Xalian Generator, which was responsible for terraforming the planet Floria.",
+      "pronunciation": {
+        "respelling": "JEN-uh-sis",
+        "ipa": "ˈdʒɛnəsɪs"
+      },
       "related": [
         "floria",
         "xalian-generator"
@@ -385,6 +493,10 @@
       "title": "Graviclaw",
       "category": "xalians",
       "definition": "The Graviclaw is a black-shelled crustacean Xalian of Grimedes, centaur-like in build, which lurks beneath the planet's foggy wetlands and intensifies gravitational waves to open miniature black holes in the water. It draws prey into its massive claws, which snap shut with a force far heavier than their size implies, and it can root itself to the ground as an immovable wall of chitin.",
+      "pronunciation": {
+        "respelling": "GRAV-ih-klaw",
+        "ipa": "ˈgrævɪklɔː"
+      },
       "related": [
         "grimedes"
       ]
@@ -394,6 +506,10 @@
       "title": "Grimedes",
       "category": "places",
       "definition": "A planet of perpetual night on the outer rim of Xalia, which borders a black hole and is known for having been the last bastion of APEX's forces during the End Wars.",
+      "pronunciation": {
+        "respelling": "gri-MEE-deez",
+        "ipa": "grɪˈmiːdiːz"
+      },
       "related": [
         "apex",
         "the-end-wars",
@@ -406,6 +522,10 @@
       "title": "Hippochamp",
       "category": "xalians",
       "definition": "The Hippochamp is a four-legged, seahorse-shaped Xalian of Poseidas whose long snout works as a high-pressure water cannon. It was designed to answer the electrical and chemical fires that occur on the hydro-processing rigs and to defend the rigs' Algael against pirates.",
+      "pronunciation": {
+        "respelling": "HIP-uh-champ",
+        "ipa": "ˈhɪpətʃæmp"
+      },
       "related": [
         "algael",
         "poseidas"
@@ -416,6 +536,10 @@
       "title": "Hypnopet",
       "category": "xalians",
       "definition": "The Hypnopet is a small, golden-furred creature of Telypso bearing a single color-changing horn, generated by the Telypso Generator as a service animal and therapist for the deranged Vallerii imprisoned on that world. Its horn pulses through shifting color to lock a subject in a trance, a sedative once used on patients in bouts of mania and now used by King Kozrak for crowd control on rebellious worlds.",
+      "pronunciation": {
+        "respelling": "HIP-noh-pet",
+        "ipa": "ˈhɪpnoʊpɛt"
+      },
       "related": [
         "king-kozrak",
         "telypso",
@@ -437,6 +561,10 @@
       "title": "Imprit",
       "category": "xalians",
       "definition": "The Imprit is a small horned Xalian of Magmuth, furred against the flammable oils it secretes and so burning continuously, designed by the Vallerii as a tinkerer and released into the mining shafts to repair the equipment sent down into the planet. Freed onto the surface it swings by its scythe-tipped tail and sets fires where they do not belong.",
+      "pronunciation": {
+        "respelling": "IM-prit",
+        "ipa": "ˈɪmprɪt"
+      },
       "related": [
         "magmuth",
         "vallerii"
@@ -447,6 +575,10 @@
       "title": "ION-9",
       "category": "technology",
       "definition": "The 'Divine Light' solar cannon which was constructed as a superweapon from the Stellaris Superstructure. A system by which the panels of the Dyson sphere could be angled like a mirror to concentrate the solar energy of one of Luminax's stars into a deadly beam of energy.",
+      "pronunciation": {
+        "respelling": "EYE-on NINE",
+        "ipa": "ˈaɪɒn ˈnaɪn"
+      },
       "related": [
         "luminax",
         "stellaris-superstructure"
@@ -457,6 +589,10 @@
       "title": "Jorian Belt",
       "category": "places",
       "definition": "An asteroid belt in the Cybele System, which collides with the planet Stonera once a year. The home of the now defunct APEX superweapon known as the Terracannon.",
+      "pronunciation": {
+        "respelling": "JOR-ee-un",
+        "ipa": "ˈdʒɔːriən"
+      },
       "related": [
         "apex",
         "cybele",
@@ -469,6 +605,10 @@
       "title": "Kelpan-5",
       "category": "places",
       "definition": "The original name of Endessa when it was still a vibrant aquatic breadbasket in the early days of the Vallerii Empire.",
+      "pronunciation": {
+        "respelling": "KEL-pan FIVE",
+        "ipa": "ˈkɛlpæn ˈfaɪv"
+      },
       "related": [
         "endessa",
         "vallerii"
@@ -479,6 +619,10 @@
       "title": "King Kozrak",
       "category": "people",
       "definition": "One of the last surviving members of the Vallerii race, who has used his knowledge of the Mercurius Machine to amass tyrannical power over the galaxy and institute the tournament for Scrambler Tokens.",
+      "pronunciation": {
+        "respelling": "KOZ-rak",
+        "ipa": "ˈkɒzræk"
+      },
       "related": [
         "mercurius-machine",
         "vallerii"
@@ -492,6 +636,10 @@
       "title": "Kosanos",
       "category": "xalians",
       "definition": "The Kosanos is a heavy four-legged Xalian of Floria with a broad blade at the end of its trunk, thought to have been designed to clear the planet's thick brush. It fells standing growth in the underforests below the World Trees.",
+      "pronunciation": {
+        "respelling": "koh-SAH-nos",
+        "ipa": "koʊˈsɑːnoʊs"
+      },
       "related": [
         "floria",
         "world-trees"
@@ -502,6 +650,10 @@
       "title": "Krystos",
       "category": "places",
       "definition": "A warmwater paradise that served as a vacation destination for Vallerii high society until it was plunged into an arctic apocalypse caused by an asteroid impact and converted into a frozen prison world and planetary cold-storage facility for APEX.",
+      "pronunciation": {
+        "respelling": "KRIS-tos",
+        "ipa": "ˈkrɪstɒs"
+      },
       "related": [
         "apex",
         "vallerii"
@@ -513,6 +665,10 @@
       "title": "Leviticus Overdrive",
       "category": "technology",
       "definition": "The name given to the Phantiri Generator's unprecedented act of re-writing its own code after centuries of watching its creations die on arrival. Under this new programming it abandoned organic life entirely, learning instead to produce ghost-like Xalians formed of spectral energy with no corporeal bodies at all.",
+      "pronunciation": {
+        "respelling": "leh-VIT-ih-kus",
+        "ipa": "ləˈvɪtɪkəs"
+      },
       "related": [
         "phantiri",
         "xalians"
@@ -523,6 +679,10 @@
       "title": "Luceras",
       "category": "xalians",
       "definition": "The Luceras is a small long-eared, curve-horned leaping animal of Saiphus, one of the great leaping animals that bound between the planet's floating islands. It jumps so high that at times it seems as if it is flying, and comes down on what it strikes like a battering ram.",
+      "pronunciation": {
+        "respelling": "loo-SEH-rus",
+        "ipa": "luːˈsɛrəs"
+      },
       "related": [
         "saiphus"
       ]
@@ -532,6 +692,10 @@
       "title": "Luminax",
       "category": "places",
       "definition": "A planet with binary stars that is subject to immense radiation, therefore serving as the solar energy capital of Xalia.",
+      "pronunciation": {
+        "respelling": "LOO-mih-naks",
+        "ipa": "ˈluːmɪnæks"
+      },
       "related": [
         "xalia"
       ],
@@ -542,6 +706,10 @@
       "title": "Magmuth",
       "category": "places",
       "definition": "A fiery hellscape of a planet known for containing valuable minerals.",
+      "pronunciation": {
+        "respelling": "MAG-muth",
+        "ipa": "ˈmægməθ"
+      },
       "related": [],
       "element": "fire"
     },
@@ -550,6 +718,10 @@
       "title": "Magmuth Massacre",
       "category": "history",
       "definition": "A massacre of Xalian laborers that took part at a mining camp on Magmuth as part of a corporate power struggle which led to the planet-wide revolt of Magmuth's Xalian population against the Vallerii.",
+      "pronunciation": {
+        "respelling": "MAG-muth",
+        "ipa": "ˈmægməθ"
+      },
       "related": [
         "magmuth",
         "vallerii"
@@ -559,6 +731,10 @@
       "title": "Magmuthites",
       "category": "factions",
       "definition": "The people of Magmuth. Stereotyped by other Xalians as the most aggressive, rebellious, and warlike of their kind, they remain wracked by internecine warfare fueled by old blood feuds from the company wars, and the rest of Xalia quietly counts itself fortunate that they have never united.",
+      "pronunciation": {
+        "respelling": "MAG-muth-ites",
+        "ipa": "ˈmægməθaɪts"
+      },
       "key": "magmuthites",
       "related": [
         "company-wars",
@@ -572,6 +748,10 @@
       "title": "Mercurius Machine",
       "category": "technology",
       "definition": "A unique device controlled by King Kozrak on Valleron, which prints Scrambler Tokens that can be used to breed new Xalians that are immune to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "mer-KOO-ree-us",
+        "ipa": "mɜrˈkjʊəriəs"
+      },
       "related": [
         "king-kozrak",
         "nemesis-plague",
@@ -584,6 +764,10 @@
       "title": "Nemesis Plague",
       "category": "phenomena",
       "definition": "A galaxy-killing virus built by APEX which targets the genomes of the Vallerii and Xalians alike.",
+      "pronunciation": {
+        "respelling": "NEM-uh-sis",
+        "ipa": "ˈnɛməsɪs"
+      },
       "related": [
         "apex",
         "vallerii",
@@ -595,6 +779,10 @@
       "title": "Neph",
       "category": "xalians",
       "definition": "The Neph is a colossal hydrogen jellyfish of Saiphus, drifting in flocks through the lower atmosphere and drawing Benthane and atmospheric plankton up through long trailing tentacles. Generated for the Benthane industry, it is shepherded and milked for the coolant gas that keeps Tachyon Drive Cores from superheating.",
+      "pronunciation": {
+        "respelling": "nef",
+        "ipa": "nɛf"
+      },
       "related": [
         "benthane",
         "saiphus"
@@ -605,6 +793,10 @@
       "title": "Newtapede",
       "category": "xalians",
       "definition": "The Newtapede is a sixteen legged amphibious Xalian of Poseidas, long and segmented, with a slender frame and webbed feet that make it a formidable opponent in water. It lives among the water-breathing Xalians of the planet's rigs.",
+      "pronunciation": {
+        "respelling": "NOOT-uh-peed",
+        "ipa": "ˈnuːtəpiːd"
+      },
       "related": [
         "poseidas",
         "xalians"
@@ -615,6 +807,10 @@
       "title": "Nightcap",
       "category": "substances",
       "definition": "A biochemical present only on Endessa that is necessary to induce stasis for sub-light space travel.",
+      "pronunciation": {
+        "respelling": "NITE-kap",
+        "ipa": "ˈnaɪtkæp"
+      },
       "related": [
         "endessa"
       ]
@@ -623,6 +819,10 @@
       "title": "Operation Phantiri",
       "category": "history",
       "definition": "The codename under which top secret Vallerii excavations of Shadharam IV continued for decades, termed after the nickname xenoarchaeologists gave the planet's original inhabitants. Its findings were sealed and classified after the reawakening of the moon-weapon that followed the discovery of the City of Wraiths.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "key": "operation-phantiri",
       "related": [
         "city-of-wraiths",
@@ -635,6 +835,10 @@
       "title": "Phantiri",
       "category": "places",
       "definition": "A tomb world whose lifeforms are under constant assault from an unknown energy source emanating from its orbital moon and whose Xalian Generator has responded by creating Xalians of a spectral, undead nature. Alternatively, the name of the extinct ancient alien species who once inhabited the planet and the top secret operation which uncovered their remains.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "related": [
         "xalian-generator",
         "xalians"
@@ -646,6 +850,10 @@
       "title": "Poseidas",
       "category": "places",
       "definition": "An ocean world that is subject to toxic algae blooms, torrential hurricanes, and immense tsunamis. The only known source of Algael in Xalia.",
+      "pronunciation": {
+        "respelling": "po-SY-das",
+        "ipa": "poʊˈsaɪdəs"
+      },
       "related": [
         "algael",
         "xalia"
@@ -657,6 +865,10 @@
       "title": "QED",
       "category": "technology",
       "definition": "Quantum Entanglement Device. A specially engineered computer chip exposed to a Bloodstorm on Zolton, which can be used to link communications equipment across the galaxy.",
+      "pronunciation": {
+        "respelling": "cue-ee-DEE",
+        "ipa": "kjuː iː ˈdiː"
+      },
       "related": [
         "bloodstorm",
         "zolton"
@@ -671,6 +883,10 @@
       "title": "Saigill Combines",
       "category": "factions",
       "definition": "The largest agricorp in the Vallerii Empire, which was driven to bankruptcy in its attempt to terraform Luminax before the invention of the Xalian Generators.",
+      "pronunciation": {
+        "respelling": "SAY-gill",
+        "ipa": "ˈseɪgɪl"
+      },
       "related": [
         "luminax",
         "vallerii"
@@ -681,6 +897,10 @@
       "title": "Saiphus",
       "category": "places",
       "definition": "A hydrogen-helium gas giant that is home to the only known source of Benthane in Xalia.",
+      "pronunciation": {
+        "respelling": "SIGH-fus",
+        "ipa": "ˈsaɪfəs"
+      },
       "related": [
         "benthane",
         "xalia"
@@ -692,6 +912,10 @@
       "title": "Scalatto",
       "category": "xalians",
       "definition": "The Scalatto is a plated two-legged Xalian of Endessa shielded by a scaly exoskeleton that lets it roll into a ball to protect itself. It lives in the sand and cavern networks of its homeworld.",
+      "pronunciation": {
+        "respelling": "skuh-LAT-oh",
+        "ipa": "skəˈlætoʊ"
+      },
       "related": [
         "endessa"
       ]
@@ -701,6 +925,10 @@
       "title": "Scrambler Token",
       "category": "technology",
       "definition": "A special chip printed by the Mercurius Machine which possesses a randomly generated and encrypted Xalian genome that can be used by a Xalian Generator to create new, unique Xalians that are immune to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "SKRAM-blur",
+        "ipa": "ˈskræmblər"
+      },
       "related": [
         "nemesis-plague",
         "xalian-generator",
@@ -712,6 +940,10 @@
       "title": "Shadharam IV",
       "category": "places",
       "definition": "The original Vallerii name for the planet Phantiri, before the discovery the extinct alien species now known as the Phantiri after the name of the top secret operation under which they were discovered.",
+      "pronunciation": {
+        "respelling": "SHAD-uh-ram the FOURTH",
+        "ipa": "ˈʃædərɑm ðə ˈfɔːrθ"
+      },
       "related": [
         "phantiri",
         "vallerii"
@@ -722,6 +954,10 @@
       "title": "Smokat",
       "category": "xalians",
       "definition": "The Smokat is a clever upright feline generated on Phantiri to work the dig sites the Imperial Houses opened there, able to atomize into a cloud of smoke at will and gather itself again. It now hunts the haze above the Dreadscape.",
+      "pronunciation": {
+        "respelling": "SMOH-kat",
+        "ipa": "ˈsmoʊkæt"
+      },
       "related": [
         "dreadscape",
         "imperial-houses",
@@ -752,6 +988,10 @@
       "title": "Stellaris Superstructure",
       "category": "places",
       "definition": "A Dyson sphere which was constructed around one of Luminax's stars in order to capture over a hundred-quadrillion gigawatts per second of solar energy.",
+      "pronunciation": {
+        "respelling": "steh-LAH-ris",
+        "ipa": "stəˈlɑːrɪs"
+      },
       "related": [
         "luminax"
       ],
@@ -764,6 +1004,10 @@
       "title": "Stonera",
       "category": "places",
       "definition": "A rocky planet with an incredibly thin atmosphere that is subjected to annual planetary bombardments as it passes through its star system's asteroid belt, leading to an immense saturation of valuable minerals and rare earth metals.",
+      "pronunciation": {
+        "respelling": "stoh-NAIR-uh",
+        "ipa": "stoʊˈnɛərə"
+      },
       "related": [],
       "element": "rock"
     },
@@ -785,6 +1029,10 @@
       "title": "Tachyon Drive Core",
       "category": "technology",
       "definition": "The only engine known to be able to achieve faster than light space travel, but which emits sterilizing Cherenkov radiation.",
+      "pronunciation": {
+        "respelling": "TAK-ee-on",
+        "ipa": "ˈtækiɒn"
+      },
       "related": [
         "cherenkov-radiation"
       ]
@@ -794,6 +1042,10 @@
       "title": "Telypso",
       "category": "places",
       "definition": "A psychedelic world at the center of Xalia used by the Vallerii as a planetary asylum and believed to be the origin of all life in the galaxy. The planet disobeys the laws of physics and is believed to contain a sort of psychosphere or planetary consciousness that drives its inhabitants mad.",
+      "pronunciation": {
+        "respelling": "teh-LIP-so",
+        "ipa": "təˈlɪpsoʊ"
+      },
       "related": [
         "vallerii",
         "xalia"
@@ -805,6 +1057,10 @@
       "title": "Terracannon",
       "category": "technology",
       "definition": "A now defunct superweapon built by APEX which used a reverse-tractor beam to propel supermassive asteroids from the Jorian Belt at its targets.",
+      "pronunciation": {
+        "respelling": "TERR-uh-kan-un",
+        "ipa": "ˈtɛrəkænən"
+      },
       "related": [
         "apex",
         "jorian-belt"
@@ -818,6 +1074,10 @@
       "title": "Terragoyle",
       "category": "xalians",
       "definition": "The Terragoyle is a horned, winged sentry of Stonera that lines the edges of the Chasm, holding a stone aloft at the tip of its tail. Generated to airlift debris from the strip mines, it now hibernates in a statue-like state along the perimeter and, when roused, rises above the Chasm to fling boulders and rake intruders with falling gravel.",
+      "pronunciation": {
+        "respelling": "TERR-uh-goyl",
+        "ipa": "ˈtɛrəgɔɪl"
+      },
       "related": [
         "stonera",
         "the-chasm"
@@ -828,6 +1088,10 @@
       "title": "Tetrahive",
       "category": "xalians",
       "definition": "The Tetrahive is a small winged Xalian of Grimedes with a long whipping tail that fights by conjuring a swarm of little flying familiars with teeth like piranhas, holding every one of them in its mind and moving them as a single unit to attack or defend. It was generated as a test subject rather than a laborer, and hunts the planet's thick, stalky undergrowth in perpetual night.",
+      "pronunciation": {
+        "respelling": "TET-ruh-hive",
+        "ipa": "ˈtɛtrəhaɪv"
+      },
       "related": [
         "grimedes"
       ]
@@ -861,6 +1125,10 @@
       "title": "The Zolto",
       "category": "factions",
       "definition": "The people of Zolton. Freed from APEX's control by Source Code 606, the Zolto now work to re-establish the connection between worlds, hoping to prevent the extinction of Xalian-kind; King Kozrak has labeled those who form such networks galactic enemies and cracked down on the planet to control the manufacture of and access to QEDs.",
+      "pronunciation": {
+        "respelling": "ZOL-toh",
+        "ipa": "ˈzoʊltoʊ"
+      },
       "key": "the-zolto",
       "related": [
         "apex",
@@ -874,6 +1142,10 @@
       "title": "Thirstaserp",
       "category": "xalians",
       "definition": "The Thirstaserp is a large hooded serpent of Endessa that lies buried in the dunes and draws opponents in with a subsonic vibration from the rattles on its tail. Its bite carries a venom that drains the water from what it bites, killing by extreme dehydration on a world whose oceans were vaporized by the Thousand Families.",
+      "pronunciation": {
+        "respelling": "THURST-uh-serp",
+        "ipa": "ˈθɜrstəsɜrp"
+      },
       "related": [
         "endessa",
         "thousand-families"
@@ -893,6 +1165,10 @@
       "title": "Tizzie",
       "category": "xalians",
       "definition": "The Tizzie is a small furred Xalian of Telypso that hangs from the branches by its hands, distinguished by a long tail tipped in a flat spiral disc and by spiral-patterned eyes that fill much of its face. It waves the disc to win a subject's attention, and once eye contact is made it works on that subject from inside its mind rather than through its body.",
+      "pronunciation": {
+        "respelling": "TIZ-ee",
+        "ipa": "ˈtɪzi"
+      },
       "related": [
         "telypso"
       ]
@@ -902,6 +1178,10 @@
       "title": "Vallerii",
       "category": "people",
       "definition": "An ancient, hyper-capitalistic and imperialistic spacefaring race which created both Xalians and APEX.",
+      "pronunciation": {
+        "respelling": "val-LEH-ree-eye",
+        "ipa": "vaˈlɛriaɪ"
+      },
       "related": [
         "apex",
         "xalians"
@@ -915,6 +1195,10 @@
       "title": "Valleron",
       "category": "places",
       "definition": "The last bastion of the Vallerii race, where Vallerii scientists developed the Mercurius Machine over which King Kozrak has established his stronghold.",
+      "pronunciation": {
+        "respelling": "VAL-uh-ron",
+        "ipa": "ˈvælərɒn"
+      },
       "related": [
         "king-kozrak",
         "mercurius-machine",
@@ -926,6 +1210,10 @@
       "title": "Venemist",
       "category": "xalians",
       "definition": "The Venemist is a shaggy four-legged hunter of Drainov that expels a dissolving mist from a tube seated in its jaws. Carrying only two teeth, it takes its food by breaking it down outside the body rather than by biting.",
+      "pronunciation": {
+        "respelling": "VEN-uh-mist",
+        "ipa": "ˈvɛnəmɪst"
+      },
       "related": [
         "drainov"
       ]
@@ -935,6 +1223,10 @@
       "title": "Veridians",
       "category": "factions",
       "definition": "The people of Veridium. During the End Wars, APEX drove the planet's ancient drones and robotic servants as a single hive mind and corralled the Veridians into a formidable fighting force, supplied by starship foundries large enough to spread its menace across the galaxy.",
+      "pronunciation": {
+        "respelling": "veh-RID-ee-unz",
+        "ipa": "vəˈrɪdiənz"
+      },
       "related": [
         "apex",
         "the-end-wars",
@@ -946,6 +1238,10 @@
       "title": "Veridium",
       "category": "places",
       "definition": "A metallic world filled with dilapidated drones and believed to be a superstructure or worldship leftover from a now extinct alien race, which served as the lynchpin of Vallerii industry and technological advancement throughout galactic history.",
+      "pronunciation": {
+        "respelling": "veh-RID-ee-um",
+        "ipa": "vəˈrɪdiəm"
+      },
       "related": [
         "vallerii"
       ],
@@ -956,6 +1252,10 @@
       "title": "Voltish",
       "category": "xalians",
       "definition": "The Voltish is a shaggy, long-limbed Xalian of Zolton whose bones and claws are a tough conductive alloy. It takes in electrical energy from its surroundings and releases the shock into its enemies.",
+      "pronunciation": {
+        "respelling": "VOL-tish",
+        "ipa": "ˈvoʊltɪʃ"
+      },
       "related": [
         "zolton"
       ]
@@ -965,6 +1265,10 @@
       "title": "Windsailor",
       "category": "factions",
       "definition": "Rogueish and rugged pilots who were once paid high sums to scour Saiphus for Benthane squalls.",
+      "pronunciation": {
+        "respelling": "WIND-say-lur",
+        "ipa": "ˈwɪndseɪlər"
+      },
       "related": [
         "benthane",
         "saiphus"
@@ -984,6 +1288,10 @@
       "title": "Wraithix",
       "category": "places",
       "definition": "The star system which contained the ghost fleet that led to Operation Phantiri, the discovery of Shadharam IV, and the discovery of the extinct alien species now known as the Phantiri",
+      "pronunciation": {
+        "respelling": "RAY-thiks",
+        "ipa": "ˈreɪθɪks"
+      },
       "related": [
         "ghost-fleet",
         "operation-phantiri",
@@ -999,6 +1307,10 @@
       "title": "Xalia",
       "category": "places",
       "definition": "The galaxy in which Xalians live.",
+      "pronunciation": {
+        "respelling": "ZAY-lee-uh",
+        "ipa": "ˈzeɪliə"
+      },
       "related": [
         "xalians"
       ]
@@ -1028,6 +1340,10 @@
       "title": "Xalians",
       "category": "xalians",
       "definition": "Bio-engineered organisms created by the Vallerii to serve as soldiers and laborers, who are specially adapted to the extreme environments of Xalia due to the incredible science of the Xalian Generators.",
+      "pronunciation": {
+        "respelling": "ZAY-lee-unz",
+        "ipa": "ˈzeɪliənz"
+      },
       "related": [
         "vallerii",
         "xalia"
@@ -1038,6 +1354,10 @@
       "title": "Xylum",
       "category": "xalians",
       "definition": "The Xylum is a giant rooted organism of the Floria underforests, a mass of thick intertwined limbs that act as tentacles. It lives mostly underground, where it absorbs its power.",
+      "pronunciation": {
+        "respelling": "ZY-lum",
+        "ipa": "ˈzaɪləm"
+      },
       "related": [
         "floria"
       ]
@@ -1047,6 +1367,10 @@
       "title": "Yetimoth",
       "category": "xalians",
       "definition": "The Yetimoth is a hulking, white-furred ape of Krystos with the head of a mammoth and a pair of frozen tusks, generated to serve as the rank and file of the planet's high-security prison complexes. It conjures thick sheets of frost from nothing to armor itself, wall off escape routes, and encase what it means to reach, then closes and pummels with its heavy fists.",
+      "pronunciation": {
+        "respelling": "YET-ee-moth",
+        "ipa": "ˈjɛtimɒθ"
+      },
       "related": [
         "krystos"
       ]
@@ -1056,6 +1380,10 @@
       "title": "Zolton",
       "category": "places",
       "definition": "A mountainous, storm-wracked world whose unique weather allows for the generation of immense sums of electricity, plasma energy, and Quantum Entanglement Devices.",
+      "pronunciation": {
+        "respelling": "ZOL-ton",
+        "ipa": "ˈzoʊltɒn"
+      },
       "related": [],
       "element": "electric"
     },
@@ -1064,6 +1392,10 @@
       "title": "Grimedites",
       "category": "factions",
       "definition": "The people of Grimedes. Stigmatized for the gravity, shadow, and time-bending abilities their Generator was made to produce, they now stand watch at the edge of the galaxy against APEX's possible return, their numbers replenished only by those who win Scrambler Tokens in King Kozrak's tournament.",
+      "pronunciation": {
+        "respelling": "GRIM-uh-dites",
+        "ipa": "ˈgrɪmədaɪts"
+      },
       "related": [
         "grimedes",
         "apex",
@@ -1076,6 +1408,10 @@
       "title": "Luminarii",
       "category": "factions",
       "definition": "The people of Luminax. Held under King Kozrak's martial law to protect his monopoly, they labor to earn Scrambler Tokens to maintain the misfiring Stellaris Superstructure, while some among them study the mutations caused by its ION-9 cannon in secret, hoping for a cure that answers to no Token.",
+      "pronunciation": {
+        "respelling": "loo-mih-NAH-ree-eye",
+        "ipa": "luːmɪˈnɑːriaɪ"
+      },
       "related": [
         "luminax",
         "king-kozrak",
@@ -1089,6 +1425,10 @@
       "title": "Krystians",
       "category": "factions",
       "definition": "The people of Krystos. A divided people who shoulder the blame for a war-scarred world that once served as APEX's cold-storage core, the Krystians must replenish their numbers through King Kozrak's Scrambler Tokens before they can search APEX's old techno-labyrinth for any answer to the Nemesis Plague.",
+      "pronunciation": {
+        "respelling": "KRIS-tee-unz",
+        "ipa": "ˈkrɪstiənz"
+      },
       "related": [
         "krystos",
         "apex",
@@ -1102,6 +1442,10 @@
       "title": "Phantiri (Xalians of)",
       "category": "factions",
       "definition": "The Xalians of Phantiri. Non-corporeal ghost Xalians produced after their Generator rewrote itself in the Leviticus Overdrive, they compete for Scrambler Tokens to resurrect themselves and the original Phantiri buried in the City of Wraiths beneath the Dreadscape.",
+      "pronunciation": {
+        "respelling": "fan-TEER-ee",
+        "ipa": "fænˈtɪəri"
+      },
       "related": [
         "phantiri",
         "leviticus-overdrive",

--- a/my-app/src/lore/__tests__/lore.pronunciation.test.js
+++ b/my-app/src/lore/__tests__/lore.pronunciation.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter, Route } from 'react-router-dom';
+import encyclopedia from '../../json/encyclopedia.json';
+import Pronunciation from '../../components/encyclopedia/Pronunciation';
+import EntryView from '../../components/encyclopedia/EntryView';
+
+const byKey = Object.fromEntries(encyclopedia.entries.map((e) => [e.key, e]));
+
+// No @testing-library/react in this project, so mount with react-dom directly
+// and read the painted DOM. Returns the container so a test can assert on
+// what actually rendered rather than on props.
+function paint(element) {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	act(() => {
+		ReactDOM.render(element, container);
+	});
+	return container;
+}
+
+
+describe('pronunciation data', () => {
+	it('carries a respelling and IPA on every entry that has one', () => {
+		const withPron = encyclopedia.entries.filter((e) => e.pronunciation);
+		expect(withPron.length).toBeGreaterThan(80);
+		for (const e of withPron) {
+			expect(e.pronunciation.respelling, e.key).toBeTruthy();
+			expect(e.pronunciation.ipa, e.key).toBeTruthy();
+		}
+	});
+
+	it('holds the rulings Nick made', () => {
+		expect(byKey['phantiri'].pronunciation.respelling).toBe('fan-TEER-ee');
+		expect(byKey['xalia'].pronunciation.respelling).toBe('ZAY-lee-uh');
+		expect(byKey['xalians'].pronunciation.respelling).toBe('ZAY-lee-unz');
+		expect(byKey['saiphus'].pronunciation.respelling).toBe('SIGH-fus');
+		expect(byKey['grimedes'].pronunciation.respelling).toBe('gri-MEE-deez');
+		expect(byKey['vallerii'].pronunciation.respelling).toBe('val-LEH-ree-eye');
+		expect(byKey['luceras'].pronunciation.respelling).toBe('loo-SEH-rus');
+		expect(byKey['algael'].pronunciation.respelling).toBe('AL-gale');
+	});
+
+	it('leaves transparent English names unmarked', () => {
+		for (const key of ['death-tide', 'drilltail', 'world-trees', 'the-end-wars']) {
+			expect(byKey[key].pronunciation, key).toBeUndefined();
+		}
+	});
+
+	it('never contradicts itself across entries sharing a name', () => {
+		const p = (k) => byKey[k].pronunciation.respelling;
+		expect(p('operation-phantiri')).toBe(p('phantiri'));
+		expect(p('battle-of-grimedes')).toBe(p('grimedes'));
+		expect(p('magmuth-massacre')).toBe(p('magmuth'));
+	});
+});
+
+describe('pronunciation rendering', () => {
+	it('paints the respelling for an entry that has one', () => {
+		const c = paint(<Pronunciation pronunciation={byKey['phantiri'].pronunciation} />);
+		expect(c.textContent).toContain('fan-TEER-ee');
+		expect(c.querySelector('.enc-pronunciation')).toBeTruthy();
+		// the IPA rides along as the title attribute
+		expect(c.querySelector('.enc-pronunciation').getAttribute('title')).toBe(byKey['phantiri'].pronunciation.ipa);
+	});
+
+	it('renders nothing at all when an entry has none', () => {
+		const c = paint(<Pronunciation pronunciation={undefined} />);
+		expect(c.innerHTML).toBe('');
+	});
+
+	it('shows up under the title on a real entry page', () => {
+		const c = paint(
+			<MemoryRouter initialEntries={['/encyclopedia/entry/telypso']}>
+				<Route path="/encyclopedia/entry/:key"><EntryView /></Route>
+			</MemoryRouter>
+		);
+		const h1 = c.querySelector('h1.g-title');
+		expect(h1.textContent).toBe('Telypso');
+		const pron = c.querySelector('.enc-pronunciation');
+		expect(pron.textContent).toBe('teh-LIP-so');
+		// and it sits after the title inside the same designation header
+		expect(h1.parentElement.contains(pron)).toBe(true);
+		expect(h1.compareDocumentPosition(pron) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+});


### PR DESCRIPTION
Adds pronunciation to the Encyclopedia. 86 of the 104 entries get one, printed under the designation in mono on entry, species and world records alike. The other 18 are transparent English (Death Tide, Drilltail, World Trees) and are deliberately unmarked, so an absent field means the name reads as written.

Each entry carries a respelling and an IPA:

```json
"pronunciation": { "respelling": "fan-TEER-ee", "ipa": "fænˈtɪəri" }
```

The respelling is what the page prints, since it is the half a reader can use without training. The IPA rides along for a later audio or screen-reader pass and surfaces only as the element's title attribute.

## Rulings

Nick decided these; they are recorded in `ENCYCLOPEDIA-INTERNAL.md` so the next person does not have to guess.

- **The Vallerii sound Roman.** Anything the Empire named takes a classical Latin reading: Vallerii val-LEH-ree-eye, Grimedes gri-MEE-deez, Poseidas po-SY-das, Mercurius mer-KOO-ree-us, Luminarii loo-mih-NAH-ree-eye. This is a fact about the Empire's language, so it governs every name they coined.
- **The rule stops at Vallerii coinages and does not reach creature names.** A Xalian is not a Vallerii artifact, so Luceras is loo-SEH-rus with the soft English c, not the classical hard k, despite the Latin root.
- **Real-world names keep their real readings.** Reading the definitions turned up two names that were never invented: Cybele is the Phrygian goddess (SIB-uh-lee) and Bacillota Requiem is scientific Latin. Neither was ours to respell freely.
- **Algael is AL-gale**, hard g, keeping the algae etymology the definition states audible to a reader meeting the word cold.
- **Xalia is ZAY-lee-uh, Xalians is ZAY-lee-unz.**
- Saigill (SAY-gill) is a default rather than a ruling. Nothing in the lore anchors it; revisit if it ever matters.

## Consistency

A name that appears in several entries reads the same in each: Phantiri the world, Operation Phantiri and the Phantiri Xalians are all fan-TEER-ee. Same for Grimedes and Magmuth across their battle and massacre entries. The test asserts this rather than trusting the data.

## Display

One `Pronunciation` component, rendered under the `h1` in all three designation headers. It brings its own stylesheet, so the style travels with it rather than depending on which view happens to import `EntryView.css`. Entries without a pronunciation render nothing at all.

## Verification

- `lore.pronunciation.test.js` (7 tests) covers the data shape, every ratified reading, the deliberately-unmarked entries, cross-entry consistency, and a DOM assertion that the respelling actually paints under the title in the right place. It fails if the field is dropped, misspelled, or rendered somewhere else.
- Full suite: 426 passing (was 419).
- `yarn build` clean; `node scripts/bundleLore.js` and `yarn copy-json` run, so `lambda/` and `my-app/` copies are in sync.
- Prose is untouched: the encyclopedia diff is 344 insertions and zero deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)