### PR TITLE
Add Long Return expedition prototype

### DIFF
--- a/docs/design/xalians-long-return-spoke-brainstorm.md
+++ b/docs/design/xalians-long-return-spoke-brainstorm.md
@@ -1,0 +1,341 @@
+# Xalians: The Long Return — expedition-game spoke brainstorm
+
+Status: design sketch, 2026-09-01. Not ratified and not an implementation plan.
+
+Companion documents: `xalian-creature-data-structure.md` (consumer contract), `xalian-creature-system-redesign.md` (authoritative creature system), `xalian-ability-grammar-draft.md` (ability vocabulary), and `xalians-platform-vision-and-economy.md` (hub-and-spoke platform direction).
+
+## Recommendation in one sentence
+
+Build a solo-first, cooperative-ready **push-your-luck expedition roguelite** in which a crew of owned Xalians crosses hazardous worlds and derelict Vallerii infrastructure, using incomplete sensory information and creature-specific ways of traversing, surviving, communicating, and manipulating the environment.
+
+Working title: **Xalians: The Long Return**. The name points at the present-day goal of making the creatures' homeworlds livable again, not simply winning another arena.
+
+This is intentionally not:
+
+- a creature-versus-creature battler;
+- a grid tactics or capture-the-flag game like Duel;
+- a deck, hand-economy, or row-control game like Tribute;
+- a straight-line racing game in which Sprint becomes the one stat that matters.
+
+Its fantasy is: **“These are not cards or chess pieces. This is the crew I trust to get us home.”**
+
+## Why this is the best third spoke
+
+The creature record is unusually rich in facts that describe exploration but are secondary in combat: environmental tolerance, breathing media, senses, communication channels, diet, anatomy, manipulation, size, locomotion, composition, covering, and temperament. An expedition game can make those facts central without pretending they all mean damage.
+
+It also creates collection demand orthogonal to both known spokes. A slow, low-aggression, liquid-breathing creature with tremorsense and high manipulation may be mediocre in a flag race and unremarkable in a point-total card game, but uniquely valuable when a flooded ruin is collapsing in darkness. The game rewards **coverage and complementarity**, not a universal best roll.
+
+Most importantly, an expedition gives those facts decisions to shape. The bad version of this idea is a sequence of “your Swim is 63, requirement is 60” checks. The proposed game instead makes the player choose how much to learn, which risk to accept, which creature to expose, which solution to spend, and when to turn back.
+
+## The player experience
+
+A mission is a 20–35 minute run across a branching route of 8–12 scenes. The player brings three owned Xalians. A longer mode could use four, but three is the right first target: legible, compatible with the proposed starter collection, and small enough that every individual matters.
+
+The run has one objective: recover a plague lab archive, restart an environmental stabilizer, extract a stranded survey team, map a Generator fault, or salvage a piece of End Wars infrastructure. The crew collects discoveries on the way. Reaching the objective completes the contract; extracting safely banks everything found. Pushing past an extraction point offers rarer discoveries and a better score while the mission-specific danger clock, crew strain, and expended abilities accumulate.
+
+The emotional arc is:
+
+1. **Prepare:** read the destination's known conditions and choose a complementary crew.
+2. **Scout:** reveal only the risks your crew can actually perceive.
+3. **Commit:** choose a route and a method with imperfect knowledge.
+4. **Adapt:** absorb the consequence, reroute, or spend a scarce answer.
+5. **Push or extract:** wager the run's banked discoveries against the next unknown scene.
+6. **Bring back a story:** the final report names the creatures and the specific acts that saved or cost the expedition.
+
+The fun should come from route-reading, improvisation, and growing familiarity with one's creatures—not from rolling a hidden percentage and hoping.
+
+## The scene: the smallest unit of play
+
+Each scene has three facets:
+
+| Facet | Question | Examples |
+|---|---|---|
+| **Approach** | Can the crew get into position? | flooded shaft, broken span, vertical duct, buried passage, open vacuum |
+| **Work** | What must be done there? | lift wreckage, decode a lock, stabilize a bridge, retrieve a core, calm local fauna |
+| **Fallout** | What does acting here disturb? | structural collapse, elemental exposure, noise, pursuit, heat loss, separated crew |
+
+Some facet tags begin concealed. The player first assigns a **scout**. Senses reveal tags rather than adding a generic percentage: sight reads geometry and moving silhouettes; hearing reads machinery and motion; smell reads biological and chemical traces; special senses reveal their registry-defined domains. A creature may discover a danger but be unable to relay it immediately if its communication channel does not work through the scene's medium or separation. The result is delayed until the team regroups, not arbitrarily discarded.
+
+The player then picks one of the visible routes and assigns:
+
+- a **lead**, whose capability or ability provides the method;
+- a **support**, who contributes one compatible fact such as manipulation, a sense, protection, or communication;
+- a **reserve**, protected from ordinary strain and available for an emergency reaction.
+
+Resolution is deterministic once all relevant tags are known. Concealed tags create uncertainty, not invisible dice. A method can succeed while producing different costs: time, noise, strain, elemental exposure, lost salvage, or a rising mission danger clock. This is essential. “Break the door,” “phase through the door,” “decode the door,” and “pull its mechanism from the other side” should all work, but leave a different mission state.
+
+### Why this is a game rather than a stat checker
+
+- Scouting costs time and exposes the scout; skipping it preserves tempo but leaves facet tags hidden.
+- Every route favors different coverage, so the strongest numerical creature is not automatically the safest assignment.
+- Abilities are limited-use expedition tools. Spending the perfect Ward now may leave no answer for the extraction.
+- The same successful method can change noise, pressure, or the topology of later scenes.
+- The reserve slot creates a real hedge: commit all useful creatures now, or protect an answer for the unknown fallout.
+- Extraction points force a clean push-your-luck decision with banked value on the line.
+
+There is no permanent injury and no creature progression. **Strain** is local to the run, derived by this game's rules, and disappears afterward. Account progression unlocks harder contract regions, alternate starting gear, report cosmetics, and tournament/leaderboard access—not stronger creatures.
+
+## How the creature record is read
+
+The game should consume the whole record honestly over the life of the game, but no individual scene should quiz ten fields at once. A good scene exposes roughly three relevant facts and one optional clever answer.
+
+### Fields used directly
+
+| Record data | Expedition interpretation |
+|---|---|
+| `capabilities.flight/swim/burrow/climb/sprint/leap` | Route methods. The value affects reliability, strain, and how much cargo can be carried through that route; thresholds may grant qualitatively different access. |
+| `capabilities.manipulation` | Operating devices, handling fragile salvage, carrying tools, and supporting another creature's physical action. The anatomy/telekinetic means remains visible in presentation. |
+| `senses` | Which concealed scene tags a scout can reveal, how far ahead it can reveal them, and which ambushes can trigger an emergency reaction. Special senses get explicit per-key interpretations. |
+| `ambientMedia`, `breathes`, `temperatureC` | Whether a route is safe, time-limited, or requires support. Drowning is applied only under the ratified rule: the creature breathes something and is submerged in a medium it cannot breathe. Unmodeled pressure or chemistry is never inferred. |
+| `heightCm`, `weightKg`, `bodyPlan` | Passage fit, load-bearing, stability, transport capacity, and whether a scene can separate the creature. Size is sometimes an advantage and sometimes a constraint. |
+| `corporeality`, `composition`, `covering` | Conservative, published interactions with physical barriers and environmental exposures. These never become an improvised universal immunity system. |
+| `anatomy` | What can physically reach, hold, cut, brace, illuminate, or operate. Ability instruments must remain consistent with the pinned anatomy registry. |
+| `diet` | What kind of field cache or camp environment can restore strain: forage, biological ration, light, stored energy, or none. This makes route supplies different without turning the game into hunger micromanagement. |
+| `communication` | How a separated scout relays discoveries and which coordination methods remain available through gas, liquid, darkness, solid contact, or line of sight. `[]` means explicitly mute, not missing data. |
+| ten `attributes` | Quality within a chosen method: Strength moves mass; Vitality absorbs bodily strain; Endurance sustains long work; Agility maneuvers; Reflex handles sudden fallout; Intelligence decodes; Willpower resists mental pressure; Instinct reads incomplete situations; Charisma influences living encounters; Resilience tolerates harsh exposure. |
+| `element.affinities` | Typed environmental exposure and ability-medium performance. A secondary affinity is blended continuously rather than becoming a binary second type. |
+| `traits` | Sparse exceptions and specializations through a versioned interpretation table. Unknown traits are ignored. |
+| `temperament` | Predictable autonomous reactions to surprises. It never adds power or modifies a check. |
+| `abilities` | The crew's limited-use verbs: method, reach/shape, medium, and magnitude. Signature and rolled abilities use the same baseline grammar. |
+
+### Fields intentionally not made into power
+
+| Record data | Treatment |
+|---|---|
+| build/archetype identity | Displayed as a useful summary of the rolled individual. Its favored attributes already exist in the record, so adding another bonus would double-count them. |
+| `appearance.finish` | Rendered proudly but ignored by expedition rules. This is not an appearance-shaped game. |
+| provenance, serial, generator version | Display and verification only. Old or low-serial creatures are not stronger. |
+| chirality | No gameplay. The record contract explicitly gives it no rank or present-game meaning. |
+| lifespan | No effect in a 30-minute expedition. It remains valuable natural-history data for future spokes. |
+| history | The game may append a mission-result event but never reads history for access, bonuses, or legality. |
+
+Leaving those fields alone is a feature. “Use the creature” does not mean forcing every stored fact into every game.
+
+## Abilities as expedition verbs
+
+Every launch action receives a baseline interpretation so all existing signatures degrade gracefully. The exact result also reads the instrument/action edge's descriptive delivery class when the registry supplies it; the game must not infer that every `burst` is ranged or every `cloud` travels downrange.
+
+| Action | Baseline expedition use |
+|---|---|
+| `strike` | Precise break, impact, or activation at contact/reach. |
+| `lash` | Sweep a path, catch several light targets, or form a temporary line. |
+| `crush` | Break or compact a heavy obstruction; may be loud or irreversible. |
+| `rake` | Strip, scrape, excavate, or make several quick cuts. |
+| `shove` | Reposition an obstacle, creature, or hazard front. |
+| `drain` | Pull energy, fluid, heat, or an element-colored contaminant from a target. |
+| `ambush` | Rapidly close or cross an exposed interval before fallout triggers. |
+| `beam` | Apply a focused effect at line range: cut, reveal, energize, or disable. |
+| `hurl` | Deliver mass or a carried object to a remote point. |
+| `spray` | Coat or clear a cone-shaped area. |
+| `burst` | Affect the immediate area around the user in one violent release. |
+| `cloud` | Create a lingering local condition that changes later scene resolution. |
+| `snare` | Catch, stabilize, tow, hold, or retrieve something. |
+| `ward` | Protect a creature or area from the next matching fallout. |
+| `mend` | Restore a strained creature or stabilize damaged living/mechanical material as the medium permits. |
+| `terrorize` | Repel, scatter, or hold living opposition at bay without creature combat. |
+
+`intensity` controls magnitude, duration, or coverage—not always “damage.” `medium` supplies the physical fantasy and typed interaction. A Water Mend and Metal Mend can both stabilize an expedition but solve different fiction. `instrument` plus the pinned allowed-action/delivery edge controls reach and plausibility. The unique name is used in the report: players should remember that Event Horizon held the bridge, not that “tool 3 added 41.”
+
+Abilities should recharge between missions, not at camps. That makes their use a run-level decision and prevents a single versatile creature from solving every scene repeatedly.
+
+## Temperament: behavior, never power
+
+Temperament matters only when an uncommanded or separated creature must react to newly revealed fallout. The UI always previews its likely response before commitment.
+
+| Axis | What it selects between |
+|---|---|
+| Boldness | hold position versus press through immediate danger |
+| Curiosity | stay on task versus investigate an unexpected signal or cache |
+| Energy | conserve effort versus keep acting when strained |
+| Aggression | evade/contain a living threat versus confront or drive it off |
+| Sociability | finish an isolated assignment versus regroup to aid the crew |
+
+These are deterministic priorities with context-sensitive outcomes, not +10% bonuses. No pole is universally good. A curious scout may find a hidden archive or wake a defense system. A bold creature may save time or take avoidable strain. The player receives a small number of **command overrides** per mission, turning knowledge of a creature's nature into planning rather than punishment.
+
+This is one of the game's most important attachment systems: two statistically similar individuals can feel different to take into the field without one receiving a higher power rating.
+
+## Trait interpretation, first pass
+
+Traits should be introduced in small tested batches, but the vocabulary already has a natural expedition reading:
+
+| Trait family | Expedition use |
+|---|---|
+| `healing`, `regenerative`, `protective` | restore others, self-repair after a scene, or intercept fallout |
+| `armored`, `resistant`, `mind-sealed` | reduce a narrow published class of physical, contaminant, or mental consequences; never blanket immunity |
+| `anchored`, `slippery`, `phasing` | resist forced movement, escape restraint, or bypass some physical interactions |
+| `ramming`, `telekinetic` | specialize a movement-backed obstruction method or remote manipulation |
+| `toxic`, `volatile`, `reflective` | create a hazardous method or reactive consequence that must be planned around |
+| `perceptive`, `foresighted`, `nocturnal`, `luminous`, `stealthy` | reveal, preview, illuminate, or avoid particular information and detection tags |
+| `hypnotic`, `menacing`, `inspiring` | alter living-encounter behavior and crew regroup choices, not raw work output |
+| `pack-bonded`, `solitary` | change the autonomous preference to work together or apart; no flat stat bonus |
+
+Each rules version publishes exact mappings per key and ignores anything it does not know. A trait's mere presence never creates a fee or score premium unless that rules version has an active interpretation for it.
+
+## Worked read: the sample Graviclaw
+
+The current Graviclaw pilot immediately produces a coherent expedition role without inventing a class for it.
+
+- It tolerates gas and liquid, breathes both, and operates from −15°C to 20°C. It is a natural choice for a cold flooded route, though typed environmental exposure is still resolved through the matrix.
+- Swim 52 gives it a credible aquatic approach. Sprint 12, Leap 4, Climb 18, Agility 14, and Reflex 38 make a broken elevated route a dangerous commitment.
+- Tremorsense plus Instinct 71 can reveal unstable flooring or moving mass before sight does. Vibration communication works especially well while the scout remains in solid contact with the crew's structure, and poorly across open gaps.
+- Weight 372 kg, Strength 74, Resilience 93, `armored`, and `anchored` make it excellent at bracing, towing, and holding a failing scene in place. Its size and mass can also close off fragile or narrow routes.
+- Manipulation 44 and pincers make it a competent physical operator, not a master technician. Intelligence 42 reinforces that distinction.
+- Point of No Return and Null Grasp are `snare` solutions: retrieve a remote object, pin shifting wreckage, or keep a bridge section from separating. Wraith Vise is a `crush` method. Event Horizon is a run-saving `ward`. Their Dark/Ghost media determine what hazards they safely answer.
+- High boldness and aggression with low energy and sociability predict a creature that will confront immediate danger, then prefer to hold a position alone rather than chase a curiosity. The player can plan around that; it grants no bonus.
+
+The result is a **cold-water anchor and recovery specialist** who can make one route safe for everybody but cannot cover speed, height, precision machinery, or broad communication. That is exactly the kind of role a complementary three-creature collection should create.
+
+## Registry and versioning contract
+
+This spoke should model the platform's intended consumer pattern explicitly:
+
+1. Fetch the schema and every controlled vocabulary from the record's pinned `generatorVersion`. Never resolve an old key against a current registry by accident.
+2. Validate/normalize descriptive inputs without changing the stored record.
+3. Apply a separate pinned `longReturnRulesVersion` containing:
+   - scene-tag definitions;
+   - thresholds and derived-score formulas;
+   - special-sense interpretations;
+   - communication-channel interpretations;
+   - trait interpretations;
+   - action and instrument/action-delivery interpretations;
+   - affinity/exposure blending;
+   - unknown-key fallbacks.
+4. Freeze both versions when a mission starts. A rules patch never changes an active or historical run.
+5. Ignore unknown optional fields and registry keys. Unknown traits are inert; an unknown future action cannot be selected as a specialized method until the rules version maps it, but the record and UI still load.
+6. Fix balance by changing the next `longReturnRulesVersion`, never by editing creatures or silently overriding their descriptive facts.
+7. Optionally append `expedition_started`, `objective_reached`, `crew_extracted`, and `expedition_lost` history events. Gameplay never reads them.
+
+One likely shared registry improvement is an **instrument-action edge delivery class**, already recommended by the Tribute work. This game also needs to know whether an actual edge is contact, reach, line, cone, deployed field, self-wave, or aura. It should consume that descriptive tag rather than maintain a second hand-guessed range taxonomy.
+
+## Mission generation and fairness
+
+A mission is generated from authored scene modules, not from free-form prose. Each module declares:
+
+- media, temperature, and typed exposure;
+- route tags and size/load limits;
+- concealed tags and which senses reveal them;
+- valid baseline methods and their state costs;
+- action/trait-specific alternatives;
+- possible fallout and topology changes;
+- report-language fragments.
+
+Daily challenges can publish one deterministic mission seed so players compare approaches on the same route. For a competitive leaderboard, use either a crew-specific **Expedition Fee** cap or normalize score by the crew's derived access/value vector. Story missions do not need an artificial fee; their branching route is already the balancing surface.
+
+Any fee must price only interpretations active in that rules version. It cannot be a universal creature-power score. A creature's value is mission-dependent by design.
+
+The generator should enforce route solvability at the mission level, not guarantee that every crew can take every branch. Every offered mission must have at least one viable route for a documented baseline starter profile. A player bringing a mismatched team should discover safer alternate paths, not hit an unavoidable hard lock at scene seven.
+
+## Collection, trading, and platform fit
+
+- **Generate:** a new creature creates immediate “what missions could this one open?” curiosity beyond combat strength.
+- **Own:** the binder can show a Long Return readout—strong routes, environmental envelope, senses, and interpreted tools—without altering the creature record.
+- **Trade:** demand emerges for coverage gaps: vacuum tolerance, liquid communication, manipulation, a particular special sense, a protective ability, or a small-bodied climber.
+- **History:** reports provide provenance flavor (“held the collapsing Deepwater span with Point of No Return”) without veterancy power.
+- **Progression:** accounts unlock contract regions, optional challenge modifiers, report frames, and cosmetic camp objects. Creatures gain no levels or learned moves.
+- **Economy:** missions can award a small Scrambler Token trickle, with difficult objectives or daily score bands offering larger payouts. Generation remains the sink.
+
+Because success needs complementary coverage, the proposed starter squad of three becomes meaningful immediately. The curation system can ensure the first trio includes distinct locomotion, sensing, and survival profiles without guaranteeing a perfect expedition team.
+
+## First playable: cut it hard
+
+The full design is too large for an MVP. The smallest honest proof is:
+
+- one deterministic 8-scene mission assembled from 12–15 authored modules;
+- three-creature crew selection from sample records;
+- three facets per scene, with one or two concealed;
+- a mandatory post-scout field report that narrates the action, distinguishes detected from relayed information, names affected routes, and explains the decision impact;
+- the lead/support/reserve assignment;
+- four route tags: vertical, submerged, unstable, sealed;
+- three environmental systems: medium, temperature, one typed exposure;
+- baseline graded senses plus two special senses;
+- all locomotion capabilities and manipulation;
+- six attributes initially: Strength, Endurance, Agility, Reflex, Intelligence, Resilience;
+- eight actions initially interpreted: crush, shove, beam, hurl, snare, ward, mend, ambush;
+- six traits initially interpreted: armored, anchored, resistant, perceptive, stealthy, phasing;
+- persistent crew strain, a mission-specific external danger clock, one extraction point, and one optional deep objective;
+- deterministic temperament reaction previews, with two command overrides;
+- an end-of-run story report naming the actual creatures and abilities used.
+
+This is enough to test the central question: **is scouting incomplete information and committing a complementary crew to costly methods intrinsically fun?** If not, adding more registry keys will not save it.
+
+No server is required for the first playable. A mission seed and three immutable records are sufficient for a local run. A ghost-style daily leaderboard can come later.
+
+## Operational failure, scouting, and field encounters
+
+The Black Archive prototype now names its external danger clock **Annex Instability**. This is not literal air or water pressure and it is not creature health. It represents failing structure, waking archive systems, and routes becoming harder to control. At 10, the annex forces extraction. A future mission should give the same rules slot a fiction-specific name—an approaching patrol, a spreading fire, a storm front—rather than exposing a universal abstract “pressure” label.
+
+Strain is persistent operational degradation:
+
+- 0–2: **Ready**, with all roles available;
+- 3–4: **Worn**, with reduced lead and support contribution;
+- 5: **Critical**, unable to scout and one consequence from being spent;
+- 6: **Spent**, unable to scout, lead, or support.
+
+The run also forces extraction when fewer than two crew members remain able to act. Creatures never die, take permanent wounds, or mutate their registry records. Failure means the crew can no longer complete the operation before the external clock closes it down.
+
+Scouting now exposes three competing roles derived from registry data rather than one “best scout” score: a quiet scout tries to notice and escape, a defensive scout can hold if detected, and a contact scout can communicate with or aid a native. Communication is a separate constraint. A useful observation relayed by display, vibration, voice, or telepathy can reach command immediately; without a compatible channel the scout must physically return, adding both strain and instability. If a scout is cornered, a remote channel can also make the difference between calling the crew and resolving the encounter alone.
+
+Field encounters are short expedition decisions, not a second battle game. The authored Turbine Hall encounter can begin with the scout or with the full crew. Choices include withdrawing, calling a medic, treating an injury, driving the native away, or taking another route. Each option previews crew readiness and Annex Instability consequences. A helped native may become a restricted **field companion** for the current mission only. It is never acquired or added to the user’s registry; it can intervene once to prevent a crossing consequence.
+
+Every resolution beat must state the fiction, the cause, and the persistent effect. “Nothing bad happened” is an explicit result: no strain, no instability, and any salvage or companion benefit gained. Untaken branches stay hidden.
+
+## Decision support is its own difficulty axis
+
+The interface should separate **mission difficulty** from **information difficulty**. Guidance changes how clearly command interprets known data; it never changes a creature's scores, the route target, hidden information, strain, danger-clock state, rewards, or consequences.
+
+- **Simple** is an alternate command surface, not a larger pile of explanations. It presents one decision at a time: who scouts or whether the crew stays together, how to respond to contact, which route to take, and whether to approve the recommended crew plan. It shows readiness changes, the fiction-specific danger clock, salvage, and whether hidden risk remains. The full assignment board stays behind “Choose a different plan.” “Recommended” means the best overall known tradeoff, not a promise that an unresolved route is safe.
+- **Guided** explains how every visible score was derived, calculates the team margin, translates that margin into likely consequences, and marks the best-known method for the currently assigned crew. It must say “best known,” because unrevealed hazards remain unrevealed.
+- **Standard** exposes the same derivation and consequence forecast but does not rank or recommend choices. The player gets a legible instrument panel, not an answer key.
+- **Expert** preserves the compact raw readout for players who want to infer the relationships themselves.
+
+These modes should remain switchable during a mission so learning the system is not a permanent commitment made at setup. Switching modes changes presentation and decision support only; it never rerolls or recalculates the mission.
+
+### Progressive disclosure
+
+The default decision surface should answer four questions without prose: **will the crew get through, what will it cost, what remains unknown, and what should I do next?** In Simple mode, hide global panels that do not help with the active choice: the full mission track, crew rail, ability ledger, field printer, score equation, and unused counters. Use outcome labels, cost tiles, warning chips, and short imperative actions instead. Derivation formulas, field definitions, weighting, registry provenance, and caveats belong behind a clearly labeled information control, manual-plan view, or calculation modal. Story prose belongs in the scan result and resolution beats, where the player is learning what happened rather than comparing options.
+
+This hierarchy is not permission to hide consequential information. Known strain, danger-clock changes, environmental incompatibility, ability consumption, and unresolved hazards must remain visible before commitment. Progressive disclosure removes explanatory repetition; it does not conceal stakes.
+
+The score-building equation is consequential information for players who are constructing a plan. Guided, Standard, Expert, and Simple's manual-plan escape hatch must visibly teach **lead method + support = team score versus route target**. Route difficulty should be labeled as a target, an incomplete assignment should show the empty equation, and selections should fill it in live. Simple may omit the equation while it proposes a complete plan, because the active decision there is approval rather than construction; the named lead, support, method, likely outcome, costs, and uncertainty remain visible. Weighting formulas belong in details.
+
+Teach that equation with one large, named example before presenting thresholds: “Chromocat uses Leap for 86; Ectoghoul adds 7; the crew's 93 beats the route's 63.” The primary takeaway should be readable as a sentence—**make the crew score at least as high as the route target; farther above means less strain**. The four margin bands and secondary modifiers are reference material and should not compete with that first lesson.
+
+## Design traps to avoid
+
+1. **Spreadsheet checks.** If every scene is “pick the largest number,” the concept is dead. Methods must change cost, information, and future topology.
+2. **One survival god-stat.** Do not average the record into an Expedition Power. Preserve access, information, action, and endurance as separate axes.
+3. **Punishing temperament.** Reactions must be previewed and contextually mixed, with command overrides. A temperament pole is never a defect.
+4. **Trait fan fiction.** Interpret only the registry's normative nature. Do not use one-line wording as permission to invent unrelated powers.
+5. **False environmental precision.** Pressure, humidity, atmosphere chemistry, and internal organs are not modeled. Do not infer them.
+6. **Ability-as-damage relapse.** Intensity should usually mean force, area, reach, duration, restoration, or control in this game.
+7. **Hard-lock runs.** Individual branches may be inaccessible; the generated mission must retain a viable route for its advertised profile.
+8. **Permanent wounds or training.** Run-local strain is fine. Mutating or leveling a creature is not.
+9. **Rare finish advantage.** Finish changes the expedition portrait and report treatment, never survival odds.
+10. **Trying to use every field.** Chirality and lifespan have no honest role here. Restraint protects the platform philosophy.
+11. **Silent state transitions.** Never move directly from “scan” to a wall of route data. Every creature action needs a result beat: what happened in the fiction, what the record allowed the creature to perceive or relay, what changed mechanically, and what the player should decide next.
+
+## Two nearby variants, and why they are weaker as the main pitch
+
+### Habitat Zero — sanctuary/ecosystem builder
+
+Build habitats whose media, temperature, diet supply, social mix, and labor needs fit a rotating population of owned creatures. This reads even more physiology and could become a warm, nonviolent collection spoke. Its risk is that creatures become passive production modifiers and the minute-to-minute game turns into menus. It is an excellent later cozy spoke or Long Return camp layer, but a weaker first standalone game pitch.
+
+### Directive — autonomous obstacle-course programming
+
+Program behavior priorities for a three-creature team, then watch temperament and senses drive a simulated rescue course. This uses temperament more deeply and could support shareable challenges. Its risk is opacity: players may blame the simulation rather than their plan, and authoring readable behavior rules is a larger design problem than authoring expedition scenes. It is a compelling future mode after The Long Return proves the traversal vocabulary.
+
+## Questions worth answering in the next brainstorm
+
+1. Is the desired tone hopeful restoration, dangerous salvage, cosmic-horror investigation, or a rotation among all three?
+2. Should the player control one three-creature crew for a full run, or rotate six owned creatures through three-person expedition legs?
+3. Should abilities be once per mission, charge-based by action, or usable repeatedly at sharply rising strain? Recommendation: once per mission for the first playable.
+4. Is delayed scouting information through communication channels delightful or too fussy? This is the first mechanic to paper-prototype.
+5. Should extraction failure lose all discoveries, or bank the objective while losing optional salvage? Recommendation: never erase the objective; risk only the optional haul and score.
+6. Which two special senses best demonstrate non-stat information gameplay in the first mission? Tremorsense and psychic/heat-sense are strong contrasts.
+7. Does the facility-pressure track create enough urgency, or does the game also need a finite light/supply clock?
+
+## Current verdict
+
+The Long Return is promising because it uses the record's richest underused layer—**what kind of body can exist, perceive, and act in a place**—as the central play surface. Duel asks, “How does this creature contest space against another squad?” Tribute asks, “What is this creature worth when abstracted into a court dossier?” The Long Return asks a third, independent question:
+
+**“Where can this individual go, what will it notice there, and how will it get everyone back?”**

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -54,6 +54,7 @@ const TributePage = lazy(() => import('./pages/games/tributePage'));
 const ReclamationPage = lazy(() => import('./pages/games/reclamationPage'));
 const DuelPlaygroundPage = lazy(() => import('./pages/games/duelPlaygroundPage'));
 const EncyclopediaPage = lazy(() => import('./pages/encyclopediaPage'));
+const LongReturnPage = lazy(() => import('./pages/games/longReturnPage'));
 
 
 // The legacy species detail route accepted either a zero-padded numeric id
@@ -106,6 +107,7 @@ class App extends React.Component {
               <Route exact path="/duel"><DuelStartPage/></Route>
               <Route exact path="/tribute"><TributePage/></Route>
               <Route exact path="/reclamation"><ReclamationPage/></Route>
+              <Route exact path="/long-return"><LongReturnPage /></Route>
               <Route exact path="/account"><UserAccountPage /></Route>
               <Route exact path="/train"><TrainingGroundsPage /></Route>
                 <Route exact path="/train/match"><MatchCardGamePage /></Route>

--- a/my-app/src/components/games/longReturn/longReturn.css
+++ b/my-app/src/components/games/longReturn/longReturn.css
@@ -1,0 +1,3292 @@
+.lr-console {
+  min-width: 320px;
+}
+
+.lr-shell button:not(:disabled) { cursor: pointer; }
+.lr-shell button:focus-visible,
+.lr-shell input:focus-visible {
+  outline: 3px solid var(--g-phosphor);
+  outline-offset: 3px;
+}
+.lr-shell button:disabled { cursor: not-allowed; }
+
+.lr-shell {
+  width: min(1540px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0 80px;
+}
+
+.lr-briefing {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, .95fr);
+  gap: 32px;
+  padding: 34px;
+  overflow: hidden;
+}
+
+.lr-briefing::after {
+  content: 'LR-07';
+  position: absolute;
+  right: 24px;
+  top: 13px;
+  color: var(--g-ink-low);
+  font: 600 10px/1 var(--g-font-mono);
+  letter-spacing: .18em;
+}
+
+.lr-briefing-copy {
+  align-self: center;
+}
+
+.lr-briefing-copy .g-title {
+  margin: 8px 0 18px;
+}
+
+.lr-lead {
+  max-width: 66ch;
+  margin: 0;
+  color: var(--g-ink-mid);
+  font-size: 1.08rem;
+  line-height: 1.65;
+}
+
+.lr-mission-stamp {
+  display: grid;
+  width: fit-content;
+  min-width: 310px;
+  margin-top: 28px;
+  padding: 12px 16px;
+  border: 1px solid var(--g-brass-dark);
+  border-left: 6px solid var(--g-hazard);
+  background: var(--g-hull-lo);
+  box-shadow: var(--g-recess);
+}
+
+.lr-mission-stamp span,
+.lr-mission-stamp small {
+  color: var(--g-ink-low);
+  font: 500 10px/1.5 var(--g-font-mono);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.lr-mission-stamp strong {
+  color: var(--g-ink);
+  font: 600 1.25rem/1.3 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-briefing-screen {
+  min-height: 320px;
+  padding: 28px;
+}
+
+.lr-briefing-screen .g-screen-line:first-child {
+  margin-bottom: 20px;
+  font-weight: 600;
+}
+
+.lr-howto {
+  display: grid;
+  gap: 8px;
+  margin-top: 26px;
+  padding-top: 20px;
+  border-top: 1px solid rgba(116, 255, 176, .16);
+}
+
+.lr-simple-hidden {
+  display: none;
+}
+
+.lr-howto span {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--g-phosphor-dim);
+  font: 500 12px/1.3 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-howto b {
+  display: grid;
+  width: 23px;
+  height: 23px;
+  place-items: center;
+  border: 1px solid rgba(116, 255, 176, .3);
+  border-radius: 50%;
+  color: var(--g-phosphor);
+}
+
+.lr-crew-select {
+  margin-top: 44px;
+}
+
+.lr-section-head,
+.lr-launch-row,
+.lr-mission-head,
+.lr-route-title-row,
+.lr-assignment-head,
+.lr-action-row,
+.lr-scene-heading,
+.lr-rail-title,
+.lr-meter-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.lr-section-head {
+  margin-bottom: 20px;
+}
+
+.lr-section-head .g-h2 {
+  margin-top: 5px;
+}
+
+.lr-selection-count {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 1px solid var(--g-rule);
+  background: var(--g-hull-lo);
+}
+
+.lr-selection-count strong {
+  color: var(--g-hazard);
+  font: 700 1.8rem/1 var(--g-font-mono);
+}
+
+.lr-selection-count span {
+  color: var(--g-ink-low);
+  font: 500 11px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.lr-crossing-primer {
+  margin: 0 0 20px;
+  padding: 24px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-seam);
+  border-left: 4px solid var(--g-phosphor);
+  box-shadow: var(--g-recess);
+}
+
+.lr-primer-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.lr-primer-head h2 {
+  margin: 4px 0 0;
+  color: var(--g-ink);
+  font: 600 1.5rem/1.15 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-primer-head > span {
+  padding: 7px 9px;
+  color: var(--g-phosphor);
+  background: var(--g-screen);
+  border: 1px solid rgba(116, 255, 176, .22);
+  font: 700 9px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-primer-takeaway {
+  max-width: 76ch;
+  margin: 0 0 18px;
+  color: var(--g-ink-mid);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.lr-primer-example {
+  padding: 14px;
+  background: var(--g-screen);
+  border: 1px solid var(--g-phosphor-dim);
+}
+
+.lr-primer-build {
+  display: grid;
+  grid-template-columns: minmax(145px, 1fr) 34px minmax(145px, 1fr) 34px minmax(145px, 1fr);
+  align-items: stretch;
+  gap: 7px;
+}
+
+.lr-primer-build > div {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 5px 10px;
+  min-height: 78px;
+  padding: 12px;
+  background: rgba(116, 255, 176, .045);
+  border-bottom: 3px solid var(--g-rule);
+}
+
+.lr-primer-build > div.is-crew { border-color: var(--g-phosphor); background: rgba(116, 255, 176, .09); }
+.lr-primer-build small { grid-column: 1 / -1; color: var(--g-phosphor-dim); font: 700 8px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-primer-build span { color: var(--g-ink-mid); font: 600 11px/1.2 var(--g-font-mono); text-transform: uppercase; }
+.lr-primer-build strong { color: var(--g-phosphor); font: 700 2rem/1 var(--g-font-mono); }
+.lr-primer-build > i { align-self: center; color: var(--g-phosphor); font: 700 1.1rem/1 var(--g-font-mono); font-style: normal; text-align: center; }
+
+.lr-primer-compare {
+  display: grid;
+  grid-template-columns: minmax(110px, .7fr) 28px minmax(110px, .7fr) 32px minmax(190px, 1.2fr);
+  align-items: center;
+  gap: 7px;
+  margin-top: 9px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(116, 255, 176, .15);
+}
+
+.lr-primer-compare > div {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 5px 10px;
+  padding: 10px 12px;
+  background: var(--g-hull);
+}
+
+.lr-primer-compare small { color: var(--g-ink-low); font: 700 8px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-primer-compare strong { color: var(--g-phosphor); font: 700 1.5rem/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-primer-compare > i { color: var(--g-hazard); font-size: 15px; text-align: center; }
+.lr-primer-compare .is-result { grid-template-columns: 1fr; gap: 5px; background: rgba(116, 255, 176, .1); border: 1px solid rgba(116, 255, 176, .25); }
+.lr-primer-compare .is-result strong { font-size: 13px; }
+.lr-primer-compare .is-result span { color: var(--g-phosphor-dim); font: 600 8px/1 var(--g-font-mono); text-transform: uppercase; }
+
+.lr-primer-next {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: #2d291c;
+  border-left: 3px solid var(--g-hazard);
+}
+
+.lr-primer-next strong { color: var(--g-hazard); font: 700 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-primer-next span { color: var(--g-ink-mid); font-size: .9rem; }
+
+.lr-crossing-equation {
+  display: grid;
+  grid-template-columns: minmax(70px, 1fr) 18px minmax(70px, 1fr) 18px minmax(70px, 1fr) 24px minmax(70px, 1fr) minmax(120px, 1.2fr);
+  align-items: stretch;
+  gap: 5px;
+  padding: 8px;
+  background: var(--g-screen);
+  border: 1px solid var(--g-phosphor-dim);
+}
+
+.lr-crossing-equation > div:not(.lr-crossing-result) {
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  min-height: 48px;
+  padding: 7px;
+  text-align: center;
+  background: rgba(116, 255, 176, .035);
+}
+
+.lr-crossing-equation > i {
+  align-self: center;
+  color: var(--g-phosphor-dim);
+  font: 600 10px/1 var(--g-font-mono);
+  font-style: normal;
+  text-align: center;
+}
+
+.lr-crossing-equation small {
+  color: var(--g-phosphor-dim);
+  font: 600 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-crossing-equation strong {
+  color: var(--g-phosphor);
+  font: 700 18px/1 var(--g-font-mono);
+}
+
+.lr-crossing-equation .is-team { box-shadow: inset 0 -2px 0 var(--g-phosphor); }
+.lr-crossing-equation .is-target { box-shadow: inset 0 -2px 0 var(--g-hazard); }
+
+.lr-crossing-result {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-content: center;
+  gap: 3px 8px;
+  padding: 7px 10px;
+  background: rgba(116, 255, 176, .1);
+  border-left: 2px solid var(--g-phosphor);
+}
+
+.lr-crossing-result small { grid-column: 1 / -1; }
+.lr-crossing-result span { color: var(--g-phosphor); font: 600 7px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-crossing-result.is-behind { background: rgba(228, 72, 60, .09); border-color: var(--g-lamp-red); }
+.lr-crossing-result.is-behind strong,
+.lr-crossing-result.is-behind span { color: var(--g-lamp-red); }
+
+.lr-primer-steps {
+  display: grid;
+  grid-template-columns: 1fr 18px 1fr 18px 1fr 18px 1fr;
+  align-items: center;
+  gap: 5px;
+  margin-top: 10px;
+}
+
+.lr-primer-steps > div {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  align-items: center;
+  gap: 7px;
+}
+
+.lr-primer-steps b {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  color: var(--g-ink-invert);
+  background: var(--g-hazard);
+  border-radius: 50%;
+  font: 700 9px/1 var(--g-font-mono);
+}
+
+.lr-primer-steps span { color: var(--g-ink-low); font: 500 8px/1.3 var(--g-font-mono); text-transform: uppercase; }
+.lr-primer-steps span strong { color: var(--g-ink); }
+.lr-primer-steps > i { color: var(--g-rule); text-align: center; }
+
+.lr-margin-scale {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 3px;
+  margin-top: 12px;
+}
+
+.lr-margin-scale span { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: 7px; padding: 7px 9px; border-top: 3px solid var(--g-phosphor); background: var(--g-hull); }
+.lr-margin-scale b { color: var(--g-phosphor); font: 700 9px/1 var(--g-font-mono); }
+.lr-margin-scale small { color: var(--g-ink-low); font: 600 7px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-margin-scale span.is-costly { border-color: var(--g-hazard); }
+.lr-margin-scale span.is-costly b { color: var(--g-hazard); }
+.lr-margin-scale span.is-rough,
+.lr-margin-scale span.is-critical { border-color: var(--g-lamp-red); }
+.lr-margin-scale span.is-rough b,
+.lr-margin-scale span.is-critical b { color: var(--g-lamp-red); }
+
+.lr-primer-modifiers {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 10px;
+}
+
+.lr-primer-modifiers span,
+.lr-primer-modifiers b {
+  padding: 5px 7px;
+  color: var(--g-ink-low);
+  background: var(--g-hull);
+  border: 1px solid var(--g-rule);
+  font: 600 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-primer-modifiers span { color: var(--g-hazard); background: transparent; border: 0; padding-left: 0; }
+.lr-primer-modifiers b i { color: var(--g-hazard); }
+.lr-crossing-primer--detailed { margin: 4px 0 18px; padding: 16px; border-left-width: 1px; box-shadow: none; }
+.lr-crossing-primer--detailed .lr-primer-head h2 { font-size: 1.05rem; }
+.lr-crossing-primer--detailed .lr-primer-takeaway { font-size: .86rem; }
+.lr-crossing-primer--detailed .lr-primer-build { grid-template-columns: minmax(105px, 1fr) 22px minmax(105px, 1fr) 22px minmax(105px, 1fr); }
+.lr-crossing-primer--detailed .lr-primer-build strong { font-size: 1.35rem; }
+
+.lr-simple-primer {
+  display: grid;
+  grid-template-columns: 48px minmax(260px, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 20px;
+  padding: 18px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-seam);
+  border-left: 4px solid var(--g-phosphor);
+}
+
+.lr-simple-primer > i {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  color: var(--g-phosphor);
+  background: var(--g-screen);
+  border: 1px solid rgba(116, 255, 176, .2);
+  font-size: 20px;
+}
+
+.lr-simple-primer h2 { margin: 3px 0 4px; color: var(--g-ink); font: 600 1.35rem/1.1 var(--g-font-stencil); text-transform: uppercase; }
+.lr-simple-primer p:last-child { margin: 0; font-size: .95rem; line-height: 1.45; }
+.lr-simple-primer-steps { display: flex; align-items: center; gap: 6px; }
+.lr-simple-primer-steps span { display: flex; align-items: center; gap: 6px; color: var(--g-ink-mid); font: 600 8px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-primer-steps b { display: grid; width: 22px; height: 22px; place-items: center; color: var(--g-ink-invert); background: var(--g-hazard); border-radius: 50%; }
+.lr-simple-primer-steps > i { color: var(--g-rule); }
+
+.lr-mode-simple .lr-crew-choice .lr-chip-row,
+.lr-mode-simple .lr-crew-choice .lr-choice-footer { display: none; }
+.lr-mode-simple .lr-briefing-screen .g-screen-line { font-size: 13px; line-height: 1.55; }
+.lr-mode-simple .lr-crew-choice h3 { font-size: 1.65rem; }
+.lr-mode-simple .lr-role { font: 500 13px/1.45 var(--g-font-mono); }
+
+.lr-guidance-setup {
+  display: grid;
+  grid-template-columns: minmax(230px, .75fr) minmax(480px, 1.25fr);
+  align-items: center;
+  gap: 20px;
+  margin-top: 20px;
+  padding: 17px;
+}
+
+.lr-guidance-setup h2 {
+  margin: 4px 0 6px;
+  color: var(--g-ink);
+  font: 600 1.05rem/1.15 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-guidance-setup > div:first-child > p:last-child {
+  margin: 0;
+  color: var(--g-ink-low);
+  font-size: .86rem;
+  line-height: 1.45;
+}
+
+.lr-guidance-selector {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.lr-guidance-selector > button {
+  position: relative;
+  min-height: 76px;
+  padding: 10px;
+  color: var(--g-ink-mid);
+  text-align: left;
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+}
+
+.lr-guidance-selector > button:hover,
+.lr-guidance-selector > button.is-selected {
+  border-color: var(--g-hazard);
+}
+
+.lr-guidance-selector > button.is-selected {
+  background: #2d291c;
+  box-shadow: inset 0 0 0 1px var(--g-hazard);
+}
+.lr-guidance-selector > button.is-selected::after {
+  content: '✓';
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  color: var(--g-hazard);
+  font: 700 12px/1 var(--g-font-mono);
+}
+
+.lr-guidance-selector span,
+.lr-guidance-selector small {
+  display: block;
+}
+
+.lr-guidance-selector span {
+  color: var(--g-ink);
+  font: 600 12px/1.2 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-guidance-selector span em {
+  display: inline-block;
+  margin-left: 5px;
+  padding: 2px 4px;
+  color: var(--g-ink-invert);
+  background: var(--g-hazard);
+  font: 600 8px/1 var(--g-font-mono);
+  font-style: normal;
+}
+
+.lr-guidance-selector small {
+  margin-top: 6px;
+  color: var(--g-ink-low);
+  font: 500 10px/1.45 var(--g-font-mono);
+}
+
+.lr-guidance-selector--compact {
+  min-width: 292px;
+  gap: 3px;
+}
+
+.lr-guidance-selector--compact > button {
+  min-height: 0;
+  padding: 6px 7px;
+  text-align: center;
+}
+
+.lr-guidance-selector--compact span {
+  font-size: 10px;
+}
+
+.lr-guidance-selector--compact span em {
+  display: none;
+}
+
+.lr-crew-choice {
+  position: relative;
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  min-height: 180px;
+  padding: 0;
+  overflow: hidden;
+  color: var(--g-ink);
+  text-align: left;
+  background: var(--g-hull);
+  border: 1px solid var(--g-seam);
+  border-radius: var(--g-radius-panel);
+  box-shadow: var(--g-relief), var(--g-drop);
+  transition: transform var(--g-snap), border-color var(--g-snap), opacity var(--g-snap);
+}
+
+.lr-crew-choice:hover:not(:disabled) {
+  transform: translateY(-2px);
+  border-color: var(--g-brass-dark);
+}
+
+.lr-crew-choice:disabled {
+  opacity: .43;
+}
+
+.lr-choice-disabled {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 7px 9px;
+  color: var(--g-ink);
+  background: rgba(228, 72, 60, .16);
+  border: 1px solid rgba(228, 72, 60, .35);
+  font: 600 9px/1.25 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-crew-choice--selected {
+  border-color: var(--g-el);
+  box-shadow: inset 0 0 0 1px var(--g-el), var(--g-drop);
+}
+
+.lr-portrait {
+  --g-el: var(--g-phosphor);
+  position: relative;
+  height: 100%;
+  min-height: 180px;
+  overflow: hidden;
+  background: var(--g-hull-lo);
+  border-right: 1px solid var(--g-seam);
+}
+
+.lr-portrait .xalian-image-wrapper {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: inherit;
+  padding: 0 !important;
+  border: 0;
+  border-radius: 0;
+}
+
+.lr-portrait .xalian-image {
+  display: block;
+  width: 84% !important;
+  height: 84% !important;
+  max-height: none;
+  margin: auto;
+  padding: 0 !important;
+  filter: drop-shadow(0 7px 4px rgba(0, 0, 0, .45));
+}
+
+.lr-element-mark {
+  position: absolute;
+  left: 9px;
+  bottom: 9px;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  color: rgba(13, 11, 9, .9);
+  background: rgba(244, 241, 211, .78);
+  border: 1px solid rgba(13, 11, 9, .3);
+  border-radius: 50%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .28);
+}
+
+.lr-element-mark svg {
+  display: block;
+  margin: 0 !important;
+}
+
+.lr-crew-choice-body {
+  position: relative;
+  padding: 20px 18px 15px;
+}
+
+.lr-choice-check {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid var(--g-rule);
+  border-radius: 50%;
+  color: var(--g-ink-low);
+}
+
+.lr-crew-choice--selected .lr-choice-check {
+  color: var(--g-ink-invert);
+  background: var(--g-el);
+  border-color: var(--g-el);
+}
+
+.lr-crew-choice h3 {
+  margin: 3px 30px 1px 0;
+  font: 600 1.5rem/1.1 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-role {
+  margin: 0 0 13px;
+  color: var(--g-el);
+  font: 500 12px/1.4 var(--g-font-mono);
+}
+
+.lr-chip-row,
+.lr-env-row,
+.lr-route-cost {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.lr-chip-row span,
+.lr-env-row span {
+  padding: 4px 6px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+  font: 500 10px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-choice-footer {
+  display: grid;
+  gap: 4px;
+  margin-top: 13px;
+  padding-top: 10px;
+  border-top: 1px solid var(--g-rule-faint);
+}
+
+.lr-choice-footer span {
+  color: var(--g-ink-low);
+  font: 500 10px/1.25 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-choice-footer i {
+  margin-right: 5px;
+  color: var(--g-el);
+}
+
+.lr-launch-row {
+  margin-top: 22px;
+  padding: 16px 18px;
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+}
+
+.lr-launch-row p {
+  margin: 0;
+  color: var(--g-ink-low);
+  font: 500 12px/1.4 var(--g-font-mono);
+}
+
+.lr-launch-row p i {
+  margin-right: 7px;
+  color: var(--g-hazard);
+}
+
+.lr-launch {
+  min-width: 250px;
+}
+
+/* Mission HUD */
+.lr-play-shell {
+  padding-top: 26px;
+}
+
+.lr-mission-head {
+  align-items: flex-end;
+  margin-bottom: 18px;
+  padding: 0 4px;
+}
+
+.lr-mission-head h1 {
+  margin: 3px 0 0;
+  color: var(--g-ink);
+  font: 700 2.2rem/1 var(--g-font-stencil);
+  letter-spacing: .02em;
+  text-transform: uppercase;
+}
+
+.lr-head-readouts {
+  display: flex;
+  align-items: flex-end;
+  gap: 18px;
+}
+
+.lr-head-readouts .lr-meter {
+  width: 220px;
+}
+
+.lr-rules-button {
+  min-height: 42px;
+  padding: 8px 10px;
+  color: var(--g-hazard);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+  font: 600 8px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-rules-button:hover { color: var(--g-ink); border-color: var(--g-hazard); }
+
+.lr-counter {
+  display: grid;
+  min-width: 90px;
+  padding: 8px 12px;
+  border: 1px solid var(--g-rule);
+  background: var(--g-hull-lo);
+  text-align: right;
+}
+
+.lr-counter span {
+  color: var(--g-ink-low);
+  font: 500 9px/1 var(--g-font-mono);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.lr-counter strong {
+  margin-top: 4px;
+  color: var(--g-phosphor);
+  font: 700 1.35rem/1 var(--g-font-mono);
+}
+.lr-salvage-counter { position: relative; }
+.lr-salvage-counter.is-changing { animation: lr-status-impact 1.4s ease-out; }
+.lr-salvage-counter > em { position: absolute; right: -7px; bottom: -8px; padding: 4px 6px; color: var(--g-ink-invert); background: var(--g-hazard); font: 800 9px/1 var(--g-font-mono); font-style: normal; animation: lr-delta-pop 1.6s ease-out both; }
+
+.lr-track {
+  margin-bottom: 18px;
+  padding: 12px 18px 15px;
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-seam);
+  box-shadow: var(--g-recess);
+}
+
+.lr-track-summary {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+  padding-bottom: 9px;
+  border-bottom: 1px solid var(--g-rule-faint);
+}
+
+.lr-track-summary > div {
+  display: grid;
+  gap: 4px;
+}
+
+.lr-track-summary span,
+.lr-track-summary small {
+  color: var(--g-ink-low);
+  font: 500 8px/1.25 var(--g-font-mono);
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.lr-track-summary strong {
+  color: var(--g-hazard);
+  font: 600 10px/1.2 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-track-line {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.lr-track-node {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 7px;
+  color: var(--g-ink-low);
+}
+
+.lr-track-node:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  z-index: 0;
+  top: 12px;
+  left: calc(50% + 14px);
+  width: calc(100% - 28px);
+  height: 2px;
+  background: var(--g-rule);
+}
+
+.lr-track-node > span {
+  z-index: 1;
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid var(--g-rule);
+  border-radius: 50%;
+  background: var(--g-hull-lo);
+  font: 600 10px/1 var(--g-font-mono);
+}
+
+.lr-track-copy {
+  display: grid;
+  gap: 3px;
+  justify-items: center;
+  min-width: 0;
+  text-align: center;
+}
+
+.lr-track-copy strong {
+  overflow: hidden;
+  max-width: 100%;
+  color: var(--g-ink-low);
+  font: 600 8px/1.15 var(--g-font-mono);
+  letter-spacing: .04em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.lr-track-copy small {
+  font: 500 8px/1 var(--g-font-mono);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.lr-track-node--done > span {
+  color: var(--g-ink-invert);
+  background: var(--g-phosphor);
+  border-color: var(--g-phosphor);
+}
+
+.lr-track-node--done .lr-track-copy strong,
+.lr-track-node--done .lr-track-copy small {
+  color: var(--g-phosphor-dim);
+}
+
+.lr-track-node--done::after {
+  background: rgba(116, 255, 176, .5) !important;
+}
+
+.lr-track-node--active > span {
+  color: var(--g-hazard);
+  border-color: var(--g-hazard);
+  box-shadow: 0 0 0 3px rgba(217, 164, 16, .13);
+}
+
+.lr-track-node--active .lr-track-copy strong,
+.lr-track-node--active .lr-track-copy small {
+  color: var(--g-hazard);
+}
+
+.lr-track-node--objective:not(.lr-track-node--active) > span {
+  border-style: double;
+  border-width: 3px;
+}
+
+.lr-game-grid {
+  display: grid;
+  grid-template-columns: 300px minmax(520px, 1fr) 280px;
+  align-items: start;
+  gap: 16px;
+}
+
+.lr-mode-simple .lr-game-grid {
+  grid-template-columns: minmax(0, 1000px);
+  justify-content: center;
+}
+
+.lr-mode-simple .lr-crew-rail,
+.lr-mode-simple .lr-log,
+.lr-mode-simple .lr-track-line,
+.lr-mode-simple .lr-track-summary > small,
+.lr-mode-simple .lr-head-readouts .lr-counter,
+.lr-mode-simple .lr-scene-orientation > div:last-child { display: none; }
+.lr-mode-simple .lr-scene-orientation { grid-template-columns: 1fr; }
+
+.lr-mode-simple .lr-mission-head,
+.lr-mode-simple .lr-track { width: min(1000px, 100%); margin-inline: auto; }
+.lr-mode-simple .lr-track { padding: 10px 14px; }
+.lr-mode-simple .lr-track-summary { margin: 0; }
+.lr-mode-simple .lr-scene { min-height: 0; }
+.lr-mode-simple .lr-scene-copy { font-size: 1rem; }
+.lr-mode-simple .lr-scene-orientation span { font-size: 10px; }
+.lr-mode-simple .lr-scene-orientation strong { font: 500 13px/1.45 var(--g-font-mono); }
+
+.lr-mode-simple.lr-is-customizing .lr-game-grid {
+  grid-template-columns: 280px minmax(520px, 1fr);
+  max-width: 1300px;
+  margin-inline: auto;
+}
+
+.lr-mode-simple.lr-is-customizing .lr-crew-rail { display: block; }
+
+.lr-crew-rail,
+.lr-log {
+  padding: 14px;
+}
+
+.lr-rail-title {
+  margin-bottom: 11px;
+}
+
+.lr-rail-title > span {
+  color: var(--g-hazard);
+  font: 600 9px/1 var(--g-font-mono);
+  letter-spacing: .1em;
+}
+
+.lr-crew-member {
+  --g-el: var(--g-phosphor);
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  width: 100%;
+  min-height: 100px;
+  margin-bottom: 8px;
+  padding: 0;
+  overflow: hidden;
+  color: var(--g-ink);
+  text-align: left;
+  background: var(--g-hull);
+  border: 1px solid var(--g-seam);
+  border-radius: var(--g-radius);
+  box-shadow: var(--g-relief);
+}
+
+.lr-crew-member:hover:not(:disabled) {
+  border-color: var(--g-brass-dark);
+}
+
+.lr-crew-member--selected {
+  border-color: var(--g-el);
+  box-shadow: inset 0 0 0 1px var(--g-el);
+}
+
+.lr-crew-member--spent {
+  filter: grayscale(.8);
+  opacity: .5;
+}
+
+.lr-portrait--compact {
+  min-height: 92px;
+  height: 100%;
+}
+
+.lr-portrait--compact .xalian-image {
+  width: 80% !important;
+  height: 80% !important;
+}
+
+.lr-portrait--compact .lr-element-mark {
+  left: 6px;
+  bottom: 6px;
+  width: 26px;
+  height: 26px;
+}
+
+.lr-crew-member-main {
+  min-width: 0;
+  padding: 10px 9px 8px;
+}
+
+.lr-crew-member-main strong,
+.lr-member-role,
+.lr-member-detail {
+  display: block;
+}
+
+.lr-member-role {
+  overflow: hidden;
+  color: var(--g-el);
+  font: 500 9px/1.25 var(--g-font-mono);
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.lr-crew-member-main > strong {
+  margin: 3px 0;
+  font: 600 1rem/1 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-member-detail {
+  overflow: hidden;
+  margin-bottom: 7px;
+  color: var(--g-ink-low);
+  font: 500 9px/1.25 var(--g-font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lr-meter-label {
+  margin-bottom: 4px;
+  color: var(--g-ink-low);
+  font: 500 9px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-meter-label strong {
+  color: var(--g-ink-mid);
+  font-size: 9px;
+}
+
+.lr-meter-track {
+  height: 5px;
+  overflow: hidden;
+  background: var(--g-seam);
+  border: 1px solid rgba(255, 255, 255, .03);
+}
+
+.lr-meter-track span {
+  display: block;
+  height: 100%;
+  background: var(--g-hazard);
+}
+
+.lr-meter--danger .lr-meter-track span {
+  background: var(--g-lamp-red);
+}
+
+.lr-ability-ledger {
+  margin-top: 16px;
+  padding-top: 13px;
+  border-top: 1px solid var(--g-rule);
+}
+
+.lr-ability-ledger > div {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) 32px;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--g-rule-faint);
+  font-family: var(--g-font-mono);
+}
+
+.lr-ability-ledger > div span {
+  color: var(--g-el);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.lr-ability-ledger > div strong {
+  overflow: hidden;
+  color: var(--g-ink-mid);
+  font-size: 10px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lr-ability-ledger > div small {
+  color: var(--g-ink-low);
+  font-size: 9px;
+  text-align: right;
+}
+
+.lr-ability-ledger > div.is-spent {
+  opacity: .3;
+  text-decoration: line-through;
+}
+
+.lr-scene {
+  min-height: 690px;
+  padding: 25px;
+  scroll-margin-top: 82px;
+}
+
+.lr-scene-heading {
+  align-items: flex-start;
+}
+
+.lr-scene-heading .g-h2 {
+  margin-top: 4px;
+}
+
+.lr-objective-badge,
+.lr-optional-badge {
+  padding: 6px 9px;
+  color: var(--g-ink-invert);
+  background: var(--g-hazard);
+  font: 700 9px/1 var(--g-font-mono);
+  letter-spacing: .1em;
+}
+
+.lr-optional-badge {
+  color: var(--g-ink);
+  background: var(--g-brass-dark);
+}
+
+.lr-scene-copy {
+  max-width: 72ch;
+  margin: 13px 0 14px;
+  color: var(--g-ink-mid);
+  line-height: 1.55;
+}
+
+.lr-scene-orientation {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 1px;
+  margin-bottom: 20px;
+  background: var(--g-seam);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-scene-orientation > div {
+  display: grid;
+  gap: 5px;
+  padding: 11px 13px;
+  background: var(--g-hull-lo);
+}
+
+.lr-scene-orientation span,
+.lr-route-intent span,
+.lr-route-methods span,
+.lr-report-readouts span,
+.lr-intel-card span,
+.lr-report-analysis span,
+.lr-decision-brief span {
+  color: var(--g-ink-low);
+  font: 600 9px/1 var(--g-font-mono);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.lr-scene-orientation strong {
+  color: var(--g-ink-mid);
+  font: 500 12px/1.45 var(--g-font-mono);
+}
+
+.lr-phase-panel {
+  padding-top: 20px;
+  border-top: 1px solid var(--g-rule);
+}
+
+.lr-phase-intro {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
+.lr-step-number {
+  display: grid;
+  min-width: 38px;
+  height: 38px;
+  place-items: center;
+  color: var(--g-ink-invert);
+  background: var(--g-hazard);
+  font: 700 13px/1 var(--g-font-mono);
+}
+
+.lr-phase-intro h3 {
+  margin: 0 0 3px;
+  color: var(--g-ink);
+  font: 600 1.2rem/1.1 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-phase-intro p {
+  margin: 0;
+  color: var(--g-ink-low);
+  font-size: .92rem;
+}
+
+.lr-signal-board {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  margin-bottom: 16px;
+  background: var(--g-seam);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-signal-board > div {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  background: var(--g-hull-lo);
+}
+
+.lr-signal-board span {
+  color: var(--g-ink-low);
+  font: 500 9px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-signal-board strong {
+  color: var(--g-ink-mid);
+  font: 500 12px/1.3 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-scan-preview,
+.lr-scan-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull-lo);
+  border-left: 3px solid var(--g-lamp-red);
+  font: 500 11px/1.3 var(--g-font-mono);
+}
+
+.lr-scan-preview.is-good,
+.lr-scan-strip {
+  border-color: var(--g-phosphor);
+}
+
+.lr-scan-preview i,
+.lr-scan-strip i {
+  color: var(--g-phosphor);
+}
+
+.lr-scan-report {
+  position: relative;
+}
+
+.lr-scan-report::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 90px;
+  height: 2px;
+  content: '';
+  background: var(--g-phosphor);
+}
+
+.lr-scan-report--trapped::before,
+.lr-scan-report--unrelayed::before,
+.lr-scan-report--blind::before {
+  background: var(--g-hazard);
+}
+
+.lr-report-head {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  margin-bottom: 14px;
+}
+
+.lr-report-head h3 {
+  margin: 3px 0 0;
+  color: var(--g-ink);
+  font: 600 1.35rem/1.1 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-report-seal {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  color: var(--g-phosphor);
+  background: var(--g-screen);
+  border: 1px solid var(--g-phosphor-dim);
+  font-size: 19px;
+}
+
+.lr-scan-report--trapped .lr-report-seal,
+.lr-scan-report--unrelayed .lr-report-seal,
+.lr-scan-report--blind .lr-report-seal {
+  color: var(--g-hazard);
+  border-color: var(--g-hazard);
+}
+
+.lr-report-narrative {
+  max-width: 70ch;
+  margin: 0 0 14px;
+  color: var(--g-ink-mid);
+  font-size: .98rem;
+  line-height: 1.6;
+}
+
+.lr-report-readouts {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin-bottom: 12px;
+  background: var(--g-seam);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-report-readouts > div {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  background: var(--g-hull-lo);
+}
+
+.lr-report-readouts strong {
+  color: var(--g-phosphor);
+  font: 600 11px/1.25 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-intel-card {
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  gap: 10px;
+  margin-top: 9px;
+  padding: 12px;
+  color: var(--g-ink-mid);
+  background: rgba(153, 33, 25, .12);
+  border: 1px solid rgba(228, 72, 60, .45);
+}
+
+.lr-intel-card > i {
+  color: var(--g-lamp-red);
+  font-size: 18px;
+}
+
+.lr-intel-card strong,
+.lr-intel-card p,
+.lr-intel-card small {
+  display: block;
+}
+
+.lr-intel-card strong {
+  margin: 4px 0;
+  color: var(--g-lamp-red);
+  font: 600 12px/1.2 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-intel-card p {
+  margin: 0 0 5px;
+}
+
+.lr-intel-card small {
+  color: var(--g-ink-low);
+  font: 500 8px/1.3 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-intel-card--trapped {
+  background: #2d291c;
+  border-color: var(--g-hazard);
+}
+
+.lr-intel-card--trapped > i,
+.lr-intel-card--trapped strong {
+  color: var(--g-hazard);
+}
+
+.lr-report-analysis {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.lr-report-analysis > div {
+  padding: 12px;
+  background: var(--g-hull-lo);
+  border-left: 3px solid var(--g-rule);
+}
+
+.lr-report-analysis > div:last-child {
+  border-color: var(--g-hazard);
+}
+
+.lr-report-analysis p {
+  margin: 6px 0 0;
+  color: var(--g-ink-mid);
+  font: 500 10px/1.5 var(--g-font-mono);
+}
+
+.lr-decision-brief {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 12px;
+  color: var(--g-ink-mid);
+  background: #2d291c;
+  border: 1px solid var(--g-hazard);
+}
+
+.lr-decision-brief > i {
+  color: var(--g-hazard);
+  font-size: 20px;
+}
+
+.lr-decision-destination {
+  display: block;
+  margin-top: 5px;
+  color: var(--g-ink);
+  font: 600 12px/1.35 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-decision-destination i {
+  margin: 0 7px;
+  color: var(--g-hazard);
+}
+
+.lr-decision-steps {
+  display: flex;
+  gap: 5px;
+  margin-top: 10px;
+}
+
+.lr-decision-steps b {
+  padding: 5px 8px;
+  color: var(--g-hazard);
+  background: rgba(217, 164, 16, .08);
+  border: 1px solid rgba(217, 164, 16, .24);
+  font: 600 8px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-action-row {
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+
+.lr-route-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.lr-route {
+  position: relative;
+  min-height: 210px;
+  padding: 17px;
+  color: var(--g-ink);
+  text-align: left;
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-seam);
+  border-radius: var(--g-radius);
+  box-shadow: var(--g-recess);
+}
+
+.lr-route:hover {
+  border-color: var(--g-brass-dark);
+}
+
+.lr-route--selected {
+  border-color: var(--g-hazard);
+  box-shadow: inset 0 0 0 1px var(--g-hazard), var(--g-recess);
+}
+
+.lr-route-select {
+  position: absolute;
+  top: 13px;
+  right: 13px;
+  color: var(--g-hazard);
+}
+
+.lr-route-title-row {
+  align-items: flex-start;
+  padding-right: 28px;
+}
+
+.lr-route h3 {
+  margin: 0;
+  font: 600 1.15rem/1.2 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-difficulty {
+  color: var(--g-hazard);
+  font: 600 10px/1.5 var(--g-font-mono);
+}
+
+.lr-route > p {
+  min-height: 42px;
+  margin: 8px 0 10px;
+  color: var(--g-ink-mid);
+  font-size: .86rem;
+  line-height: 1.45;
+}
+
+.lr-route-intent {
+  min-height: 43px;
+  padding: 8px 9px;
+  background: rgba(0, 0, 0, .18);
+  border-left: 2px solid var(--g-brass-dark);
+}
+
+.lr-hazard {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  gap: 7px;
+  margin-top: 10px;
+  padding: 8px;
+  color: var(--g-ink-low);
+  background: rgba(0, 0, 0, .2);
+  border: 1px dashed var(--g-rule);
+  font: 500 9px/1.35 var(--g-font-mono);
+}
+
+.lr-hazard i {
+  color: var(--g-ink-low);
+  font-size: 15px;
+}
+
+.lr-hazard strong,
+.lr-hazard span {
+  display: block;
+}
+
+.lr-hazard--revealed {
+  color: var(--g-ink-mid);
+  border-color: rgba(228, 72, 60, .4);
+}
+
+.lr-hazard--revealed i,
+.lr-hazard--revealed strong {
+  color: var(--g-lamp-red);
+}
+
+.lr-route-methods {
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--g-rule-faint);
+}
+
+.lr-route-methods > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 5px;
+}
+
+.lr-route-methods b {
+  padding: 4px 6px;
+  color: var(--g-phosphor-dim);
+  background: var(--g-screen);
+  border: 1px solid rgba(116, 255, 176, .18);
+  font: 600 8px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-route-cost {
+  justify-content: space-between;
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--g-rule-faint);
+}
+
+.lr-route-cost span {
+  color: var(--g-ink-low);
+  font: 500 9px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-route-cost i { color: var(--g-hazard); }
+
+.lr-assignment-board {
+  margin-top: 18px;
+  padding: 16px;
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-seam);
+  box-shadow: var(--g-recess);
+}
+
+.lr-assignment-board > .lr-crossing-equation {
+  margin-bottom: 9px;
+}
+
+.lr-crossing-equation--compact {
+  padding: 6px;
+}
+
+.lr-crossing-equation--compact > div:not(.lr-crossing-result) {
+  min-height: 40px;
+  padding: 5px;
+}
+
+.lr-crossing-equation--compact strong { font-size: 14px; }
+.lr-crossing-equation--compact small,
+.lr-crossing-equation--compact .lr-crossing-result span { font-size: 8px; }
+
+.lr-assignment-head {
+  margin-bottom: 12px;
+}
+
+.lr-assignment-head > div:first-child > span {
+  color: var(--g-ink-low);
+  font: 500 9px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-assignment-head > div:first-child {
+  display: grid;
+  gap: 4px;
+}
+
+.lr-assignment-mode {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.lr-assignment-mode > small {
+  color: var(--g-ink-low);
+  font: 500 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-assignment-guidance {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 10px;
+  padding: 9px 11px;
+  color: var(--g-hazard);
+  background: #2d291c;
+  border: 1px solid var(--g-hazard);
+  font: 600 10px/1.35 var(--g-font-mono);
+}
+
+.lr-assignment-guidance.is-ready {
+  color: var(--g-phosphor);
+  background: var(--g-screen);
+  border-color: var(--g-phosphor-dim);
+}
+
+.lr-role-picker {
+  display: grid;
+  grid-template-columns: .8fr 1.4fr .8fr;
+  gap: 1px;
+  background: var(--g-seam);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-role-picker > div {
+  min-height: 62px;
+  padding: 10px;
+  background: var(--g-hull);
+}
+
+.lr-role-picker > div.is-current,
+.lr-role-picker > div.is-current {
+  outline: 2px solid var(--g-hazard);
+  outline-offset: -2px;
+}
+
+.lr-role-picker span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--g-ink-low);
+  font: 500 8px/1 var(--g-font-mono);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.lr-role-picker strong {
+  color: var(--g-ink);
+  font: 600 1rem/1.2 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-support-select > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.lr-support-select > span b,
+.lr-methods-head .g-label b {
+  margin-left: 5px;
+  color: var(--g-hazard);
+  font: inherit;
+}
+
+.lr-support-select button {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 4px;
+  min-width: 118px;
+  padding: 7px 8px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+  font: 500 9px/1.1 var(--g-font-mono);
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.lr-support-select button:hover {
+  color: var(--g-ink);
+  border-color: var(--g-hazard);
+}
+
+.lr-support-select button:disabled {
+  cursor: not-allowed;
+  opacity: .4;
+}
+
+.lr-support-select button:disabled:hover {
+  color: var(--g-ink-mid);
+  border-color: var(--g-rule);
+}
+
+.lr-support-select button > span,
+.lr-support-select button strong,
+.lr-support-select button small {
+  display: block;
+  margin: 0;
+  font-family: var(--g-font-mono);
+}
+
+.lr-support-select button strong {
+  color: inherit;
+  font-size: 9px;
+}
+
+.lr-support-select button small {
+  margin-top: 3px;
+  color: var(--g-ink-low);
+  font-size: 7px;
+}
+
+.lr-support-select button.is-selected {
+  color: var(--g-ink-invert);
+  background: var(--g-hazard);
+  border-color: var(--g-hazard);
+}
+
+.lr-support-select button.is-selected small {
+  color: var(--g-ink-invert);
+}
+
+.lr-methods {
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid transparent;
+}
+
+.lr-methods.is-current {
+  border-color: var(--g-hazard);
+}
+
+.lr-methods-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 9px;
+}
+
+.lr-methods-head .g-label {
+  margin: 0;
+}
+
+.lr-methods-key {
+  display: flex;
+  gap: 11px;
+  color: var(--g-ink-low);
+  font: 600 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-methods-key span { display: flex; align-items: center; gap: 4px; }
+.lr-methods-key i { display: inline-block; width: 13px; height: 4px; background: var(--g-phosphor); }
+.lr-methods-key i.is-target { width: 2px; height: 11px; background: var(--g-hazard); }
+
+.lr-method-recommendation {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 9px;
+  margin-bottom: 8px;
+  padding: 9px 10px;
+  color: var(--g-ink-mid);
+  background: rgba(217, 164, 16, .09);
+  border-left: 3px solid var(--g-hazard);
+}
+
+.lr-method-recommendation > i {
+  color: var(--g-hazard);
+  font-size: 17px;
+}
+
+.lr-method-recommendation span,
+.lr-method-recommendation strong {
+  display: block;
+}
+
+.lr-method-recommendation span {
+  color: var(--g-hazard);
+  font: 600 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-method-recommendation strong {
+  margin: 3px 0;
+  color: var(--g-ink);
+  font: 600 10px/1.2 var(--g-font-mono);
+}
+
+.lr-signal-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.lr-signal-chips b,
+.lr-detail-flags span,
+.lr-outcome-flags span {
+  padding: 4px 6px;
+  color: var(--g-phosphor);
+  background: var(--g-screen);
+  border: 1px solid rgba(116, 255, 176, .18);
+  font: 600 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-signal-chips b.is-unknown { color: var(--g-hazard); border-color: rgba(217, 164, 16, .3); }
+
+.lr-method-option {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 34px;
+  width: 100%;
+  margin-top: 5px;
+  background: var(--g-hull);
+  border: 1px solid var(--g-rule);
+}
+
+.lr-method-select {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) minmax(78px, 110px);
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px;
+  color: var(--g-ink);
+  text-align: left;
+  background: transparent;
+  border: 0;
+}
+
+.lr-method-option:hover,
+.lr-method-option.is-selected {
+  border-color: var(--g-hazard);
+}
+
+.lr-method-select:disabled {
+  cursor: not-allowed;
+  opacity: .45;
+}
+
+.lr-method-option.is-selected {
+  background: #2d291c;
+}
+
+.lr-method-option.is-recommended {
+  box-shadow: inset 3px 0 0 var(--g-phosphor);
+}
+
+.lr-info-button {
+  display: grid;
+  min-width: 44px;
+  min-height: 44px;
+  place-items: center;
+  color: var(--g-ink-low);
+  background: var(--g-hull-lo);
+  border: 0;
+  border-left: 1px solid var(--g-rule);
+  font-size: 14px;
+}
+
+.lr-info-button:hover { color: var(--g-hazard); background: #2d291c; }
+
+.lr-method-icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  color: var(--g-hazard);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+}
+
+.lr-method-copy > strong,
+.lr-method-copy > small {
+  display: block;
+}
+
+.lr-method-copy strong {
+  font: 500 11px/1.3 var(--g-font-mono);
+}
+
+.lr-method-copy > small {
+  margin-top: 2px;
+  color: var(--g-ink-low);
+  font: 500 8px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-method-name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.lr-method-name em {
+  padding: 2px 4px;
+  color: var(--g-ink-invert);
+  background: var(--g-phosphor);
+  font: 700 6px/1 var(--g-font-mono);
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.lr-method-score {
+  display: grid;
+  justify-items: end;
+  gap: 3px;
+}
+
+.lr-method-score > small {
+  color: var(--g-ink-low);
+  font: 500 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-method-score b {
+  color: var(--g-phosphor);
+  font: 700 1.1rem/1 var(--g-font-mono);
+  text-align: right;
+}
+
+.lr-method-score em {
+  color: var(--g-ink-low);
+  font: 600 7px/1 var(--g-font-mono);
+  font-style: normal;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.lr-method-score em.is-clean { color: var(--g-phosphor); }
+.lr-method-score em.is-costly { color: var(--g-hazard); }
+.lr-method-score em.is-rough,
+.lr-method-score em.is-critical { color: var(--g-lamp-red); }
+
+.lr-forecast-bar-wrap { margin-top: 7px; }
+
+.lr-forecast-bar {
+  position: relative;
+  height: 5px;
+  overflow: visible;
+  background: var(--g-rule-faint);
+}
+
+.lr-forecast-bar > span {
+  display: block;
+  height: 100%;
+  background: var(--g-phosphor);
+}
+
+.lr-forecast-bar.is-costly > span { background: var(--g-hazard); }
+.lr-forecast-bar.is-rough > span,
+.lr-forecast-bar.is-critical > span { background: var(--g-lamp-red); }
+
+.lr-forecast-bar > i {
+  position: absolute;
+  top: -3px;
+  width: 2px;
+  height: 11px;
+  background: var(--g-hazard);
+  box-shadow: 0 0 0 1px var(--g-hull);
+}
+
+.lr-forecast-bar-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  color: var(--g-ink-low);
+  font: 600 6px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-commit-readout {
+  display: grid;
+  grid-template-columns: 1.4fr .6fr;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.lr-score-explained {
+  padding: 12px;
+  background: var(--g-hull);
+  border-left: 3px solid var(--g-hazard);
+}
+
+.lr-score-explained--clean { border-color: var(--g-phosphor); }
+.lr-score-explained--rough,
+.lr-score-explained--critical { border-color: var(--g-lamp-red); }
+
+.lr-outcome-summary {
+  padding: 12px;
+  background: var(--g-hull);
+  border-left: 3px solid var(--g-hazard);
+}
+
+.lr-outcome-summary--clean { border-color: var(--g-phosphor); }
+.lr-outcome-summary--rough,
+.lr-outcome-summary--critical { border-color: var(--g-lamp-red); }
+
+.lr-outcome-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 3px 10px;
+}
+
+.lr-outcome-head span {
+  grid-column: 1 / -1;
+  color: var(--g-ink-low);
+  font: 600 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-outcome-head strong {
+  color: var(--g-ink);
+  font: 600 12px/1.2 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-outcome-head b { color: var(--g-phosphor); font: 700 12px/1 var(--g-font-mono); }
+
+.lr-outcome-signals {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin-top: 10px;
+  background: var(--g-seam);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-outcome-signals > div {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 3px;
+  padding: 8px;
+  background: var(--g-hull-lo);
+}
+
+.lr-outcome-signals i { grid-row: 1 / 3; color: var(--g-phosphor); }
+.lr-outcome-signals span { color: var(--g-ink-low); font: 600 6px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-outcome-signals strong { color: var(--g-ink); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-outcome-signals .is-unknown i,
+.lr-outcome-signals .is-unknown strong { color: var(--g-hazard); }
+
+.lr-outcome-flags { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+.lr-outcome-flags span { color: var(--g-hazard); border-color: rgba(217, 164, 16, .3); }
+.lr-outcome-flags span.is-good { color: var(--g-phosphor); border-color: rgba(116, 255, 176, .18); }
+
+.lr-calculation-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  margin-top: 9px;
+  padding: 0;
+  color: var(--g-ink-low);
+  background: transparent;
+  border: 0;
+  font: 600 8px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-calculation-link:hover { color: var(--g-hazard); }
+
+.lr-score-equation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 5px;
+  padding: 9px;
+  background: var(--g-screen);
+  border: 1px solid var(--g-phosphor-dim);
+}
+
+.lr-score-equation span {
+  display: grid;
+  gap: 3px;
+  text-align: center;
+}
+
+.lr-score-equation small {
+  color: var(--g-phosphor-dim);
+  font: 500 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-score-equation b {
+  color: var(--g-phosphor);
+  font: 700 15px/1 var(--g-font-mono);
+}
+
+.lr-score-equation i {
+  color: var(--g-phosphor-dim);
+  font: 500 9px/1 var(--g-font-mono);
+  font-style: normal;
+}
+
+.lr-score-verdict {
+  margin-top: 9px;
+}
+
+.lr-score-verdict span {
+  color: var(--g-ink-low);
+  font: 600 7px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-score-verdict strong {
+  display: block;
+  margin: 4px 0;
+  color: var(--g-ink);
+  font: 600 11px/1.3 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-score-verdict p,
+.lr-score-legend p {
+  margin: 0;
+  color: var(--g-ink-mid);
+  font: 500 9px/1.45 var(--g-font-mono);
+}
+
+.lr-score-legend {
+  display: grid;
+  gap: 5px;
+  margin-top: 9px;
+  padding-top: 8px;
+  border-top: 1px solid var(--g-rule-faint);
+}
+
+.lr-score-legend b { color: var(--g-hazard); }
+
+.lr-forecast-limits {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 6px;
+  margin-top: 9px;
+  padding: 8px;
+  color: var(--g-ink-low);
+  background: var(--g-hull-lo);
+  font: 500 8px/1.4 var(--g-font-mono);
+}
+
+.lr-forecast-limits i { color: var(--g-hazard); }
+
+.lr-score-screen {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  min-height: 82px;
+  padding: 12px;
+  color: var(--g-phosphor-dim);
+  font: 600 10px/1.3 var(--g-font-mono);
+}
+
+.lr-score-screen i {
+  color: var(--g-phosphor-dim);
+  font-style: normal;
+}
+
+.lr-score-screen strong {
+  color: var(--g-phosphor);
+}
+
+.lr-reaction {
+  padding: 10px 12px;
+  background: var(--g-hull);
+  border-left: 3px solid var(--g-lamp-red);
+}
+
+.lr-reaction.is-match {
+  border-color: var(--g-phosphor);
+}
+
+.lr-reaction span,
+.lr-reaction strong,
+.lr-reaction em {
+  display: block;
+}
+
+.lr-reaction span {
+  color: var(--g-ink-low);
+  font: 500 8px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-reaction strong {
+  margin: 4px 0;
+  color: var(--g-ink-mid);
+  font: 500 10px/1.3 var(--g-font-mono);
+}
+
+.lr-reaction em {
+  color: var(--g-ink-low);
+  font: 500 9px/1.3 var(--g-font-mono);
+}
+
+.lr-guided-tip {
+  margin: 8px 0 0;
+  padding: 7px;
+  color: var(--g-hazard);
+  background: rgba(217, 164, 16, .08);
+  font: 500 8px/1.4 var(--g-font-mono);
+}
+
+.lr-command-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 7px;
+  color: var(--g-hazard);
+  font: 600 9px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-command-toggle input {
+  accent-color: var(--g-hazard);
+}
+
+.lr-modal-backdrop {
+  position: fixed;
+  z-index: 10000;
+  inset: 0;
+  display: grid;
+  padding: 24px;
+  place-items: center;
+  background: rgba(5, 6, 5, .82);
+  backdrop-filter: blur(4px);
+}
+
+.lr-detail-modal {
+  position: relative;
+  width: min(640px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  padding: 26px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull);
+  border: 1px solid var(--g-hazard);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, .65), inset 0 0 0 5px var(--g-hull-lo);
+}
+
+.lr-detail-modal h2 {
+  margin: 5px 40px 14px 0;
+  color: var(--g-ink);
+  font: 600 1.45rem/1.15 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  color: var(--g-ink-low);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+}
+
+.lr-modal-close:hover { color: var(--g-hazard); border-color: var(--g-hazard); }
+
+.lr-detail-equation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px;
+  background: var(--g-screen);
+  border: 1px solid var(--g-phosphor-dim);
+}
+
+.lr-detail-equation span { display: grid; gap: 4px; text-align: center; }
+.lr-detail-equation small { color: var(--g-phosphor-dim); font: 600 7px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-detail-equation b { color: var(--g-phosphor); font: 700 18px/1 var(--g-font-mono); }
+.lr-detail-equation i { color: var(--g-phosphor-dim); font: 600 9px/1 var(--g-font-mono); font-style: normal; }
+
+.lr-detail-section {
+  margin-top: 14px;
+  padding: 12px;
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-rule);
+}
+
+.lr-detail-heading,
+.lr-detail-input > div:first-child {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.lr-detail-heading { color: var(--g-ink-low); font: 600 8px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-detail-heading strong { color: var(--g-hazard); font-size: 15px; }
+
+.lr-detail-input { margin-top: 10px; }
+.lr-detail-input span { color: var(--g-ink-mid); font: 600 9px/1 var(--g-font-mono); }
+.lr-detail-input small { margin-left: auto; color: var(--g-ink-low); font: 500 7px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-detail-input b { width: 26px; color: var(--g-ink); font: 700 10px/1 var(--g-font-mono); text-align: right; }
+.lr-detail-input > div:last-child { height: 4px; margin-top: 5px; background: var(--g-rule-faint); }
+.lr-detail-input > div:last-child span { display: block; height: 100%; background: var(--g-phosphor); }
+
+.lr-detail-notes {
+  display: grid;
+  gap: 7px;
+  margin: 14px 0;
+  padding-left: 18px;
+  color: var(--g-ink-mid);
+  font: 500 9px/1.45 var(--g-font-mono);
+}
+
+.lr-detail-notes strong { color: var(--g-hazard); }
+.lr-mechanics-survival { display: grid; gap: 7px; margin: 15px 0 18px; }
+.lr-mechanics-survival > div { display: grid; grid-template-columns: 28px 1fr; gap: 10px; padding: 11px; color: var(--g-ink-mid); background: var(--g-hull-lo); border-left: 3px solid var(--g-hazard); font-size: .85rem; line-height: 1.45; }
+.lr-mechanics-survival i { color: var(--g-hazard); font-size: 1.1rem; }
+.lr-mechanics-survival span { display: grid; gap: 3px; }
+.lr-mechanics-survival strong { color: var(--g-ink); font: 600 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-detail-flags { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 18px; }
+.lr-detail-flags span.is-clean { color: var(--g-phosphor); }
+.lr-detail-flags span.is-rough,
+.lr-detail-flags span.is-critical { color: var(--g-lamp-red); border-color: rgba(228, 72, 60, .3); }
+
+.lr-log-screen {
+  min-height: 330px;
+  max-height: 430px;
+  overflow: auto;
+  padding: 13px;
+}
+
+.lr-log-screen > div {
+  margin-bottom: 13px;
+  padding-bottom: 11px;
+  border-bottom: 1px solid rgba(116, 255, 176, .1);
+}
+
+.lr-log-screen span {
+  color: var(--g-phosphor);
+  font: 600 8px/1 var(--g-font-mono);
+}
+
+.lr-log-screen p {
+  margin: 5px 0 0;
+  color: var(--g-phosphor-dim);
+  font: 500 9px/1.45 var(--g-font-mono);
+}
+
+.lr-rules-note {
+  margin-top: 16px;
+}
+
+.lr-rules-note ul {
+  margin: 8px 0 0;
+  padding-left: 17px;
+  color: var(--g-ink-low);
+  font: 500 11px/1.6 var(--g-font-mono);
+}
+
+.lr-simple-decision { padding-top: 22px; border-top: 1px solid var(--g-rule); animation: lr-stage-enter .5s cubic-bezier(.2,.8,.2,1) both; }
+
+.lr-simple-status {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr 1fr;
+  gap: 7px;
+  margin: 10px 0 16px;
+}
+
+.lr-simple-status > div {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-height: 78px;
+  padding: 14px 16px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-simple-status > div > span { color: var(--g-ink-low); font: 700 10px/1 var(--g-font-mono); letter-spacing: .05em; text-transform: uppercase; }
+.lr-simple-status > div > strong { color: var(--g-ink); font: 600 13px/1.25 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-status > div > small { color: var(--g-ink-low); font: 500 11px/1.35 var(--g-font-mono); }
+.lr-simple-status-crew { grid-template-columns: 1fr; }
+.lr-simple-status-crew > div { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+.lr-simple-status-crew > div > span { position: relative; display: grid; gap: 4px; }
+.lr-simple-status-crew b { color: var(--g-ink); font: 600 12px/1.15 var(--g-font-mono); }
+.lr-simple-status-crew em { color: var(--g-ink-low); font: 500 10px/1.2 var(--g-font-mono); font-style: normal; text-transform: uppercase; }
+.lr-simple-status-crew .is-worn em,
+.lr-simple-status-crew .is-critical em { color: var(--g-hazard); }
+.lr-simple-status-crew .is-spent em { color: var(--g-lamp-red); }
+.lr-simple-status-crew .is-worn .lr-projection-track > i.is-current,
+.lr-simple-status-crew .is-critical .lr-projection-track > i.is-current { background: var(--g-hazard); border-color: #ffe478; }
+.lr-simple-status-crew .is-spent .lr-projection-track > i.is-current,
+.lr-simple-status-clock.is-imminent .lr-projection-track > i.is-current { background: var(--g-lamp-red); border-color: #ff8b82; }
+.lr-simple-status-clock.is-failing,
+.lr-simple-status-clock.is-imminent,
+.lr-simple-status-clock.is-collapse { border-color: var(--g-lamp-red); }
+.lr-simple-status-objective.is-secured,
+.lr-simple-status-companion { border-color: rgba(116, 255, 176, .45); }
+.lr-simple-status-companion { grid-column: 1 / -1; }
+.lr-simple-status .is-changing { animation: lr-status-impact 1.4s ease-out; }
+.lr-simple-status-clock { position: relative; }
+.lr-status-delta { position: absolute; z-index: 2; top: -7px; right: -5px; padding: 4px 6px; color: var(--g-ink-invert) !important; background: var(--g-hazard); box-shadow: 0 0 0 4px rgba(217,164,16,.12); font: 800 9px/1 var(--g-font-mono) !important; text-transform: uppercase; animation: lr-delta-pop 1.6s ease-out both; }
+.lr-simple-status-clock > .lr-status-delta { top: 7px; right: 8px; }
+
+.lr-threshold-track {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 7px;
+  overflow: hidden;
+  background: var(--g-seam);
+  border: 1px solid rgba(255, 255, 255, .05);
+}
+.lr-threshold-track > i { position: absolute; inset: 0 auto 0 0; background: var(--g-phosphor); transition: width .25s ease; }
+.lr-threshold-track.is-danger > i { background: var(--g-lamp-red); }
+.lr-threshold-track > b { position: absolute; top: 0; bottom: 0; width: 1px; padding: 0; background: rgba(255, 255, 255, .42); }
+.lr-threshold-track.is-annex .at-warning { left: 30%; }
+.lr-threshold-track.is-annex .at-danger { left: 60%; }
+.lr-threshold-track.is-annex .at-critical { left: 90%; }
+.lr-threshold-track.is-strain .at-warning { left: 50%; }
+.lr-threshold-track.is-strain .at-danger { left: 83.333%; }
+.lr-threshold-track.is-strain .at-critical { left: calc(100% - 1px); }
+
+.lr-current-action {
+  display: grid;
+  grid-template-columns: 46px 1fr auto;
+  align-items: center;
+  gap: 13px;
+  margin: 0 0 20px;
+  padding: 13px 15px;
+  color: var(--g-ink-mid);
+  background: #2d291c;
+  border: 1px solid var(--g-hazard);
+  border-left-width: 5px;
+  box-shadow: var(--g-recess);
+  scroll-margin-top: 82px;
+}
+.lr-current-action > i { display: grid; width: 42px; height: 42px; place-items: center; color: var(--g-hazard); background: var(--g-hull); font-size: 18px; }
+.lr-current-action > div { display: grid; gap: 4px; }
+.lr-current-action span { color: var(--g-hazard); font: 700 9px/1 var(--g-font-mono); letter-spacing: .05em; text-transform: uppercase; }
+.lr-current-action strong { color: var(--g-ink); font: 600 14px/1.25 var(--g-font-mono); text-transform: uppercase; }
+.lr-current-action small { color: var(--g-ink-mid); font-size: .9rem; line-height: 1.35; }
+.lr-current-action > button { min-height: 44px; padding: 8px 10px; color: var(--g-ink-mid); background: transparent; border: 1px solid var(--g-rule); font: 600 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-current-action > button:hover { color: var(--g-ink); border-color: var(--g-phosphor); }
+.lr-current-action.is-resolved { background: rgba(116, 255, 176, .06); border-color: var(--g-phosphor); }
+.lr-current-action.is-resolved > i,
+.lr-current-action.is-resolved span { color: var(--g-phosphor); }
+.lr-current-action { animation: lr-guide-next .7s cubic-bezier(.2,.8,.2,1) both; }
+
+.lr-action-feedback { display: grid; grid-template-columns: 38px 1fr; gap: 11px; align-items: center; margin: -9px 0 20px; padding: 11px 13px; background: rgba(217,164,16,.07); border: 1px solid rgba(217,164,16,.34); border-left: 4px solid var(--g-hazard); animation: lr-feedback-enter .45s ease-out both; }
+.lr-action-feedback > i { display: grid; width: 34px; height: 34px; place-items: center; color: var(--g-hazard); background: var(--g-hull); animation: lr-feedback-beacon 1s ease-in-out 2; }
+.lr-action-feedback > div { display: grid; gap: 6px; }
+.lr-action-feedback > div > span { color: var(--g-hazard); font: 700 9px/1 var(--g-font-mono); letter-spacing: .05em; text-transform: uppercase; }
+.lr-action-feedback > div > div { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+.lr-action-feedback b { padding: 6px 8px; background: var(--g-hull); font: 700 10px/1.2 var(--g-font-mono); text-transform: uppercase; animation: lr-chip-enter .45s ease-out both; }
+.lr-action-feedback b:nth-child(2) { animation-delay: .1s; }
+.lr-action-feedback b:nth-child(3) { animation-delay: .2s; }
+.lr-action-feedback b.is-energy { color: #72d8ff; }
+.lr-action-feedback b.is-stability { color: var(--g-phosphor); }
+.lr-action-feedback b.is-salvage { color: var(--g-hazard); }
+
+.lr-transition-beat {
+  display: grid;
+  gap: 18px;
+  max-width: 820px;
+  margin: 18px auto 0;
+  padding: clamp(22px, 4vw, 38px);
+  color: var(--g-ink-mid);
+  background: linear-gradient(145deg, rgba(116, 255, 176, .08), rgba(12, 14, 12, .92) 48%);
+  border: 1px solid var(--g-phosphor);
+  box-shadow: inset 4px 0 0 var(--g-phosphor), 0 16px 36px rgba(0, 0, 0, .28);
+  animation: lr-stage-enter .55s cubic-bezier(.2,.8,.2,1) both;
+}
+.lr-transition-route { display: flex; align-items: center; gap: 12px; color: var(--g-ink-low); font: 700 10px/1.3 var(--g-font-mono); letter-spacing: .05em; text-transform: uppercase; }
+.lr-transition-route i { color: var(--g-phosphor); }
+.lr-transition-route strong { color: var(--g-ink); }
+.lr-transition-beat > p { margin: 0; color: var(--g-ink); font: 500 clamp(1.1rem, 2vw, 1.35rem)/1.6 var(--g-font-body); }
+.lr-transition-beat blockquote { display: flex; gap: 10px; margin: 0; padding: 13px 15px; color: var(--g-ink-mid); background: rgba(255,255,255,.025); border-left: 2px solid var(--g-rule); font-style: italic; }
+.lr-transition-beat blockquote i { color: var(--g-hazard); }
+.lr-transition-beat > button { justify-self: end; min-height: 50px; }
+.lr-memory-card,
+.lr-consequence-preview { display: grid; grid-template-columns: 40px 1fr; gap: 13px; align-items: start; padding: 15px; background: rgba(116, 255, 176, .07); border: 1px solid rgba(116, 255, 176, .35); }
+.lr-memory-card > i,
+.lr-consequence-preview > i { display: grid; width: 38px; height: 38px; place-items: center; color: var(--g-phosphor); background: var(--g-hull); font-size: 17px; }
+.lr-memory-card div,
+.lr-consequence-preview div { display: grid; gap: 4px; }
+.lr-memory-card span,
+.lr-consequence-preview span,
+.lr-memory-effects > span { color: var(--g-phosphor); font: 700 9px/1 var(--g-font-mono); letter-spacing: .05em; text-transform: uppercase; }
+.lr-memory-card strong,
+.lr-consequence-preview strong { color: var(--g-ink); font: 700 13px/1.3 var(--g-font-mono); text-transform: uppercase; }
+.lr-memory-card p,
+.lr-consequence-preview p { margin: 0; font-size: .94rem; line-height: 1.45; }
+.lr-memory-effects { display: grid; gap: 7px; }
+.lr-memory-effects > div { display: grid; grid-template-columns: 1fr auto; gap: 4px 12px; padding: 11px 13px; background: var(--g-hull); border-left: 3px solid var(--g-hazard); }
+.lr-memory-effects strong { color: var(--g-ink); font: 600 12px/1.3 var(--g-font-mono); }
+.lr-memory-effects b { color: var(--g-hazard); font: 700 10px/1.3 var(--g-font-mono); text-transform: uppercase; }
+.lr-memory-effects small { grid-column: 1 / -1; font-size: .86rem; line-height: 1.4; }
+.lr-route-memory { display: flex; align-items: center; gap: 5px; margin-top: 10px; padding: 9px 10px; color: var(--g-phosphor); background: rgba(116, 255, 176, .07); border-left: 3px solid var(--g-phosphor); font: 600 11px/1.4 var(--g-font-mono); }
+.lr-route-memory b { color: var(--g-ink); }
+.lr-creature-reaction { display: flex; gap: 9px; margin: 0; padding: 11px 13px; color: var(--g-ink-mid); background: rgba(255,255,255,.025); border-left: 2px solid var(--g-rule); font-style: italic; line-height: 1.45; }
+.lr-creature-reaction i { color: var(--g-hazard); }
+.lr-consequence-preview { margin-top: 12px; }
+.lr-simple-question { max-width: 760px; margin-bottom: 24px; scroll-margin-top: 82px; }
+.lr-simple-question > span,
+.lr-simple-report-result span,
+.lr-simple-plan-head span,
+.lr-simple-result-head span { color: var(--g-hazard); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-question h3,
+.lr-simple-report-result h3,
+.lr-simple-plan-head h3,
+.lr-simple-result-head h3 { margin: 7px 0; color: var(--g-ink); font: 600 1.75rem/1.15 var(--g-font-stencil); text-transform: uppercase; }
+.lr-simple-question p { margin: 0; color: var(--g-ink-mid); font-size: 1.05rem; line-height: 1.55; }
+.lr-projection-legend { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin: -10px 0 16px; color: var(--g-ink-low); font: 600 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-projection-legend > span { display: flex; align-items: center; gap: 6px; }
+.lr-projection-legend i { width: 18px; height: 8px; background: #287d9e; border: 1px solid #72d8ff; border-radius: 2px; }
+.lr-projection-legend i.is-fading { background: repeating-linear-gradient(135deg, #287d9e 0 3px, rgba(40,125,158,.25) 3px 6px); opacity: .5; animation: lr-resource-loss 1.2s ease-in-out infinite alternate; }
+.lr-projection-legend i.is-empty { background: var(--g-seam); border-color: rgba(255,255,255,.05); }
+
+.lr-simple-scouts { display: grid; grid-template-columns: 1fr; gap: 9px; }
+.lr-simple-scouts > button { display: grid; grid-template-columns: 150px minmax(0, 1fr); min-width: 0; min-height: 156px; padding: 0; overflow: hidden; color: var(--g-ink); text-align: left; background: var(--g-hull-lo); border: 1px solid var(--g-seam); }
+.lr-simple-scouts > button:hover,
+.lr-simple-scouts > button.is-recommended { border-color: var(--g-phosphor); box-shadow: inset 4px 0 0 var(--g-phosphor); }
+@media (hover: hover) {
+  .lr-simple-scouts > button,
+  .lr-route-choice-main,
+  .lr-encounter-options > button { transition: transform .15s ease, border-color .15s ease, background-color .15s ease, box-shadow .15s ease; }
+  .lr-simple-scouts > button:hover,
+  .lr-route-choice-main:hover,
+  .lr-encounter-options > button:hover { z-index: 1; transform: translateY(-3px); background: #23241d; box-shadow: 0 10px 20px rgba(0, 0, 0, .25); }
+  .lr-simple-scouts > button:hover { transform: translateX(3px); }
+}
+.lr-simple-scouts .lr-portrait { min-height: 156px; border-right: 1px solid var(--g-seam); border-bottom: 0; }
+.lr-simple-scouts > button > .lr-scout-card-copy { display: grid; min-width: 0; grid-template-columns: minmax(205px, .82fr) minmax(520px, 2.2fr) 84px; align-items: stretch; }
+.lr-scout-card-copy > span { display: grid; min-width: 0; align-content: center; padding: 15px 16px; border-left: 1px solid var(--g-seam); }
+.lr-scout-card-head { gap: 7px; background: rgba(255, 255, 255, .018); }
+.lr-scout-card-head > em { width: fit-content; padding: 5px 7px; color: var(--g-ink-invert); background: var(--g-phosphor); font: 700 9px/1 var(--g-font-mono); font-style: normal; text-transform: uppercase; }
+.lr-scout-card-head > strong { font: 600 1.25rem/1 var(--g-font-stencil); text-transform: uppercase; }
+.lr-scout-card-head > small { color: var(--g-ink-low); font: 600 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-scout-forecast { gap: 7px; background: rgba(255, 255, 255, .018); }
+.lr-scout-forecast > small,
+.lr-scout-relay > small,
+.lr-scout-impact > small { color: var(--g-ink-low); font: 700 9px/1 var(--g-font-mono); letter-spacing: .04em; text-transform: uppercase; }
+.lr-scout-forecast > strong { color: var(--g-hazard); font: 700 11px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-scout-forecast .lr-scout-contact { padding-top: 9px; border-top: 1px solid var(--g-seam); }
+.lr-scout-contact { display: grid; grid-template-columns: 20px 1fr; gap: 7px; align-content: center; }
+.lr-scout-contact small { color: var(--g-ink-low); font: 700 8px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-scout-contact strong { color: var(--g-ink); font: 700 9px/1.25 var(--g-font-mono); }
+.lr-scout-relay { gap: 9px; }
+.lr-scout-storyline { display: grid; grid-template-columns: minmax(160px, 1fr) 12px minmax(145px, .9fr) 12px minmax(190px, 1.15fr); gap: 5px; align-items: stretch; }
+.lr-scout-storyline > i { align-self: center; color: var(--g-seam-hi); font-size: 10px; }
+.lr-scout-story-step { display: grid; min-width: 0; grid-template-columns: 27px 1fr; gap: 7px; align-content: center; padding: 9px 10px; background: var(--g-hull); border-top: 2px solid var(--g-seam-hi); }
+.lr-scout-story-step > i { grid-row: 1 / 3; color: var(--g-hazard); font-size: 18px; }
+.lr-scout-story-step > span > small { display: block; color: var(--g-ink-low); font: 700 8px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-scout-story-step > span > b { display: block; margin-top: 5px; color: var(--g-ink); font: 700 9px/1.15 var(--g-font-mono); text-transform: uppercase; }
+.lr-scout-story-step > .lr-signal-gauge,
+.lr-scout-story-step > em,
+.lr-scout-story-step > .lr-return-cost { grid-column: 1 / -1; }
+.lr-scout-story-step > .lr-signal-gauge { margin-top: 2px; }
+.lr-scout-story-step > em,
+.lr-return-cost > em { display: flex; width: fit-content; align-items: center; gap: 4px; padding: 4px 6px; background: transparent; font: 700 8px/1 var(--g-font-mono); font-style: normal; text-transform: uppercase; }
+.lr-scout-story-step > em.is-energy,
+.lr-return-cost > em.is-energy { color: #72d8ff; border: 1px solid rgba(114, 216, 255, .28); }
+.lr-scout-story-step > em.is-safe { color: var(--g-phosphor); border: 1px solid rgba(116, 255, 161, .24); }
+.lr-return-cost { display: flex; gap: 5px; flex-wrap: wrap; }
+.lr-return-cost > em.is-stability { color: var(--g-phosphor); border: 1px solid rgba(116, 255, 161, .24); }
+.lr-scout-relay.is-good .lr-scout-story-step.is-communication,
+.lr-scout-relay.is-good .lr-scout-story-step.is-followup { border-color: var(--g-phosphor); }
+.lr-scout-relay.is-good .lr-scout-story-step.is-communication > i,
+.lr-scout-relay.is-good .lr-scout-story-step.is-followup > i { color: var(--g-phosphor); }
+.lr-signal-gauge { display: grid; grid-template-columns: repeat(5, 1fr); gap: 5px; }
+.lr-signal-gauge > i { display: grid; height: 18px; place-items: center; color: var(--g-ink-low); font-size: 14px; opacity: .35; }
+.lr-signal-gauge > i.is-filled { color: var(--g-hazard); opacity: 1; text-shadow: 0 0 8px rgba(217, 164, 16, .35); }
+.lr-scout-action { display: flex; align-items: center; justify-content: center; gap: 7px; color: var(--g-hazard); background: rgba(224, 177, 0, .045); border-left: 1px solid var(--g-seam); font: 700 10px/1 var(--g-font-mono); letter-spacing: .03em; text-transform: uppercase; }
+.lr-simple-scouts > button:hover .lr-scout-action { color: var(--g-ink-invert); background: var(--g-hazard); }
+
+.lr-field-sign {
+  display: flex;
+  gap: 12px;
+  margin: 0 0 13px;
+  padding: 12px;
+  background: rgba(224, 177, 0, .08);
+  border-left: 3px solid var(--g-hazard);
+}
+.lr-field-sign > i { color: var(--g-hazard); font-size: 1.15rem; }
+.lr-field-sign span { color: var(--g-hazard); font: 700 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-field-sign strong { display: block; margin-top: 5px; color: var(--g-ink); font: 600 13px/1.25 var(--g-font-mono); }
+.lr-field-sign p { margin: 6px 0 0; color: var(--g-ink-mid); font-size: .95rem; line-height: 1.45; }
+
+.lr-simple-secondary { padding: 12px 0; color: var(--g-ink-low); background: transparent; border: 0; border-bottom: 1px solid var(--g-rule); font: 600 11px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-secondary:hover { color: var(--g-hazard); border-color: var(--g-hazard); }
+.lr-simple-decision > .lr-simple-secondary { margin-top: 16px; }
+.lr-skip-scout { display: grid; grid-template-columns: 28px auto 1fr auto; align-items: center; gap: 12px; width: 100%; margin-top: 12px; padding: 15px 17px; text-align: left; background: var(--g-hull-lo); border: 1px solid var(--g-seam); }
+.lr-skip-scout > i { color: var(--g-hazard); font-size: 18px; }
+.lr-skip-scout span { color: var(--g-ink-mid); text-transform: none; }
+.lr-skip-scout strong { color: var(--g-ink); font-size: 13px; }
+.lr-skip-scout b { color: var(--g-hazard); font: 700 10px/1 var(--g-font-mono); white-space: nowrap; }
+.lr-skip-scout-signals { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+.lr-skip-scout-signals em { display: inline-flex; align-items: center; gap: 5px; padding: 6px 8px; color: var(--g-ink-mid); background: var(--g-hull); font: 600 9px/1.2 var(--g-font-mono); font-style: normal; text-transform: uppercase; }
+.lr-skip-scout-signals em:first-child { color: var(--g-phosphor); }
+.lr-skip-scout:hover { color: var(--g-hazard); background: #23241d; border-color: var(--g-hazard); }
+
+.lr-field-encounter {
+  margin-top: 20px;
+  padding: 20px;
+  background: var(--g-hull-lo);
+  border: 1px solid var(--g-hazard);
+  box-shadow: inset 4px 0 0 var(--g-hazard);
+}
+.lr-field-encounter.is-resolved { border-color: var(--g-phosphor); box-shadow: inset 4px 0 0 var(--g-phosphor); }
+.lr-field-encounter.is-resolved { animation: lr-stage-resolve .65s ease-out both; }
+.lr-encounter-heading { display: grid; grid-template-columns: 100px 1fr; gap: 14px; align-items: center; }
+.lr-encounter-heading .lr-portrait { min-height: 100px; }
+.lr-encounter-heading span,
+.lr-encounter-result-head span { color: var(--g-hazard); font: 700 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-encounter-heading h3,
+.lr-encounter-result-head h3 { margin: 5px 0; color: var(--g-ink); font: 600 1.4rem/1.1 var(--g-font-stencil); text-transform: uppercase; }
+.lr-encounter-heading p { margin: 0; color: var(--g-ink-mid); line-height: 1.5; }
+.lr-encounter-posture { display: grid; gap: 5px; margin-top: 12px; padding: 11px; background: var(--g-hull); border-left: 3px solid var(--g-hazard); }
+.lr-encounter-posture.is-scout-first { border-color: var(--g-phosphor); }
+.lr-encounter-posture.is-native-first { border-color: var(--g-lamp-red); }
+.lr-encounter-posture strong { color: var(--g-ink); font: 600 12px/1.25 var(--g-font-mono); text-transform: uppercase; }
+.lr-encounter-posture span,
+.lr-encounter-posture small { color: var(--g-ink-mid); font-size: .92rem; line-height: 1.45; }
+.lr-encounter-options { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-top: 12px; }
+.lr-encounter-options > button { display: grid; align-content: start; gap: 9px; padding: 17px; color: var(--g-ink); text-align: left; background: var(--g-hull); border: 1px solid var(--g-seam); }
+.lr-encounter-options > button:hover,
+.lr-encounter-options > button.is-recommended { border-color: var(--g-phosphor); }
+.lr-encounter-options > button > span { color: var(--g-hazard); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-encounter-options > button > strong { font: 600 13px/1.3 var(--g-font-mono); text-transform: uppercase; }
+.lr-encounter-options > button > p { margin: 0; color: var(--g-ink-mid); font-size: .92rem; line-height: 1.45; }
+.lr-encounter-options > button > .lr-encounter-choice-signals { display: grid; gap: 7px; margin-top: 3px; }
+.lr-encounter-choice-signals .lr-route-projection { padding: 10px; background: var(--g-hull-lo); }
+.lr-encounter-companion { display: grid; grid-template-columns: 20px 1fr; gap: 7px; padding: 10px; color: var(--g-phosphor); background: rgba(116, 255, 176, .06); }
+.lr-encounter-companion small { display: block; color: var(--g-ink-low); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-encounter-companion strong { display: block; margin-top: 5px; color: var(--g-phosphor); font: 700 10px/1.3 var(--g-font-mono); text-transform: uppercase; }
+.lr-encounter-result-head { display: flex; align-items: center; gap: 12px; }
+.lr-encounter-result-head > i { display: grid; width: 48px; height: 48px; place-items: center; color: var(--g-phosphor); background: var(--g-screen); font-size: 20px; }
+.lr-encounter-impact { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; margin-bottom: 16px; }
+.lr-encounter-impact > span { display: grid; gap: 5px; padding: 12px; color: var(--g-ink-mid); background: var(--g-hull); font: 500 11px/1.4 var(--g-font-mono); }
+.lr-encounter-impact i { color: var(--g-hazard); }
+.lr-encounter-impact .is-good i,
+.lr-encounter-impact .is-good strong { color: var(--g-phosphor); }
+
+.lr-simple-report { max-width: 800px; margin-inline: auto; }
+.lr-simple-report-result,
+.lr-simple-result-head,
+.lr-simple-plan-head { display: flex; align-items: center; gap: 13px; }
+.lr-simple-report-result > i,
+.lr-simple-result-head > i,
+.lr-simple-plan-head > i { display: grid; width: 48px; height: 48px; place-items: center; color: var(--g-phosphor); background: var(--g-screen); border: 1px solid rgba(116, 255, 176, .2); font-size: 20px; }
+.lr-simple-story { margin: 18px 0; color: var(--g-ink); font-size: 1.05rem; line-height: 1.65; }
+.lr-simple-finding { display: grid; gap: 8px; padding: 16px; background: #2d291c; border-left: 4px solid var(--g-hazard); }
+.lr-simple-finding > span { color: var(--g-hazard); font: 700 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-finding > strong { color: var(--g-ink); font: 600 1rem/1.25 var(--g-font-mono); }
+.lr-simple-finding > strong i { color: var(--g-lamp-red); }
+.lr-simple-finding p { margin: 2px 0 0; color: var(--g-ink-mid); line-height: 1.5; }
+.lr-simple-report > .g-btn { margin-top: 18px; }
+.lr-simple-report > *,
+.lr-simple-result > * { animation: lr-story-step .42s ease-out both; }
+.lr-simple-report > :nth-child(2),
+.lr-simple-result > :nth-child(2) { animation-delay: .09s; }
+.lr-simple-report > :nth-child(3),
+.lr-simple-result > :nth-child(3) { animation-delay: .18s; }
+.lr-simple-report > :nth-child(4),
+.lr-simple-result > :nth-child(4) { animation-delay: .27s; }
+.lr-simple-report > :nth-child(n+5),
+.lr-simple-result > :nth-child(n+5) { animation-delay: .36s; }
+.lr-simple-report > .g-btn--primary,
+.lr-simple-result .lr-result-actions .g-btn--primary,
+.lr-transition-beat > .g-btn--primary,
+.lr-field-encounter.is-resolved > .g-btn--primary { animation: lr-next-action 1.1s ease-in-out .75s 2; }
+
+.lr-route-guidance { display: grid; grid-template-columns: 42px 1fr; gap: 12px; align-items: start; margin-bottom: 13px; padding: 14px 16px; color: var(--g-ink-mid); background: var(--g-hull-lo); border-left: 4px solid var(--g-hazard); }
+.lr-route-guidance > i { display: grid; width: 38px; height: 38px; place-items: center; color: var(--g-hazard); background: var(--g-hull); font-size: 17px; }
+.lr-route-guidance > div { display: grid; gap: 4px; }
+.lr-route-guidance span { color: var(--g-hazard); font: 700 9px/1 var(--g-font-mono); letter-spacing: .05em; text-transform: uppercase; }
+.lr-route-guidance strong { color: var(--g-ink); font: 600 14px/1.25 var(--g-font-mono); text-transform: uppercase; }
+.lr-route-guidance p { margin: 0; font-size: .92rem; line-height: 1.45; }
+.lr-route-guidance.has-recommendation { background: rgba(116, 255, 176, .06); border-color: var(--g-phosphor); }
+.lr-route-guidance.has-recommendation > i,
+.lr-route-guidance.has-recommendation span { color: var(--g-phosphor); }
+.lr-salvage-explainer { display: grid; grid-template-columns: 34px 1fr; gap: 10px; align-items: center; margin: -4px 0 13px; padding: 10px 12px; color: var(--g-ink-mid); background: rgba(116, 255, 176, .045); border: 1px solid rgba(116, 255, 176, .16); }
+.lr-salvage-explainer > i { display: grid; width: 30px; height: 30px; place-items: center; color: var(--g-phosphor); background: var(--g-hull); }
+.lr-salvage-explainer div { display: grid; gap: 3px; }
+.lr-salvage-explainer strong { color: var(--g-phosphor); font: 700 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-salvage-explainer span { font-size: .9rem; line-height: 1.4; }
+.lr-simple-routes { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.lr-simple-routes > article { position: relative; display: grid; grid-template-rows: 1fr auto; min-width: 0; background: var(--g-hull-lo); border: 1px solid var(--g-seam); transition: border-color .15s ease, box-shadow .15s ease; }
+.lr-simple-routes > article.is-recommended { border-color: rgba(116, 255, 176, .5); }
+.lr-simple-routes > article.is-selected { border: 2px solid var(--g-hazard); box-shadow: 0 0 0 3px rgba(217, 164, 16, .12), inset 4px 0 0 var(--g-hazard); }
+.lr-route-choice-main { display: grid; align-content: start; min-height: 300px; padding: 22px; color: var(--g-ink); text-align: left; background: transparent; border: 0; }
+.lr-route-choice-main:hover { background: #23241d; }
+.lr-simple-route-head { display: grid; gap: 7px; }
+.lr-simple-route-head em { width: fit-content; padding: 5px 7px; color: var(--g-hazard); background: rgba(217, 164, 16, .08); border: 1px solid rgba(217, 164, 16, .32); font: 700 9px/1 var(--g-font-mono); font-style: normal; text-transform: uppercase; }
+.lr-simple-routes > article.is-recommended .lr-simple-route-head em { color: var(--g-ink-invert); background: var(--g-phosphor); border-color: var(--g-phosphor); }
+.lr-simple-route-head b { font: 600 1.4rem/1.2 var(--g-font-stencil); text-transform: uppercase; }
+.lr-route-choice-main > p { margin: 14px 0; color: var(--g-ink-mid); font-size: 1rem; line-height: 1.5; }
+.lr-simple-plan-cost span,
+.lr-simple-result-cost span { padding: 11px; color: var(--g-ink-low); background: var(--g-hull); font: 600 10px/1.35 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-plan-cost i,
+.lr-simple-result-cost i { margin-right: 4px; color: var(--g-phosphor); }
+.lr-simple-plan-cost strong,
+.lr-simple-result-cost strong { color: var(--g-ink); }
+.lr-simple-plan-cost .is-unknown { color: var(--g-hazard); }
+.lr-route-signals { display: grid; gap: 8px; margin-top: 4px; }
+.lr-route-projection { display: grid; gap: 9px; padding: 12px; background: var(--g-hull); }
+.lr-route-projection > span:first-child { display: grid; grid-template-columns: 20px 1fr auto; gap: 7px; align-items: center; }
+.lr-route-projection i { color: var(--g-hazard); }
+.lr-route-projection.is-crew > span:first-child > i,
+.lr-scout-cost > span:first-child > i { color: #72d8ff; }
+.lr-route-projection.is-annex > span:first-child > i { color: var(--g-phosphor); }
+.lr-route-projection small,
+.lr-route-risk small,
+.lr-route-reward small { color: var(--g-ink-low); font: 700 9px/1 var(--g-font-mono); letter-spacing: .04em; text-transform: uppercase; }
+.lr-route-projection strong { color: var(--g-hazard); font: 700 13px/1 var(--g-font-mono); }
+.lr-route-projection.is-crew strong { color: #72d8ff; }
+.lr-route-projection.is-annex strong { color: var(--g-phosphor); }
+.lr-projection-track { display: grid; grid-template-columns: repeat(var(--segments, 10), 1fr); grid-auto-flow: column; gap: 4px; }
+.lr-projection-track.is-strain { --segments: 6; }
+.lr-projection-track.is-annex { --segments: 10; }
+.lr-projection-track > i { height: 11px; background: var(--g-seam); border: 1px solid rgba(255,255,255,.04); }
+.lr-projection-track.is-strain > i { border-radius: 3px; }
+.lr-projection-track.is-strain > i { color: #72d8ff; }
+.lr-projection-track.is-strain > i.is-current { background: #287d9e; border-color: #72d8ff; box-shadow: inset 0 0 4px rgba(114,216,255,.25); }
+.lr-projection-track.is-annex > i { clip-path: polygon(12% 0, 88% 0, 100% 50%, 88% 100%, 12% 100%, 0 50%); }
+.lr-projection-track.is-annex > i { color: var(--g-phosphor); }
+.lr-projection-track.is-annex > i.is-current { background: var(--g-phosphor-dim); border-color: var(--g-phosphor); }
+.lr-projection-track.is-strain > i.is-projected { background: repeating-linear-gradient(135deg, #287d9e 0 3px, rgba(40,125,158,.25) 3px 6px); border-color: #72d8ff; animation: lr-resource-loss 1.05s ease-in-out infinite alternate; }
+.lr-projection-track.is-annex > i.is-projected { background: repeating-linear-gradient(135deg, var(--g-phosphor-dim) 0 3px, rgba(116,255,176,.18) 3px 6px); border-color: var(--g-phosphor); animation: lr-resource-loss 1.05s ease-in-out infinite alternate; }
+@keyframes lr-resource-loss {
+  from { opacity: .32; filter: saturate(.65); box-shadow: none; }
+  to { opacity: .72; filter: saturate(1); box-shadow: 0 0 7px currentColor; }
+}
+@keyframes lr-guide-next {
+  0% { opacity: 0; transform: translateY(-8px); box-shadow: 0 0 0 rgba(217,164,16,0); }
+  60% { opacity: 1; transform: translateY(0); box-shadow: 0 0 0 5px rgba(217,164,16,.13); }
+  100% { opacity: 1; transform: translateY(0); box-shadow: var(--g-recess); }
+}
+@keyframes lr-stage-enter {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes lr-stage-resolve {
+  0% { opacity: .55; transform: scale(.988); }
+  55% { box-shadow: inset 4px 0 0 var(--g-phosphor), 0 0 0 5px rgba(116,255,176,.12); }
+  100% { opacity: 1; transform: scale(1); box-shadow: inset 4px 0 0 var(--g-phosphor); }
+}
+@keyframes lr-story-step {
+  from { opacity: 0; transform: translateY(7px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes lr-status-impact {
+  0% { background-color: rgba(217,164,16,.2); box-shadow: 0 0 0 5px rgba(217,164,16,.12); }
+  100% { background-color: var(--g-hull-lo); box-shadow: none; }
+}
+@keyframes lr-delta-pop {
+  0% { opacity: 0; transform: translateY(5px) scale(.8); }
+  25% { opacity: 1; transform: translateY(0) scale(1.08); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes lr-feedback-enter {
+  from { opacity: 0; transform: translateX(-12px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes lr-feedback-beacon {
+  0%, 100% { transform: scale(1); box-shadow: 0 0 0 rgba(217,164,16,0); }
+  50% { transform: scale(1.08); box-shadow: 0 0 0 5px rgba(217,164,16,.12); }
+}
+@keyframes lr-chip-enter {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes lr-next-action {
+  0%, 100% { box-shadow: var(--g-drop); }
+  50% { box-shadow: 0 0 0 4px rgba(116,255,176,.12), 0 5px 12px rgba(0,0,0,.35); }
+}
+.lr-route-risk,
+.lr-route-reward { display: grid; grid-template-columns: 22px 1fr; gap: 8px; align-items: center; padding: 11px 12px; background: var(--g-hull); }
+.lr-route-risk > i { color: var(--g-hazard); }
+.lr-route-reward > i { color: var(--g-phosphor); }
+.lr-route-risk > span,
+.lr-route-reward > span { display: grid; gap: 3px; }
+.lr-route-risk strong,
+.lr-route-reward strong { color: var(--g-ink); font: 600 11px/1.3 var(--g-font-mono); }
+.lr-route-reward b { color: var(--g-ink-low); font: 600 9px/1.2 var(--g-font-mono); text-transform: uppercase; }
+.lr-salvage-gauge { display: grid; grid-template-columns: repeat(10, 1fr); gap: 3px; margin: 4px 0 2px; }
+.lr-salvage-gauge > i { color: var(--g-ink-low); font-size: 10px; opacity: .28; }
+.lr-salvage-gauge > i.is-filled { color: var(--g-hazard); opacity: 1; text-shadow: 0 0 7px rgba(217,164,16,.4); }
+.lr-route-no-cost { display: flex; align-items: center; gap: 8px; padding: 11px 12px; color: var(--g-phosphor); background: rgba(116, 255, 176, .06); font: 700 10px/1.3 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-route-action { align-self: end; margin-top: 16px; padding-top: 12px; color: var(--g-hazard); border-top: 1px solid var(--g-rule); font: 700 11px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-routes > article.is-selected .lr-simple-route-action { color: var(--g-phosphor); }
+@media (prefers-reduced-motion: reduce) {
+  .lr-projection-track > i.is-projected,
+  .lr-projection-legend i.is-fading { animation: none; opacity: .5; }
+  .lr-current-action,
+  .lr-simple-decision,
+  .lr-transition-beat,
+  .lr-field-encounter.is-resolved,
+  .lr-simple-report > *,
+  .lr-simple-result > *,
+  .lr-simple-status .is-changing,
+  .lr-status-delta,
+  .lr-action-feedback,
+  .lr-action-feedback > i,
+  .lr-action-feedback b,
+  .lr-salvage-counter.is-changing,
+  .lr-salvage-counter > em,
+  .lr-simple-report > .g-btn--primary,
+  .lr-simple-result .lr-result-actions .g-btn--primary,
+  .lr-transition-beat > .g-btn--primary,
+  .lr-field-encounter.is-resolved > .g-btn--primary { animation: none !important; }
+}
+.lr-route-analysis { margin: 0 20px 18px; color: var(--g-ink-mid); border-top: 1px solid var(--g-rule); }
+.lr-route-analysis summary { padding: 12px 2px 4px; color: var(--g-ink-low); cursor: pointer; font: 700 10px/1.2 var(--g-font-mono); text-transform: uppercase; }
+.lr-route-analysis summary:hover { color: var(--g-ink); }
+.lr-route-analysis p { margin: 8px 0 0; font-size: .88rem; line-height: 1.5; }
+.lr-route-continue { position: sticky; z-index: 4; bottom: 12px; display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-top: 14px; padding: 13px 15px; background: #1f211b; border: 1px solid var(--g-hazard); box-shadow: 0 12px 30px rgba(0,0,0,.42), inset 4px 0 0 var(--g-hazard); }
+.lr-route-continue > span { display: flex; align-items: center; gap: 11px; }
+.lr-route-continue > span > i { color: var(--g-hazard); font-size: 22px; }
+.lr-route-continue > span > span { display: grid; gap: 4px; }
+.lr-route-continue small { color: var(--g-hazard); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-route-continue strong { color: var(--g-ink); font: 600 13px/1.2 var(--g-font-mono); text-transform: uppercase; }
+
+.lr-route-confirmed {
+  display: grid;
+  grid-template-columns: 34px 1fr auto;
+  align-items: center;
+  gap: 11px;
+  margin-bottom: 10px;
+  padding: 11px 13px;
+  background: rgba(116, 255, 176, .07);
+  border: 1px solid rgba(116, 255, 176, .38);
+}
+.lr-route-confirmed > i { color: var(--g-phosphor); font-size: 22px; }
+.lr-route-confirmed > span { display: grid; gap: 4px; }
+.lr-route-confirmed small { color: var(--g-phosphor); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-route-confirmed strong { color: var(--g-ink); font: 600 14px/1.2 var(--g-font-mono); text-transform: uppercase; }
+.lr-route-confirmed button { min-height: 44px; padding: 8px 11px; color: var(--g-ink-mid); background: var(--g-hull); border: 1px solid var(--g-rule); font: 600 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-route-confirmed button:hover { color: var(--g-ink); border-color: var(--g-phosphor); }
+
+.lr-simple-plan { margin-top: 16px; padding: 20px; background: var(--g-hull-lo); border: 1px solid var(--g-phosphor); box-shadow: inset 4px 0 0 var(--g-phosphor); }
+.lr-simple-plan,
+.lr-simple-report,
+.lr-simple-result,
+.lr-field-encounter { scroll-margin-top: 82px; }
+.lr-simple-plan-reason { margin: 14px 0 0; padding: 11px 13px; color: var(--g-ink-mid); background: var(--g-hull); line-height: 1.45; }
+.lr-simple-plan-reason strong { color: var(--g-phosphor); }
+.lr-simple-plan-crew { display: grid; grid-template-columns: 1fr 30px 1fr 36px 1.2fr; align-items: center; gap: 5px; margin-top: 16px; }
+.lr-simple-plan-crew > span { display: grid; gap: 6px; padding: 12px; background: var(--g-hull); }
+.lr-simple-plan-crew small { color: var(--g-ink-low); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-plan-crew strong { color: var(--g-ink); font: 600 13px/1.3 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-plan-crew > i { color: var(--g-hazard); text-align: center; }
+.lr-simple-plan-cost,
+.lr-simple-result-cost { display: grid; grid-template-columns: repeat(3, 1fr); gap: 5px; margin-top: 9px; }
+.lr-simple-plan-projections { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 7px; margin-top: 9px; }
+.lr-simple-plan-projections .lr-route-risk,
+.lr-simple-plan-projections .lr-route-no-cost { min-height: 64px; }
+.lr-plan-analysis { margin-top: 9px; color: var(--g-ink-low); background: rgba(255,255,255,.018); border: 1px solid var(--g-rule); }
+.lr-plan-analysis summary { padding: 10px 12px; cursor: pointer; color: var(--g-ink-mid); font: 700 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-plan-analysis summary:hover { color: var(--g-phosphor); }
+.lr-plan-analysis p { margin: 0; padding: 0 12px 12px; color: var(--g-ink-mid); font-size: .9rem; line-height: 1.5; }
+.lr-simple-override { display: flex; align-items: center; gap: 7px; margin-top: 10px; color: var(--g-hazard); font: 600 9px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-simple-override input { accent-color: var(--g-hazard); }
+.lr-simple-plan-actions { display: flex; align-items: center; justify-content: flex-end; gap: 16px; margin-top: 18px; }
+
+.lr-simple-result { max-width: 820px; margin-inline: auto; }
+.lr-simple-result-cost { margin-bottom: 14px; }
+.lr-result-explanation,
+.lr-result-changes { margin: 14px 0; padding: 15px; background: var(--g-hull-lo); border: 1px solid var(--g-seam); }
+.lr-result-explanation > span,
+.lr-result-changes > span { color: var(--g-hazard); font: 700 10px/1 var(--g-font-mono); text-transform: uppercase; }
+.lr-result-explanation ul { display: grid; gap: 9px; margin: 13px 0 0; padding-left: 20px; color: var(--g-ink-mid); font-size: .95rem; line-height: 1.5; }
+.lr-result-changes > div { display: grid; grid-template-columns: repeat(2, 1fr); gap: 6px; margin-top: 11px; }
+.lr-result-changes article { display: grid; gap: 9px; padding: 12px; background: var(--g-hull); }
+.lr-result-changes article > span { display: grid; grid-template-columns: 20px 1fr auto; gap: 7px; align-items: center; }
+.lr-result-changes article i { color: var(--g-hazard); }
+.lr-result-changes article strong { color: var(--g-ink); font: 600 11px/1.25 var(--g-font-mono); text-transform: uppercase; }
+.lr-result-changes article b { color: var(--g-hazard); font: 700 13px/1.3 var(--g-font-mono); }
+.lr-result-changes article small { color: var(--g-ink-low); font: 500 10px/1.35 var(--g-font-mono); }
+.lr-result-changes article.is-good i,
+.lr-result-changes article.is-good b { color: var(--g-phosphor); }
+.lr-result-changes article.is-warning i,
+.lr-result-changes article.is-warning b { color: var(--g-hazard); }
+.lr-result-no-cost { grid-template-columns: 20px 1fr; align-items: center; color: var(--g-phosphor); }
+.lr-result-salvage { border-left: 2px solid var(--g-phosphor); }
+.lr-result-salvage b { color: var(--g-phosphor) !important; }
+.lr-simple-surprise { display: flex; gap: 9px; padding: 11px; color: var(--g-ink-mid); background: rgba(228, 72, 60, .08); border-left: 3px solid var(--g-lamp-red); }
+.lr-simple-surprise i,
+.lr-simple-surprise strong { color: var(--g-lamp-red); }
+.lr-simple-surprise.is-good { background: rgba(116, 255, 176, .06); border-color: var(--g-phosphor); }
+.lr-simple-surprise.is-good i,
+.lr-simple-surprise.is-good strong { color: var(--g-phosphor); }
+
+/* Result */
+.lr-result-panel > h3 {
+  margin: 20px 0;
+  color: var(--g-ink);
+  font: 500 1.25rem/1.4 var(--g-font-stencil);
+  text-transform: uppercase;
+}
+
+.lr-result-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 15px;
+  color: var(--g-ink-invert);
+  background: var(--g-hazard);
+  border-left: 7px solid var(--g-brass-dark);
+}
+
+.lr-result-banner--clean {
+  background: #77b990;
+}
+
+.lr-result-banner--rough,
+.lr-result-banner--critical {
+  color: var(--g-ink);
+  background: #933d34;
+}
+
+.lr-result-banner span {
+  font: 700 12px/1 var(--g-font-mono);
+  letter-spacing: .13em;
+}
+
+.lr-result-banner strong {
+  font: 700 1.25rem/1 var(--g-font-mono);
+}
+
+.lr-result-banner i {
+  margin: 0 5px;
+  font-size: .7rem;
+  font-style: normal;
+  opacity: .7;
+}
+
+.lr-result-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin-bottom: 14px;
+  background: var(--g-seam);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-result-grid > div {
+  display: grid;
+  padding: 12px;
+  background: var(--g-hull-lo);
+  text-align: center;
+}
+
+.lr-result-grid span,
+.lr-result-grid small {
+  color: var(--g-ink-low);
+  font: 500 8px/1.2 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-result-grid strong {
+  margin: 5px 0;
+  color: var(--g-hazard);
+  font: 700 1.4rem/1 var(--g-font-mono);
+}
+
+.lr-result-note {
+  display: flex;
+  gap: 9px;
+  margin-top: 7px;
+  padding: 9px 11px;
+  color: var(--g-ink-mid);
+  background: var(--g-hull-lo);
+  border-left: 3px solid var(--g-brass-dark);
+  font: 500 10px/1.4 var(--g-font-mono);
+}
+
+.lr-result-note i {
+  color: var(--g-hazard);
+}
+
+.lr-result-note--danger {
+  border-color: var(--g-lamp-red);
+}
+
+.lr-result-note--danger i,
+.lr-result-note--danger strong {
+  color: var(--g-lamp-red);
+}
+
+.lr-result-actions {
+  justify-content: space-between;
+}
+.lr-mode-simple .lr-result-actions .g-btn--danger {
+  color: var(--g-lamp-red);
+  background: transparent;
+  border: 1px solid rgba(228, 72, 60, .55);
+  box-shadow: none;
+}
+.lr-mode-simple .lr-result-actions .g-btn--danger:hover { color: var(--g-ink); background: rgba(228, 72, 60, .14); }
+.lr-shell button:not(:disabled):active { transform: translateY(1px); }
+
+/* End screen */
+.lr-end-shell {
+  display: grid;
+  min-height: calc(100vh - 90px);
+  place-items: center;
+}
+
+.lr-end-card {
+  width: min(860px, 100%);
+  padding: 38px;
+  text-align: center;
+}
+
+.lr-end-seal {
+  display: grid;
+  width: 72px;
+  height: 72px;
+  margin: 20px auto;
+  place-items: center;
+  color: var(--g-lamp-red);
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  font-size: 2.1rem;
+}
+
+.lr-end-card--success .lr-end-seal {
+  color: var(--g-phosphor);
+}
+
+.lr-end-copy {
+  max-width: 60ch;
+  margin: 17px auto 24px;
+  color: var(--g-ink-mid);
+  line-height: 1.6;
+}
+
+.lr-end-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--g-seam);
+  border: 1px solid var(--g-seam);
+}
+
+.lr-end-stats > div {
+  display: grid;
+  gap: 7px;
+  padding: 16px 10px;
+  background: var(--g-hull-lo);
+}
+
+.lr-end-stats span {
+  color: var(--g-ink-low);
+  font: 500 8px/1 var(--g-font-mono);
+  text-transform: uppercase;
+}
+
+.lr-end-stats strong {
+  color: var(--g-phosphor);
+  font: 700 1.05rem/1 var(--g-font-mono);
+}
+
+.lr-end-crew {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.lr-end-crew .lr-crew-member {
+  pointer-events: none;
+}
+
+.lr-end-actions {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+@media (max-width: 1260px) {
+  .lr-choice-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .lr-game-grid { grid-template-columns: 250px minmax(480px, 1fr); }
+  .lr-log { grid-column: 1 / -1; display: grid; grid-template-columns: 160px 1fr 220px; gap: 14px; align-items: start; }
+  .lr-log-screen { min-height: 160px; max-height: 220px; }
+}
+
+@media (max-width: 900px) {
+  .lr-shell { width: min(100% - 20px, 760px); padding-top: 24px; }
+  .lr-briefing { grid-template-columns: 1fr; padding: 24px; }
+  .lr-choice-grid { grid-template-columns: 1fr; }
+  .lr-game-grid { grid-template-columns: 1fr; }
+  .lr-crew-rail { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
+  .lr-crew-rail .lr-rail-title, .lr-ability-ledger { grid-column: 1 / -1; }
+  .lr-crew-member { grid-template-columns: 58px minmax(0, 1fr); }
+  .lr-portrait--compact { min-height: 88px; }
+  .lr-log { grid-template-columns: 1fr; }
+  .lr-head-readouts { width: 100%; justify-content: space-between; }
+  .lr-mission-head { align-items: stretch; flex-direction: column; }
+  .lr-guidance-setup { grid-template-columns: 1fr; }
+  .lr-simple-primer { grid-template-columns: 44px 1fr; }
+  .lr-simple-primer-steps { grid-column: 1 / -1; }
+  .lr-simple-status { grid-template-columns: 1fr 1fr; }
+  .lr-simple-status-crew,
+  .lr-simple-status-companion { grid-column: 1 / -1; }
+  .lr-encounter-options { grid-template-columns: 1fr; }
+  .lr-simple-scouts { grid-template-columns: 1fr; }
+  .lr-simple-scouts > button { grid-template-columns: 150px minmax(0, 1fr); }
+  .lr-simple-scouts .lr-portrait { min-height: 100%; border-right: 1px solid var(--g-seam); border-bottom: 0; }
+  .lr-simple-scouts > button > .lr-scout-card-copy { grid-template-columns: 1fr; }
+  .lr-scout-card-head,
+  .lr-scout-relay,
+  .lr-scout-action { grid-column: auto; grid-row: auto; }
+  .lr-scout-action { min-height: 42px; }
+  .lr-scout-storyline { grid-template-columns: minmax(120px, 1fr) 10px minmax(110px, .9fr) 10px minmax(150px, 1.15fr); }
+}
+
+@media (max-width: 650px) {
+  .lr-shell { width: calc(100% - 12px); padding-bottom: 36px; }
+  .lr-briefing, .lr-scene, .lr-end-card { padding: 19px; }
+  .lr-briefing-screen { min-height: 0; padding: 18px; }
+  .lr-mission-stamp { min-width: 0; width: 100%; }
+  .lr-section-head, .lr-launch-row { align-items: stretch; flex-direction: column; }
+  .lr-guidance-selector { grid-template-columns: 1fr; }
+  .lr-guidance-selector--compact { grid-template-columns: repeat(4, 1fr); min-width: 0; width: 100%; }
+  .lr-crossing-equation { grid-template-columns: minmax(54px, 1fr) 14px minmax(54px, 1fr) 14px minmax(54px, 1fr) 20px minmax(54px, 1fr); }
+  .lr-crossing-result { grid-column: 1 / -1; }
+  .lr-primer-head { align-items: flex-start; flex-direction: column; }
+  .lr-primer-build { grid-template-columns: minmax(0, 1fr) 24px minmax(0, 1fr); }
+  .lr-primer-build > i:nth-child(4),
+  .lr-primer-build > div:nth-child(5) { grid-column: 1 / -1; }
+  .lr-primer-build > i:nth-child(4) { transform: rotate(90deg); }
+  .lr-primer-compare { grid-template-columns: minmax(0, 1fr) 24px minmax(0, 1fr); }
+  .lr-primer-compare > i:nth-child(4),
+  .lr-primer-compare > div:nth-child(5) { grid-column: 1 / -1; }
+  .lr-primer-compare > i:nth-child(4) { transform: rotate(90deg); }
+  .lr-primer-next { align-items: flex-start; flex-direction: column; }
+  .lr-simple-routes,
+  .lr-simple-plan-cost,
+  .lr-simple-plan-projections,
+  .lr-simple-result-cost,
+  .lr-simple-status,
+  .lr-result-changes > div,
+  .lr-encounter-impact { grid-template-columns: 1fr; }
+  .lr-simple-status-crew > div { grid-template-columns: 1fr; }
+  .lr-current-action { grid-template-columns: 40px 1fr; }
+  .lr-current-action > button { grid-column: 1 / -1; }
+  .lr-route-confirmed { grid-template-columns: 28px 1fr; }
+  .lr-route-confirmed button { grid-column: 1 / -1; }
+  .lr-route-continue { position: static; align-items: stretch; flex-direction: column; }
+  .lr-route-continue > button { width: 100%; }
+  .lr-simple-scouts { grid-template-columns: 1fr; }
+  .lr-simple-scouts > button { grid-template-columns: 96px minmax(0, 1fr); }
+  .lr-simple-scouts .lr-portrait { min-height: 100%; border-right: 1px solid var(--g-seam); border-bottom: 0; }
+  .lr-simple-scouts > button > .lr-scout-card-copy { grid-template-columns: 1fr; }
+  .lr-scout-card-copy > span { padding: 12px; border-top: 1px solid var(--g-seam); }
+  .lr-scout-card-head,
+  .lr-scout-relay,
+  .lr-scout-action { grid-column: auto; grid-row: auto; }
+  .lr-scout-storyline { grid-template-columns: 1fr; }
+  .lr-scout-storyline > i { justify-self: center; transform: rotate(90deg); }
+  .lr-encounter-heading { grid-template-columns: 72px 1fr; }
+  .lr-skip-scout { align-items: start; grid-template-columns: 28px 1fr; }
+  .lr-skip-scout span,
+  .lr-skip-scout b { grid-column: 2; }
+  .lr-simple-plan-crew { grid-template-columns: 1fr; }
+  .lr-simple-plan-crew > i { transform: rotate(90deg); }
+  .lr-simple-plan-actions { align-items: stretch; flex-direction: column-reverse; }
+  .lr-primer-steps { grid-template-columns: 1fr 1fr; gap: 9px; }
+  .lr-primer-steps > i { display: none; }
+  .lr-margin-scale { grid-template-columns: 1fr 1fr; }
+  .lr-assignment-head, .lr-assignment-mode, .lr-methods-head { align-items: stretch; flex-direction: column; }
+  .lr-methods-key { justify-content: flex-start; }
+  .lr-method-select { grid-template-columns: 32px minmax(0, 1fr) 70px; }
+  .lr-outcome-signals { grid-template-columns: repeat(2, 1fr); }
+  .lr-modal-backdrop { padding: 8px; }
+  .lr-detail-modal { max-height: calc(100vh - 16px); padding: 20px; }
+  .lr-score-equation { flex-wrap: wrap; }
+  .lr-crew-choice { grid-template-columns: 105px minmax(0, 1fr); }
+  .lr-portrait { min-height: 200px; }
+  .lr-crew-rail { grid-template-columns: 1fr; }
+  .lr-crew-rail .lr-rail-title, .lr-ability-ledger { grid-column: auto; }
+  .lr-route-grid, .lr-signal-board, .lr-commit-readout, .lr-scene-orientation, .lr-report-analysis { grid-template-columns: 1fr; }
+  .lr-report-readouts { grid-template-columns: repeat(2, 1fr); }
+  .lr-role-picker { grid-template-columns: 1fr; }
+  .lr-result-grid, .lr-end-stats { grid-template-columns: repeat(2, 1fr); }
+  .lr-end-crew { grid-template-columns: 1fr; }
+  .lr-head-readouts { display: grid; grid-template-columns: 1fr 1fr; }
+  .lr-head-readouts .lr-rules-button { grid-column: 1 / -1; }
+  .lr-head-readouts .lr-meter { grid-column: 1 / -1; width: 100%; }
+  .lr-track { padding-inline: 8px; }
+  .lr-track-summary { align-items: flex-start; flex-direction: column; gap: 6px; }
+  .lr-track-copy { display: none; }
+  .lr-action-row { align-items: stretch; flex-direction: column-reverse; }
+  .lr-action-row .g-btn { width: 100%; }
+  .lr-result-actions { flex-direction: column; }
+}

--- a/my-app/src/components/games/longReturn/longReturnData.js
+++ b/my-app/src/components/games/longReturn/longReturnData.js
@@ -1,0 +1,430 @@
+export const MAX_STRAIN = 6;
+export const MAX_PRESSURE = 10;
+export const MAX_INSTABILITY = MAX_PRESSURE;
+
+export const CREATURES = [
+  {
+    id: 'graviclaw-213',
+    species: 'Graviclaw',
+    planet: 'Grimedes',
+    role: 'Cold-water anchor',
+    element: { primary: 'dark', affinities: { dark: 100, ghost: 44 } },
+    physiology: {
+      corporeality: 'corporeal', composition: 'flesh', covering: 'chitin', bodyPlan: 'multiped',
+      heightCm: 198, weightKg: 372, diet: 'carnivore', communication: ['vibration'],
+      breathes: ['gas', 'liquid'], ambientMedia: ['gas', 'liquid'], temperatureC: { min: -15, max: 20 },
+      capabilities: { flight: 0, swim: 52, burrow: 31, climb: 18, sprint: 12, leap: 4, manipulation: 44 },
+      senses: { sight: 55, hearing: 28, smell: 47, special: ['tremorsense'] }
+    },
+    attributes: { strength: 74, vitality: 61, endurance: 65, agility: 14, reflex: 38, intelligence: 42, willpower: 78, instinct: 71, charisma: 19, resilience: 93 },
+    traits: ['armored', 'anchored', 'stealthy'],
+    temperament: { boldness: 81, curiosity: 48, energy: 25, aggression: 66, sociability: 22 },
+    abilities: [
+      { id: 'grav-point', name: 'Point of No Return', signature: true, instrument: 'pincers', action: 'snare', medium: 'dark', intensity: 74 },
+      { id: 'grav-vise', name: 'Wraith Vise', instrument: 'pincers', action: 'crush', medium: 'ghost', intensity: 48 },
+      { id: 'grav-ward', name: 'Event Horizon', instrument: 'pincers', action: 'ward', medium: 'dark', intensity: 41 }
+    ]
+  },
+  {
+    id: 'chromocat-088',
+    species: 'Chromocat',
+    planet: 'Luminax',
+    role: 'Fast visual scout',
+    element: { primary: 'light', affinities: { light: 100, electric: 38 } },
+    physiology: {
+      corporeality: 'corporeal', composition: 'flesh', covering: 'fur', bodyPlan: 'quadruped',
+      heightCm: 142, weightKg: 75, diet: 'carnivore', communication: ['display', 'vocal'],
+      breathes: ['gas'], ambientMedia: ['gas'], temperatureC: { min: -5, max: 52 },
+      capabilities: { flight: 22, swim: 14, burrow: 0, climb: 65, sprint: 96, leap: 86, manipulation: 45 },
+      senses: { sight: 84, hearing: 67, smell: 54, special: ['heat-sense'] }
+    },
+    attributes: { strength: 58, vitality: 55, endurance: 72, agility: 96, reflex: 93, intelligence: 48, willpower: 60, instinct: 77, charisma: 38, resilience: 44 },
+    traits: ['stealthy', 'foresighted'],
+    temperament: { boldness: 76, curiosity: 67, energy: 94, aggression: 61, sociability: 38 },
+    abilities: [
+      { id: 'chroma-sprint', name: 'The Light Between Moments', signature: true, instrument: 'body', action: 'ambush', medium: 'light', intensity: 92 },
+      { id: 'chroma-rake', name: 'Harvesting Horizon', instrument: 'blades', action: 'rake', medium: 'light', intensity: 70 },
+      { id: 'chroma-beam', name: 'Corona Line', instrument: 'light-organs', action: 'beam', medium: 'light', intensity: 64 }
+    ]
+  },
+  {
+    id: 'hippochamp-041',
+    species: 'Hippochamp',
+    planet: 'Poseidas',
+    role: 'Flooded-site responder',
+    element: { primary: 'water', affinities: { water: 100, chemical: 33 } },
+    physiology: {
+      corporeality: 'corporeal', composition: 'flesh', covering: 'scales', bodyPlan: 'quadruped',
+      heightCm: 129, weightKg: 141, diet: 'herbivore', communication: ['vocal'],
+      breathes: ['gas', 'liquid'], ambientMedia: ['gas', 'liquid'], temperatureC: { min: -2, max: 44 },
+      capabilities: { flight: 0, swim: 92, burrow: 8, climb: 24, sprint: 48, leap: 30, manipulation: 62 },
+      senses: { sight: 62, hearing: 70, smell: 64, special: ['electroreception'] }
+    },
+    attributes: { strength: 61, vitality: 78, endurance: 91, agility: 57, reflex: 66, intelligence: 64, willpower: 72, instinct: 69, charisma: 58, resilience: 76 },
+    traits: ['protective', 'resistant', 'healing'],
+    temperament: { boldness: 64, curiosity: 41, energy: 76, aggression: 28, sociability: 79 },
+    abilities: [
+      { id: 'hippo-deluge', name: 'Deluge Emergency Protocol', signature: true, instrument: 'trunk', action: 'spray', medium: 'water', intensity: 88 },
+      { id: 'hippo-ward', name: 'Pressure Screen', instrument: 'breath', action: 'ward', medium: 'water', intensity: 72 },
+      { id: 'hippo-mend', name: 'Restorative Current', instrument: 'secretion', action: 'mend', medium: 'water', intensity: 68 }
+    ]
+  },
+  {
+    id: 'ectoghoul-117',
+    species: 'Ectoghoul',
+    planet: 'Phantiri',
+    role: 'Vacuum infiltrator',
+    element: { primary: 'ghost', affinities: { ghost: 100, dark: 57 } },
+    physiology: {
+      corporeality: 'non-corporeal', composition: 'spectral', covering: 'mist', bodyPlan: 'floating',
+      heightCm: 90, weightKg: 3, diet: 'energy-feeder', communication: ['vocal'],
+      breathes: [], ambientMedia: ['gas', 'liquid', 'vacuum'], temperatureC: { min: -90, max: 90 },
+      capabilities: { flight: 88, swim: 74, burrow: 0, climb: 0, sprint: 79, leap: 0, manipulation: 20 },
+      senses: { sight: 65, hearing: 81, smell: 0, special: ['void-sense'] }
+    },
+    attributes: { strength: 18, vitality: 49, endurance: 42, agility: 88, reflex: 91, intelligence: 70, willpower: 84, instinct: 79, charisma: 45, resilience: 53 },
+    traits: ['phasing', 'slippery', 'menacing'],
+    temperament: { boldness: 91, curiosity: 86, energy: 71, aggression: 73, sociability: 30 },
+    abilities: [
+      { id: 'ecto-dirge', name: 'The Laugh Beyond the Hull', signature: true, instrument: 'voice', action: 'terrorize', medium: 'ghost', intensity: 84 },
+      { id: 'ecto-cloud', name: 'Ectoplasmic Wake', instrument: 'body', action: 'cloud', medium: 'ghost', intensity: 66 },
+      { id: 'ecto-beam', name: 'Grave Current', instrument: 'gaze', action: 'beam', medium: 'ghost', intensity: 58 }
+    ]
+  },
+  {
+    id: 'xylum-064',
+    species: 'Xylum',
+    planet: 'Floria',
+    role: 'Subsurface engineer',
+    element: { primary: 'plant', affinities: { plant: 100, water: 61 } },
+    physiology: {
+      corporeality: 'corporeal', composition: 'plant', covering: 'hide', bodyPlan: 'amorphous',
+      heightCm: 320, weightKg: 237, diet: 'photosynthetic', communication: ['chemical', 'vibration'],
+      breathes: ['gas', 'liquid'], ambientMedia: ['gas', 'liquid'], temperatureC: { min: 2, max: 48 },
+      capabilities: { flight: 0, swim: 35, burrow: 92, climb: 54, sprint: 8, leap: 0, manipulation: 79 },
+      senses: { sight: 34, hearing: 18, smell: 86, special: ['tremorsense'] }
+    },
+    attributes: { strength: 79, vitality: 88, endurance: 82, agility: 22, reflex: 25, intelligence: 68, willpower: 73, instinct: 76, charisma: 50, resilience: 86 },
+    traits: ['anchored', 'regenerative', 'healing'],
+    temperament: { boldness: 43, curiosity: 58, energy: 31, aggression: 16, sociability: 68 },
+    abilities: [
+      { id: 'xylum-roots', name: 'The World Takes Root', signature: true, instrument: 'roots', action: 'snare', medium: 'plant', intensity: 91 },
+      { id: 'xylum-mend', name: 'Green Renewal', instrument: 'tendrils', action: 'mend', medium: 'plant', intensity: 77 },
+      { id: 'xylum-ward', name: 'Bramble Shelter', instrument: 'roots', action: 'ward', medium: 'plant', intensity: 69 }
+    ]
+  },
+  {
+    id: 'hypnopet-019',
+    species: 'Hypnopet',
+    planet: 'Telypso',
+    role: 'Empathic field medic',
+    element: { primary: 'psychic', affinities: { psychic: 100, light: 48 } },
+    physiology: {
+      corporeality: 'corporeal', composition: 'flesh', covering: 'fur', bodyPlan: 'quadruped',
+      heightCm: 35, weightKg: 13, diet: 'herbivore', communication: ['telepathic', 'display'],
+      breathes: ['gas'], ambientMedia: ['gas'], temperatureC: { min: 8, max: 36 },
+      capabilities: { flight: 0, swim: 22, burrow: 18, climb: 34, sprint: 62, leap: 71, manipulation: 70 },
+      senses: { sight: 74, hearing: 76, smell: 69, special: ['psychic'] }
+    },
+    attributes: { strength: 17, vitality: 64, endurance: 58, agility: 71, reflex: 74, intelligence: 88, willpower: 91, instinct: 83, charisma: 94, resilience: 48 },
+    traits: ['healing', 'hypnotic', 'perceptive', 'inspiring'],
+    temperament: { boldness: 35, curiosity: 74, energy: 59, aggression: 8, sociability: 94 },
+    abilities: [
+      { id: 'hypno-mercy', name: 'Mercy of the Quiet Mind', signature: true, instrument: 'aura', action: 'mend', medium: 'psychic', intensity: 90 },
+      { id: 'hypno-snare', name: 'Lucid Trance', instrument: 'gaze', action: 'snare', medium: 'psychic', intensity: 73 },
+      { id: 'hypno-ward', name: 'Empathic Shelter', instrument: 'mind', action: 'ward', medium: 'psychic', intensity: 80 }
+    ]
+  }
+];
+
+export const MISSION = {
+  id: 'black-archive-7',
+  title: 'The Black Archive',
+  location: 'Krystos / End-Wars Containment Annex 7',
+  objective: 'Recover the Nemesis Index before the annex folds into the ice shelf.',
+  briefing: 'The annex has been without power for two centuries. Old emergency systems are waking in the wrong order. Reach the archive, secure its plague research, and decide how much of the deeper Generator spine you are willing to salvage on the way out.',
+  dangerClock: {
+    label: 'Annex stability',
+    failure: 'At 0 stability, the annex collapses and forces extraction.',
+    cause: 'Noise, delays, awakened machinery, and destructive actions destabilize the annex.'
+  },
+  objectiveScene: 4,
+  scenes: [
+    {
+      id: 'service-throat', title: 'Flooded Service Throat', trackLabel: 'Flooded Entry', deck: 'ACCESS 01',
+      description: 'Black water turns beneath a collapsed maintenance gantry. The annex begins on the far side.',
+      arrival: 'The exterior seal grinds shut behind the crew. Ahead, black water and a broken gantry are the only ways into the annex.',
+      goal: 'Move all three crew members from the exterior access seal to the intact annex corridor.',
+      destination: 'the Blind Turbine Hall on the far side of the flood',
+      surveyFocus: 'the waterline, hanging gantry, and intake channel',
+      relayChannels: ['vibration', 'telepathic'],
+      hazards: [
+        { id: 'conductive-brine', label: 'Conductive brine', detail: 'The flood carries a dormant Electric charge.', sense: 'smell', threshold: 58, special: 'electroreception', strain: 1, pressure: 1 }
+      ],
+      routes: [
+        { id: 'gantry', title: 'Cross the hanging gantry', description: 'Stay dry, move lightly, and trust the old suspension bolts.', difficulty: 63, pressure: 1, salvage: 1,
+          consequence: { id: 'quiet-entry', label: 'Quiet entry', detail: 'The turbine bank ahead remains dormant.', future: 'Makes the upper catwalk easier in the next scene.' },
+          outcomes: {
+            clean: 'The gantry bows once, then settles. The crew reaches the far seal without waking the machinery beyond it.',
+            costly: 'Old bolts tear free behind the lead, but support holds the span long enough for everyone to cross.',
+            rough: 'The gantry folds into the flood. The crew scrambles onto the far ledge as the impact wakes machinery deeper inside.'
+          },
+          environment: { medium: 'gas', temperatureC: 5, element: 'metal' }, hazardIds: [],
+          reaction: { axis: 'boldness', direction: 'low', label: 'A cautious lead tests each span.' },
+          methods: [
+            { kind: 'capability', key: 'climb', attribute: 'agility', label: 'Climb the suspension frame' },
+            { kind: 'capability', key: 'leap', attribute: 'reflex', label: 'Leap between intact sections' },
+            { kind: 'action', key: 'beam', attribute: 'intelligence', label: 'Cut a controlled path' }
+          ] },
+        { id: 'intake', title: 'Ride the intake current', description: 'Enter the flood and pass beneath the wreckage.', difficulty: 58, pressure: 0, salvage: 2,
+          consequence: { id: 'coolant-bypass', label: 'Coolant bypass opened', detail: 'The current drains frozen fill from the underdeck ahead.', future: 'Makes the maintenance underdeck easier in the next scene.' },
+          outcomes: {
+            clean: 'The crew slips beneath the wreckage and rises inside the annex. Their wake pulls frozen debris out of a maintenance bypass.',
+            costly: 'The current throws the lead against the intake wall, but the crew surfaces together as the bypass begins to drain.',
+            rough: 'The intake churns the crew through metal and ice. They emerge scattered, while released floodwater tears open a lower service route.'
+          },
+          environment: { medium: 'liquid', temperatureC: 3, element: 'electric' }, hazardIds: ['conductive-brine'],
+          reaction: { axis: 'boldness', direction: 'high', label: 'A bold lead commits before the current turns.' },
+          methods: [
+            { kind: 'capability', key: 'swim', attribute: 'endurance', label: 'Swim the intake' },
+            { kind: 'action', key: 'snare', attribute: 'strength', label: 'Tow the crew through' },
+            { kind: 'action', key: 'ward', attribute: 'willpower', label: 'Screen the crossing' }
+          ] }
+      ]
+    },
+    {
+      id: 'turbine-hall', title: 'Blind Turbine Hall', trackLabel: 'Turbine Hall', deck: 'ACCESS 02',
+      description: 'Frozen turbines fill a chamber with blind corners and intermittent motion.',
+      arrival: 'The access seal opens onto a forest of frozen turbine housings. Somewhere in the dark, one mechanism completes a slow, silent turn.',
+      goal: 'Cross the dormant machinery without letting a waking turbine divide the crew.',
+      destination: 'the sealed Archive Vestibule beyond the turbine bank',
+      surveyFocus: 'the turbine housings, catwalk joints, and maintenance underdeck',
+      relayChannels: ['vibration', 'display', 'telepathic'],
+      encounterHint: 'Fresh root scoring on the underdeck suggests another Xalian may be sheltering inside the machinery.',
+      encounter: {
+        id: 'underdeck-xylum', creatureId: 'xylum-064', routeId: 'underdeck',
+        title: 'Stranded Xylum', disposition: 'injured and defensive',
+        description: 'A Xylum survivor has rooted itself around a cracked turbine bearing. It is hurt, frightened, and blocking the maintenance underdeck.',
+        concealment: 62, threat: 72,
+        companionBenefit: 'Once this mission, Xylum can brace a crossing and preserve 1 crew energy.'
+      },
+      hazards: [
+        { id: 'servo-cycle', label: 'Live servo cycle', detail: 'One turbine still completes a silent rotation every forty seconds.', sense: 'hearing', threshold: 60, special: 'tremorsense', strain: 1, pressure: 1 }
+      ],
+      routes: [
+        { id: 'catwalk', title: 'Race the upper catwalk', description: 'A fast crossing before the turbine completes its cycle.', difficulty: 68, pressure: 1, salvage: 2,
+          legacyAdjustments: [{ flag: 'quiet-entry', difficulty: -5, label: 'Quiet entry', detail: 'Because the crew entered quietly, the turbine starts later and the catwalk window is wider.' }],
+          consequence: { id: 'security-pulse', label: 'Security pulse transmitted', detail: 'The fast crossing wakes authentication systems ahead.', future: 'Makes forcing the next security door harder.' },
+          outcomes: {
+            clean: 'The crew crosses between turbine pulses. Only their footfalls reach the security wing ahead.',
+            costly: 'The turbine starts early. The lead clears the final gap as support drags the reserve out of the sweep.',
+            rough: 'The crew outruns the turning assembly by moments, triggering a security pulse beyond the hall.'
+          },
+          environment: { medium: 'gas', temperatureC: -12, element: 'ice' }, hazardIds: ['servo-cycle'],
+          reaction: { axis: 'energy', direction: 'high', label: 'An energetic lead keeps moving when the machinery wakes.' },
+          methods: [
+            { kind: 'capability', key: 'sprint', attribute: 'reflex', label: 'Outrun the servo cycle' },
+            { kind: 'capability', key: 'leap', attribute: 'agility', label: 'Clear the turbine gap' },
+            { kind: 'action', key: 'ambush', attribute: 'reflex', label: 'Close the interval in a burst' }
+          ] },
+        { id: 'underdeck', title: 'Enter the maintenance underdeck', description: 'Slow, cramped, and insulated from the main machinery.', difficulty: 61, pressure: 0, salvage: 1,
+          legacyAdjustments: [{ flag: 'coolant-bypass', difficulty: -4, label: 'Drained underdeck', detail: 'The opened coolant bypass has washed frozen fill out of this route.' }],
+          consequence: { id: 'maintenance-codes', label: 'Maintenance codes recovered', detail: 'Old service markings reveal part of the archive protocol.', future: 'Makes rebuilding the next security protocol easier.' },
+          outcomes: {
+            clean: 'The crew follows faded service marks beneath the turbine and copies a surviving maintenance code from the wall.',
+            costly: 'The underdeck narrows to a crawl. The lead forces a passage and still recovers a strip of maintenance notation.',
+            rough: 'The frozen fill gives way around the crew, but the collapse exposes an old maintenance code before they climb free.'
+          },
+          environment: { medium: 'gas', temperatureC: -6, element: 'metal' }, hazardIds: [],
+          reaction: { axis: 'curiosity', direction: 'low', label: 'A disciplined lead ignores branching service ducts.' },
+          methods: [
+            { kind: 'capability', key: 'burrow', attribute: 'strength', label: 'Open a route through frozen fill' },
+            { kind: 'trait', key: 'phasing', attribute: 'willpower', label: 'Pass through the service bulkhead' },
+            { kind: 'attribute', key: 'intelligence', secondary: 'manipulation', label: 'Trace the maintenance diagram' }
+          ] }
+      ]
+    },
+    {
+      id: 'archive-vestibule', title: 'Archive Vestibule', trackLabel: 'Vestibule', deck: 'SECURITY 01',
+      description: 'A sealed iris door waits behind a forest of dead authentication arms.',
+      arrival: 'The turbine noise dies behind the crew. A many-armed authentication rig unfolds from the wall and asks for credentials that vanished centuries ago.',
+      goal: 'Open the archive iris while preserving enough crew strength for the containment wing.',
+      destination: 'the Null Gallery inside archive security',
+      surveyFocus: 'the authentication arms, iris seam, and dormant security field',
+      relayChannels: ['vocal', 'display', 'telepathic'],
+      encounterHint: 'A small psychic distress pattern is repeating from inside the authentication rig.',
+      encounter: {
+        id: 'vestibule-hypnopet', creatureId: 'hypnopet-019', routeId: 'decode', archetype: 'trapped',
+        title: 'Trapped Signal-Mimic', disposition: 'confused and entangled',
+        description: 'A feral Hypnopet is caught between the rig’s moving authentication arms. Its panic is feeding false commands into the lock.',
+        concealment: 68, threat: 48
+      },
+      hazards: [
+        { id: 'countermeasure', label: 'Cognitive countermeasure', detail: 'The lock projects an obsolete interrogation pattern.', sense: 'sight', threshold: 72, special: 'psychic', strain: 1, pressure: 2 }
+      ],
+      routes: [
+        { id: 'decode', title: 'Wake the authentication rig', description: 'Reconstruct enough of the dead protocol to make the door open itself.', difficulty: 71, pressure: 0, salvage: 3,
+          legacyAdjustments: [{ flag: 'maintenance-codes', difficulty: -6, label: 'Recovered codes', detail: 'The underdeck markings supply the missing opening sequence.' }],
+          outcomes: {
+            clean: 'The rebuilt protocol ripples through the authentication arms. The iris recognizes a maintenance identity and opens without alarm.',
+            costly: 'The rig accepts the improvised sequence, but its interrogation pattern leaves the lead visibly shaken.',
+            rough: 'The crew floods the rig with contradictory credentials until the iris opens in self-defense.'
+          },
+          environment: { medium: 'gas', temperatureC: -4, element: 'psychic' }, hazardIds: ['countermeasure'],
+          reaction: { axis: 'curiosity', direction: 'high', label: 'A curious lead follows the machine\'s incomplete logic.' },
+          methods: [
+            { kind: 'attribute', key: 'intelligence', secondary: 'manipulation', label: 'Rebuild the protocol' },
+            { kind: 'action', key: 'beam', attribute: 'intelligence', label: 'Feed the optical reader' },
+            { kind: 'action', key: 'snare', attribute: 'manipulation', label: 'Move the authentication arms remotely' }
+          ] },
+        { id: 'breach', title: 'Open the pressure seam', description: 'Ignore the lock and force the iris along its oldest fracture.', difficulty: 72, pressure: 2, salvage: 1,
+          legacyAdjustments: [{ flag: 'security-pulse', difficulty: 5, label: 'Alerted lock', detail: 'The turbine hall’s security pulse has fully engaged the locking collar.' }],
+          outcomes: {
+            clean: 'The lead finds the old fracture and opens the iris before the locking collar can answer.',
+            costly: 'The seam opens one grinding segment at a time, showering the crew in brittle alloy.',
+            rough: 'The iris tears sideways. Alarms stutter through the security wing as the crew forces itself through.'
+          },
+          environment: { medium: 'gas', temperatureC: -9, element: 'metal' }, hazardIds: [],
+          reaction: { axis: 'boldness', direction: 'high', label: 'A bold lead keeps force on the seam as it shifts.' },
+          methods: [
+            { kind: 'action', key: 'crush', attribute: 'strength', label: 'Crush the locking collar' },
+            { kind: 'action', key: 'rake', attribute: 'agility', label: 'Cut along the fracture' },
+            { kind: 'trait', key: 'phasing', attribute: 'willpower', label: 'Cross the iris and release it inside' }
+          ] }
+      ]
+    },
+    {
+      id: 'null-gallery', title: 'The Null Gallery', trackLabel: 'Null Gallery', deck: 'SECURITY 02',
+      description: 'The shortest way to the archive crosses a gallery open to vacuum and Grimedes-dark containment residue.',
+      arrival: 'Beyond the iris, loose fragments hang motionless in a chamber open to the stars. A territorial cry moves through the hull instead of the air.',
+      goal: 'Reach the primary archive chamber without losing a crew member to the broken hull.',
+      destination: 'the Nemesis Index chamber at the end of the security wing',
+      surveyFocus: 'the exposed centerline, inner conduit, and drifting containment residue',
+      relayChannels: ['display', 'telepathic'],
+      encounterHint: 'Fresh scoring around the conduit mouth marks the boundary of a territorial void-dweller.',
+      encounter: {
+        id: 'gallery-ectoghoul', creatureId: 'ectoghoul-117', routeId: 'conduit', archetype: 'territorial',
+        title: 'Territorial Ectoghoul', disposition: 'watchful and defensive',
+        description: 'A native Ectoghoul has claimed the shielded conduit as shelter. It wants distance, not prey, but it will defend the only pressurized route.',
+        concealment: 74, threat: 70
+      },
+      hazards: [
+        { id: 'void-shear', label: 'Local gravity shear', detail: 'The centerline is slowly pulling loose material toward the outer hull.', sense: 'sight', threshold: 78, special: 'void-sense', strain: 2, pressure: 1 }
+      ],
+      routes: [
+        { id: 'outer-hull', title: 'Cross the exposed hull', description: 'Fast and direct, with nothing between the crew and vacuum.', difficulty: 73, pressure: 1, salvage: 3,
+          environment: { medium: 'vacuum', temperatureC: -35, element: 'dark' }, hazardIds: ['void-shear'],
+          reaction: { axis: 'sociability', direction: 'high', label: 'A social lead stays close enough to relay corrections.' },
+          methods: [
+            { kind: 'capability', key: 'flight', attribute: 'agility', label: 'Fly the broken centerline' },
+            { kind: 'trait', key: 'phasing', attribute: 'willpower', label: 'Follow the intact inner skin' },
+            { kind: 'action', key: 'ward', attribute: 'resilience', label: 'Carry a protected crossing bubble' }
+          ] },
+        { id: 'conduit', title: 'Crawl the shielded conduit', description: 'A longer route with intact atmosphere and no room to turn around.', difficulty: 67, pressure: 1, salvage: 1,
+          environment: { medium: 'gas', temperatureC: -18, element: 'ice' }, hazardIds: [],
+          reaction: { axis: 'sociability', direction: 'low', label: 'An independent lead works ahead without regrouping.' },
+          methods: [
+            { kind: 'attribute', key: 'manipulation', secondary: 'intelligence', label: 'Disassemble the conduit braces' },
+            { kind: 'action', key: 'snare', attribute: 'manipulation', label: 'Pull the crew through in sequence' },
+            { kind: 'capability', key: 'climb', attribute: 'endurance', label: 'Climb the conduit spine' }
+          ] }
+      ]
+    },
+    {
+      id: 'nemesis-index', title: 'The Nemesis Index', trackLabel: 'Nemesis Index', deck: 'OBJECTIVE', objective: true,
+      description: 'The archive hangs in a failed stasis field. Its blackbox contains the only surviving index of the plague work done here.',
+      goal: 'Secure the Nemesis Index—the mission succeeds if this record leaves the annex.',
+      destination: 'the extraction fork, with optional access to the deeper Core Reservoir',
+      surveyFocus: 'the stasis membrane, blackbox cradle, and contaminant layer',
+      relayChannels: ['vocal', 'display', 'vibration', 'telepathic'],
+      hazards: [
+        { id: 'plague-dust', label: 'Dormant plague dust', detail: 'Opening the field will disturb a sealed contaminant layer.', sense: 'smell', threshold: 64, special: 'psychic', strain: 2, pressure: 1 }
+      ],
+      routes: [
+        { id: 'stabilize', title: 'Stabilize the archive', description: 'Preserve the chamber and recover every readable index plate.', difficulty: 76, pressure: 1, salvage: 5,
+          environment: { medium: 'gas', temperatureC: -5, element: 'chemical' }, hazardIds: ['plague-dust'],
+          reaction: { axis: 'aggression', direction: 'low', label: 'A gentle lead avoids rupturing the stasis membrane.' },
+          methods: [
+            { kind: 'action', key: 'ward', attribute: 'willpower', label: 'Contain the collapsing field' },
+            { kind: 'action', key: 'mend', attribute: 'intelligence', label: 'Repair the stasis web' },
+            { kind: 'attribute', key: 'intelligence', secondary: 'manipulation', label: 'Rebuild the index cradle' }
+          ] },
+        { id: 'blackbox', title: 'Pull the archive blackbox', description: 'Take the essential index and let the rest of the chamber collapse.', difficulty: 70, pressure: 3, salvage: 3,
+          environment: { medium: 'gas', temperatureC: -5, element: 'chemical' }, hazardIds: ['plague-dust'],
+          reaction: { axis: 'boldness', direction: 'high', label: 'A bold lead holds position through the collapse.' },
+          methods: [
+            { kind: 'action', key: 'snare', attribute: 'strength', label: 'Pull the blackbox free' },
+            { kind: 'action', key: 'crush', attribute: 'strength', label: 'Break the cradle around it' },
+            { kind: 'attribute', key: 'manipulation', secondary: 'reflex', label: 'Release the live catches by hand' }
+          ] }
+      ]
+    },
+    {
+      id: 'core-reservoir', title: 'Core Reservoir', trackLabel: 'Core Reservoir', deck: 'OPTIONAL 01', optional: true,
+      description: 'The objective is secure. Below it, a reservoir still holds a century of captured Generator charge.',
+      goal: 'Recover optional Generator charge without sacrificing the secured Index or the remaining crew.',
+      destination: 'the final Generator Spine or the extraction route',
+      surveyFocus: 'the charged surface, collector valves, and submerged storage cells',
+      relayChannels: ['vibration', 'telepathic'],
+      hazards: [
+        { id: 'charge-bloom', label: 'Charge bloom', detail: 'The reservoir discharges when its surface is broken.', sense: 'hearing', threshold: 68, special: 'electroreception', strain: 2, pressure: 2 }
+      ],
+      routes: [
+        { id: 'harvest', title: 'Harvest the surface charge', description: 'Work from the rim and bleed the reservoir slowly.', difficulty: 74, pressure: 1, salvage: 6,
+          environment: { medium: 'gas', temperatureC: -8, element: 'electric' }, hazardIds: ['charge-bloom'],
+          reaction: { axis: 'energy', direction: 'low', label: 'A patient lead waits between discharge cycles.' },
+          methods: [
+            { kind: 'action', key: 'ward', attribute: 'resilience', label: 'Screen each discharge' },
+            { kind: 'attribute', key: 'manipulation', secondary: 'intelligence', label: 'Bleed the collector valves' },
+            { kind: 'trait', key: 'resistant', attribute: 'resilience', label: 'Work inside the contaminated rim' }
+          ] },
+        { id: 'dive', title: 'Dive for the intact cell', description: 'The richest cell is below the charged liquid surface.', difficulty: 80, pressure: 2, salvage: 9,
+          environment: { medium: 'liquid', temperatureC: -8, element: 'electric' }, hazardIds: ['charge-bloom'],
+          reaction: { axis: 'boldness', direction: 'high', label: 'A bold lead commits before the bloom peaks.' },
+          methods: [
+            { kind: 'capability', key: 'swim', attribute: 'resilience', label: 'Dive through the charged layer' },
+            { kind: 'action', key: 'snare', attribute: 'strength', label: 'Retrieve the cell from the rim' },
+            { kind: 'action', key: 'spray', attribute: 'intelligence', label: 'Displace the surface charge' }
+          ] }
+      ]
+    },
+    {
+      id: 'generator-spine', title: 'Generator Spine', trackLabel: 'Generator Spine', deck: 'OPTIONAL 02', optional: true,
+      description: 'One last chamber: concentric machinery turning around a view of the white planet below.',
+      goal: 'Take the final recovery prize and leave the annex before its pressure reaches collapse.',
+      destination: 'the surface extraction lift—this is the last crossing',
+      surveyFocus: 'the closing rings, control core, and exposed memory spindle',
+      relayChannels: ['display', 'telepathic'],
+      hazards: [
+        { id: 'ring-closure', label: 'Asymmetric ring closure', detail: 'The inner ring locks three seconds before the outer assembly.', sense: 'sight', threshold: 76, special: 'foresight', strain: 2, pressure: 2 }
+      ],
+      routes: [
+        { id: 'align', title: 'Realign the spine', description: 'Stop the rings and recover a complete Vallerii control core.', difficulty: 82, pressure: 2, salvage: 10,
+          environment: { medium: 'vacuum', temperatureC: 38, element: 'light' }, hazardIds: ['ring-closure'],
+          reaction: { axis: 'sociability', direction: 'high', label: 'A social lead keeps every brace synchronized.' },
+          methods: [
+            { kind: 'action', key: 'snare', attribute: 'strength', label: 'Hold the rings in alignment' },
+            { kind: 'attribute', key: 'manipulation', secondary: 'intelligence', label: 'Reset the core governors' },
+            { kind: 'trait', key: 'anchored', attribute: 'strength', label: 'Brace against the turning spine' }
+          ] },
+        { id: 'closure', title: 'Take the closing interval', description: 'Abandon the machinery and snatch its exposed memory spindle.', difficulty: 78, pressure: 3, salvage: 8,
+          environment: { medium: 'vacuum', temperatureC: 38, element: 'light' }, hazardIds: ['ring-closure'],
+          reaction: { axis: 'energy', direction: 'high', label: 'An energetic lead commits to the full interval.' },
+          methods: [
+            { kind: 'capability', key: 'sprint', attribute: 'reflex', label: 'Run the closing ring' },
+            { kind: 'capability', key: 'leap', attribute: 'agility', label: 'Leap through the inner assembly' },
+            { kind: 'action', key: 'ambush', attribute: 'reflex', label: 'Cross in a single burst' }
+          ] }
+      ]
+    }
+  ]
+};
+
+export const ATTRIBUTE_LABELS = {
+  strength: 'Strength', vitality: 'Vitality', endurance: 'Endurance', agility: 'Agility', reflex: 'Reflex',
+  intelligence: 'Intelligence', willpower: 'Willpower', instinct: 'Instinct', charisma: 'Charisma', resilience: 'Resilience', manipulation: 'Manipulation'
+};
+
+export const CAPABILITY_LABELS = {
+  flight: 'Flight', swim: 'Swim', burrow: 'Burrow', climb: 'Climb', sprint: 'Sprint', leap: 'Leap', manipulation: 'Manipulation'
+};

--- a/my-app/src/components/games/longReturn/longReturnEngine.js
+++ b/my-app/src/components/games/longReturn/longReturnEngine.js
@@ -1,0 +1,500 @@
+import effectiveness from '../../../json/typeEffectivenessMatrix.json';
+
+const titleCase = (value) => value ? value.charAt(0).toUpperCase() + value.slice(1) : '';
+
+export function readinessState(strain = 0) {
+  if (strain >= 6) return { id: 'spent', label: 'Spent', detail: 'Cannot scout, lead, or support. Must be protected during extraction.', scorePenalty: 100, supportPenalty: 100 };
+  if (strain >= 5) return { id: 'critical', label: 'Critical', detail: 'Cannot scout. Only 1 energy remains.', scorePenalty: 9, supportPenalty: 4 };
+  if (strain >= 3) return { id: 'worn', label: 'Worn', detail: 'Reduced performance until the expedition ends.', scorePenalty: 4, supportPenalty: 2 };
+  return { id: 'ready', label: 'Ready', detail: 'All expedition roles are available.', scorePenalty: 0, supportPenalty: 0 };
+}
+
+export function instabilityState(value = 0) {
+  if (value >= 10) return { id: 'collapse', label: 'Collapse', detail: 'Forced extraction.' };
+  if (value >= 9) return { id: 'imminent', label: 'Collapse imminent', detail: 'Only 1 stability remains.' };
+  if (value >= 6) return { id: 'failing', label: 'Failing', detail: 'The annex is actively coming apart.' };
+  if (value >= 3) return { id: 'shifting', label: 'Shifting', detail: 'Dormant systems are waking and routes are becoming less stable.' };
+  return { id: 'stable', label: 'Stable', detail: 'The crew still controls the pace.' };
+}
+
+export function applyMissionMemory(scene, flags = []) {
+  if (!scene) return scene;
+  return {
+    ...scene,
+    routes: scene.routes.map((route) => {
+      const activeEffects = (route.legacyAdjustments || []).filter((effect) => flags.includes(effect.flag));
+      const difficultyChange = activeEffects.reduce((sum, effect) => sum + (effect.difficulty || 0), 0);
+      return {
+        ...route,
+        originalDifficulty: route.difficulty,
+        difficulty: Math.max(1, route.difficulty + difficultyChange),
+        activeEffects
+      };
+    })
+  };
+}
+
+export function scoutProfile(scene, creature) {
+  const senses = creature.physiology.senses;
+  const bestSense = Math.max(senses.sight || 0, senses.hearing || 0, senses.smell || 0);
+  const weightPenalty = Math.min(18, Math.round((creature.physiology.weightKg || 0) / 30));
+  const detect = Math.round(bestSense * .65 + creature.attributes.instinct * .35 + ((senses.special || []).length ? 8 : 0));
+  const stealth = Math.round(creature.attributes.agility * .32 + creature.attributes.reflex * .24 + creature.physiology.capabilities.sprint * .2 + (creature.traits.includes('stealthy') ? 22 : 0) - weightPenalty);
+  const hold = Math.round(creature.attributes.resilience * .32 + creature.attributes.vitality * .22 + creature.attributes.strength * .22 + (creature.traits.includes('armored') ? 12 : 0) + (creature.traits.includes('anchored') ? 10 : 0));
+  const contact = Math.round(creature.attributes.charisma * .35 + creature.temperament.sociability * .25 + creature.attributes.instinct * .15 + (creature.traits.includes('healing') ? 15 : 0) + (creature.physiology.communication.includes('telepathic') ? 10 : 0));
+  const channel = relayChannel(scene, creature);
+  const strongest = [['stealth', stealth], ['hold', hold], ['contact', contact]].sort((a, b) => b[1] - a[1])[0][0];
+  const roles = {
+    stealth: { role: 'Quiet scout', strength: 'Best chance to observe and escape without contact.', risk: 'Vulnerable if concealment fails.' },
+    hold: { role: 'Defensive scout', strength: 'Can hold position safely if confronted.', risk: 'More likely to be noticed.' },
+    contact: { role: 'Contact scout', strength: 'Best chance to calm, communicate with, or aid a native.', risk: 'May lack the speed or protection to escape a charge.' }
+  };
+  return { detect, stealth, hold, contact, channel, ...roles[strongest] };
+}
+
+export function encounterOutlook(scene, creature) {
+  if (!scene.encounter) return null;
+  const profile = scoutProfile(scene, creature);
+  const awareness = profile.detect - scene.encounter.concealment;
+  const concealment = profile.stealth - scene.encounter.threat;
+  const posture = awareness >= 8 && concealment >= -12
+    ? 'scout-first'
+    : concealment <= -28
+      ? 'native-first'
+      : 'mutual';
+  return {
+    ...profile,
+    posture,
+    label: posture === 'scout-first' ? 'Likely to notice it first' : posture === 'native-first' ? 'At risk of being cornered' : 'Contact could go either way',
+    surpriseStrain: posture === 'native-first' ? 1 : 0
+  };
+}
+
+export function encounterOptions(scene, scout, crew, mode = 'scout', informed = false) {
+  if (!scene.encounter) return [];
+  const outlook = scout ? encounterOutlook(scene, scout) : null;
+  const medic = crew.find((member) => member.traits.includes('healing') || member.abilities.some((ability) => ability.action === 'mend'));
+  const baseSurprise = mode === 'group' && !informed ? 1 : outlook ? outlook.surpriseStrain : 0;
+  const archetype = scene.encounter.archetype || 'injured';
+
+  if (archetype === 'territorial') {
+    if (mode === 'group') return [
+      { id: 'signal-space', label: 'Signal peaceful intent', summary: 'Use communication and patience to gain passage without challenging its shelter.', crewStrain: baseSurprise, instability: informed ? 0 : 1, companion: false, resolution: 'cleared', recommended: true },
+      { id: 'distract', label: 'Draw it away from the conduit', summary: 'Create noise elsewhere. The route opens, but the annex becomes less stable.', crewStrain: baseSurprise, instability: 2, companion: false, resolution: 'cleared' },
+      { id: 'detour', label: 'Yield the territory', summary: 'Back away and reconsider the exposed hull route.', crewStrain: baseSurprise, instability: informed ? 0 : 1, companion: false, resolution: 'detour' }
+    ];
+    const canSignal = outlook && (outlook.contact >= 62 || outlook.channel);
+    return [
+      ...(canSignal ? [{ id: 'signal-space', label: 'Signal peaceful intent', summary: 'Show that the scout wants passage, not its shelter.', scoutStrain: baseSurprise, instability: 0, companion: false, resolution: 'cleared', recommended: true }] : []),
+      { id: 'withdraw', label: 'Withdraw and report', summary: 'Leave its boundary intact and return with a warning for the crew.', scoutStrain: baseSurprise + (outlook && outlook.stealth >= 62 ? 0 : 1), instability: 0, companion: false, resolution: 'unresolved', recommended: !canSignal },
+      { id: 'challenge', label: 'Challenge its claim', summary: 'Force the native out alone. A defensive scout fares better than a quiet one.', scoutStrain: baseSurprise + (outlook && outlook.hold >= 62 ? 1 : 2), instability: 2, companion: false, resolution: 'cleared' }
+    ];
+  }
+
+  if (archetype === 'trapped') {
+    if (mode === 'group') return [
+      { id: 'free-native', label: 'Stop and free it', summary: 'Take time to release the native and quiet the false commands entering the lock.', crewStrain: baseSurprise, instability: 1, companion: false, resolution: 'cleared', recommended: true },
+      { id: 'pin-rig', label: 'Pin the arms and pass', summary: 'Protect the crew and leave the native trapped. Fast, but physically demanding.', crewStrain: baseSurprise + 1, instability: 0, companion: false, resolution: 'cleared' },
+      { id: 'detour', label: 'Leave the rig alone', summary: 'Back away from the decode route and reconsider the pressure seam.', crewStrain: baseSurprise, instability: informed ? 0 : 1, companion: false, resolution: 'detour' }
+    ];
+    const precise = outlook && (outlook.contact >= 62 || outlook.detect >= 72);
+    return [
+      { id: 'release', label: 'Release it from the arms', summary: 'Use empathy or careful observation to stop its panic without calling the crew.', scoutStrain: baseSurprise + (precise ? 0 : 1), instability: precise ? 0 : 1, companion: false, resolution: 'cleared', recommended: precise },
+      { id: 'mark', label: 'Mark the safe controls and return', summary: 'Do not intervene alone. Give the full crew what it needs to approach safely.', scoutStrain: baseSurprise, instability: 0, companion: false, resolution: 'unresolved', recommended: !precise },
+      { id: 'force-arms', label: 'Force the arms apart', summary: 'Resolve the trap through strength. It works, but the rig records the intrusion.', scoutStrain: baseSurprise + (outlook && outlook.hold >= 62 ? 1 : 2), instability: 2, companion: false, resolution: 'cleared' }
+    ];
+  }
+
+  if (mode === 'group') {
+    const options = [];
+    if (medic) options.push({ id: 'aid', label: `${medic.species} treats the injury`, summary: 'Help the native and attempt a temporary field bond.', crewStrain: baseSurprise, instability: informed ? 0 : 1, companion: true, resolution: 'befriended', recommended: true });
+    options.push({ id: 'drive-off', label: 'Drive it out of the underdeck', summary: 'Open the route by force. The crew stays together, but the annex hears it.', crewStrain: baseSurprise + 1, instability: 2, companion: false, resolution: 'cleared' });
+    options.push({ id: 'detour', label: 'Back out and take the catwalk', summary: 'Avoid contact and reconsider the other route.', crewStrain: baseSurprise, instability: informed ? 0 : 1, companion: false, resolution: 'detour' });
+    return options;
+  }
+
+  const directMedic = scout && (scout.traits.includes('healing') || scout.abilities.some((ability) => ability.action === 'mend'));
+  const options = [];
+  if (directMedic) {
+    options.push({ id: 'aid', label: 'Treat the injury', summary: 'Use the scout’s healing ability to establish trust without calling the crew.', scoutStrain: baseSurprise, instability: 0, companion: true, resolution: 'befriended', recommended: true });
+  } else if (medic && outlook && outlook.channel) {
+    options.push({ id: 'call-medic', label: `Call ${medic.species} to help`, summary: `Use ${outlook.channel} to summon help. The delay destabilizes the annex, but may earn an ally.`, scoutStrain: baseSurprise, instability: 1, companion: true, resolution: 'befriended', recommended: true });
+  } else if (medic) {
+    options.push({ id: 'return-for-medic', label: `Return for ${medic.species}`, summary: 'Leave and physically guide the medic back. Safe, but tiring and slow.', scoutStrain: baseSurprise + 1, instability: 1, companion: true, resolution: 'befriended', recommended: true });
+  }
+  const escapeCost = baseSurprise + (outlook && outlook.stealth >= 62 ? 0 : 1);
+  options.push({ id: 'withdraw', label: 'Withdraw and report', summary: 'Preserve the encounter for the full crew. The route remains occupied.', scoutStrain: escapeCost, instability: 0, companion: false, resolution: 'unresolved' });
+  const holdCost = baseSurprise + (outlook && outlook.hold >= 62 ? 1 : 2);
+  options.push({ id: 'hold', label: 'Hold ground and drive it away', summary: 'Resolve the encounter alone through force and presence.', scoutStrain: holdCost, instability: outlook && outlook.hold >= 62 ? 1 : 2, companion: false, resolution: 'cleared' });
+  return options;
+}
+
+export function getCreatureValue(creature, key) {
+  if (key === 'manipulation') return creature.physiology.capabilities.manipulation;
+  return creature.attributes[key] || 0;
+}
+
+export function canRelay(scene, creature) {
+  return !!relayChannel(scene, creature);
+}
+
+export function relayChannel(scene, creature) {
+  const channels = creature.physiology.communication || [];
+  if (channels.includes('telepathic')) return 'telepathic';
+  return channels.find((channel) => scene.relayChannels.includes(channel)) || null;
+}
+
+export function scanScene(scene, creature) {
+  const relay = canRelay(scene, creature);
+  const hazards = scene.hazards.map((hazard) => {
+    const special = creature.physiology.senses.special || [];
+    const sensed = (creature.physiology.senses[hazard.sense] || 0) >= hazard.threshold || special.includes(hazard.special);
+    return { ...hazard, sensed, revealed: sensed && relay };
+  });
+  return {
+    relay,
+    hazards,
+    revealedIds: hazards.filter((hazard) => hazard.revealed).map((hazard) => hazard.id),
+    trappedCount: hazards.filter((hazard) => hazard.sensed && !hazard.revealed).length
+  };
+}
+
+export function scanReport(scene, creature, scan) {
+  if (scan.mode === 'blind') {
+    return {
+      outcome: 'blind',
+      title: 'No field scan performed',
+      narrative: `The crew held at the threshold of ${scene.title} and committed no scout to ${scene.surveyFocus}.`,
+      finding: `${scene.hazards.length} possible signal${scene.hazards.length === 1 ? '' : 's'} ${scene.hazards.length === 1 ? 'remains' : 'remain'} unresolved. No energy was spent, but route intelligence is incomplete.`,
+      decision: 'Every route remains available. An unresolved signal may consume extra crew energy and annex stability if its route is chosen.',
+      strainCost: 0,
+      channel: null,
+      revealed: [],
+      trapped: [],
+      affectedRoutes: []
+    };
+  }
+
+  if (scan.mode === 'debrief') {
+    const revealed = scan.hazards.filter((hazard) => hazard.revealed);
+    const affectedRoutes = scene.routes.filter((route) => revealed.some((hazard) => route.hazardIds.includes(hazard.id)));
+    return {
+      outcome: revealed.length ? 'revealed' : 'quiet',
+      title: revealed.length ? 'Scout returned with actionable intelligence' : 'Scout returned—no danger identified',
+      narrative: `${creature.species} could not report remotely, so it retraced the route and delivered its observations in person.`,
+      finding: revealed.length ? `${revealed.length} hazard signature${revealed.length === 1 ? '' : 's'} became usable after the scout returned.` : 'The scout returned safely but found no danger its senses could identify.',
+      decision: revealed.length ? `${affectedRoutes.map((route) => route.title).join(' and ')} ${affectedRoutes.length === 1 ? 'is now marked' : 'are now marked'} with known danger.` : 'Compare the routes normally. Unknown danger may still remain.',
+      strainCost: 2,
+      channel: 'physical return',
+      revealed,
+      trapped: [],
+      affectedRoutes
+    };
+  }
+
+  const revealed = scan.hazards.filter((hazard) => hazard.revealed);
+  const trapped = scan.hazards.filter((hazard) => hazard.sensed && !hazard.revealed);
+  const affectedRoutes = scene.routes.filter((route) => revealed.some((hazard) => route.hazardIds.includes(hazard.id)));
+  const channel = relayChannel(scene, creature);
+
+  if (revealed.length) {
+    return {
+      outcome: 'revealed',
+      title: 'Actionable intelligence received',
+      narrative: `${creature.species} entered the threshold and surveyed ${scene.surveyFocus}. Its senses found a danger the unaided crew could not confirm.`,
+      finding: `${revealed.length} hazard signature${revealed.length === 1 ? '' : 's'} reached command over ${channel}.`,
+      decision: `${affectedRoutes.map((route) => route.title).join(' and ')} ${affectedRoutes.length === 1 ? 'is now marked' : 'are now marked'} with the revealed hazard. You can avoid it or prepare the right lead for it.`,
+      strainCost: 1,
+      channel,
+      revealed,
+      trapped,
+      affectedRoutes
+    };
+  }
+
+  if (trapped.length) {
+    return {
+      outcome: 'trapped',
+      title: 'Signal detected—report lost',
+      narrative: `${creature.species} surveyed ${scene.surveyFocus} and reacted to something in the field, but its ${creature.physiology.communication.join(' / ') || 'lack of communication'} could not cross this chamber.`,
+      finding: `${trapped.length} sensed signature${trapped.length === 1 ? ' stayed' : 's stayed'} with the scout. Command cannot use details it never received.`,
+      decision: 'The affected route still shows an unresolved signal. Choosing it may expose the crew to surprise consequences.',
+      strainCost: 1,
+      channel: null,
+      revealed,
+      trapped,
+      affectedRoutes
+    };
+  }
+
+  if (!channel) {
+    return {
+      outcome: 'unrelayed',
+      title: 'Scan complete—no command link',
+      narrative: `${creature.species} surveyed ${scene.surveyFocus}, but none of its communication channels could carry a field report across ${scene.title}.`,
+      finding: 'The scout showed no detectable reaction to a hazard, but command cannot treat silence as a reliable all-clear.',
+      decision: 'Route intelligence remains incomplete. Any unresolved signal still carries surprise consequences if you choose its route.',
+      strainCost: 1,
+      channel: null,
+      revealed,
+      trapped,
+      affectedRoutes
+    };
+  }
+
+  return {
+    outcome: 'quiet',
+    title: 'Scan complete—no actionable signature',
+    narrative: `${creature.species} surveyed ${scene.surveyFocus} and successfully checked back with command${channel ? ` over ${channel}` : ''}.`,
+    finding: 'The scout found nothing its available senses could identify as an actionable hazard. That is a limited result, not proof that every route is safe.',
+    decision: 'Compare the routes normally. Unresolved signals remain unresolved because the scout may not possess the sense needed to identify them.',
+    strainCost: 1,
+    channel,
+    revealed,
+    trapped,
+    affectedRoutes
+  };
+}
+
+export function methodOptions(creature, route, spentAbilities = []) {
+  const options = [];
+  route.methods.forEach((method, methodIndex) => {
+    if (method.kind === 'capability') {
+      const value = creature.physiology.capabilities[method.key] || 0;
+      if (value > 0) options.push({ ...method, id: `${methodIndex}-${method.kind}-${method.key}`, sourceValue: value });
+    } else if (method.kind === 'attribute') {
+      options.push({ ...method, id: `${methodIndex}-${method.kind}-${method.key}`, sourceValue: getCreatureValue(creature, method.key) });
+    } else if (method.kind === 'trait') {
+      if (creature.traits.includes(method.key)) options.push({ ...method, id: `${methodIndex}-${method.kind}-${method.key}`, sourceValue: 100 });
+    } else if (method.kind === 'action') {
+      creature.abilities
+        .filter((ability) => ability.action === method.key && !spentAbilities.includes(ability.id))
+        .forEach((ability) => options.push({
+          ...method,
+          id: `${methodIndex}-${method.kind}-${ability.id}`,
+          ability,
+          abilityId: ability.id,
+          sourceValue: ability.intensity,
+          label: `${ability.name} — ${method.label}`
+        }));
+    }
+  });
+
+  if (!options.length) {
+    options.push({
+      id: 'fallback-careful-advance', kind: 'fallback', key: 'instinct', attribute: 'resilience',
+      label: 'Careful advance', sourceValue: creature.attributes.instinct
+    });
+  }
+  return options;
+}
+
+export function methodScore(creature, method) {
+  const attribute = getCreatureValue(creature, method.attribute);
+  if (method.kind === 'capability') return Math.round(method.sourceValue * 0.62 + attribute * 0.23 + creature.attributes.endurance * 0.15);
+  if (method.kind === 'action') return Math.round(method.sourceValue * 0.68 + attribute * 0.2 + creature.physiology.capabilities.manipulation * 0.12);
+  if (method.kind === 'trait') return Math.round(68 + attribute * 0.22);
+  if (method.kind === 'attribute') return Math.round(method.sourceValue * 0.72 + getCreatureValue(creature, method.secondary) * 0.28);
+  return Math.round(creature.attributes.instinct * 0.55 + creature.attributes.resilience * 0.45 - 12);
+}
+
+export function methodScoreInputs(creature, method) {
+  if (method.kind === 'capability') {
+    return [
+      { label: titleCase(method.key), value: method.sourceValue, weight: 62 },
+      { label: titleCase(method.attribute), value: getCreatureValue(creature, method.attribute), weight: 23 },
+      { label: 'Endurance', value: creature.attributes.endurance, weight: 15 }
+    ];
+  }
+  if (method.kind === 'action') {
+    return [
+      { label: 'Ability intensity', value: method.sourceValue, weight: 68 },
+      { label: titleCase(method.attribute), value: getCreatureValue(creature, method.attribute), weight: 20 },
+      { label: 'Manipulation', value: creature.physiology.capabilities.manipulation, weight: 12 }
+    ];
+  }
+  if (method.kind === 'trait') {
+    return [
+      { label: 'Trait baseline', value: 68, weight: null },
+      { label: titleCase(method.attribute), value: getCreatureValue(creature, method.attribute), weight: 22 }
+    ];
+  }
+  if (method.kind === 'attribute') {
+    return [
+      { label: titleCase(method.key), value: method.sourceValue, weight: 72 },
+      { label: titleCase(method.secondary), value: getCreatureValue(creature, method.secondary), weight: 28 }
+    ];
+  }
+  return [
+    { label: 'Instinct', value: creature.attributes.instinct, weight: 55 },
+    { label: 'Resilience', value: creature.attributes.resilience, weight: 45 },
+    { label: 'Fallback penalty', value: -12, weight: null }
+  ];
+}
+
+export function outcomeForMargin(margin) {
+  if (margin >= 14) return { quality: 'clean', label: 'Strong advantage', baseLeadStrain: 0, baseSupportStrain: 0, explanation: 'The team clears the target comfortably. Expect a clean passage before environmental or hidden consequences.' };
+  if (margin >= 0) return { quality: 'costly', label: 'Narrow advantage', baseLeadStrain: 1, baseSupportStrain: 0, explanation: 'The team clears the target, but only narrowly. Expect the lead to spend 1 energy.' };
+  if (margin >= -14) return { quality: 'rough', label: 'Disadvantaged', baseLeadStrain: 2, baseSupportStrain: margin < -8 ? 1 : 0, explanation: 'The team falls short of the target. The route remains passable, but support must intervene and more energy is spent.' };
+  return { quality: 'critical', label: 'Severe mismatch', baseLeadStrain: 3, baseSupportStrain: 1, explanation: 'The method is far below the target. The crew can force passage, but the cost is severe.' };
+}
+
+export function decisionForecast({ route, lead, support, method, scan, leadLoad = 0, supportLoad = 0 }) {
+  const leadReadiness = readinessState(leadLoad);
+  const supportReadiness = readinessState(supportLoad);
+  const leadScore = Math.max(0, methodScore(lead, method) - leadReadiness.scorePenalty);
+  const supportBonus = support ? Math.max(0, supportScore(support, method) - supportReadiness.supportPenalty) : 0;
+  const teamScore = leadScore + supportBonus;
+  const margin = teamScore - route.difficulty;
+  const outcome = outcomeForMargin(margin);
+  const environment = environmentConsequences(lead, route.environment);
+  const naturalReaction = reactionMatches(lead, route.reaction);
+  const unresolvedHazards = scan
+    ? route.hazardIds.filter((id) => !scan.revealedIds.includes(id))
+    : [...route.hazardIds];
+  return {
+    leadScore,
+    supportBonus,
+    teamScore,
+    difficulty: route.difficulty,
+    margin,
+    ...outcome,
+    environment,
+    naturalReaction,
+    unresolvedHazards,
+    readiness: { lead: leadReadiness, support: supportReadiness },
+    inputs: methodScoreInputs(lead, method)
+  };
+}
+
+export function supportScore(creature, method) {
+  const values = [creature.attributes.intelligence, creature.attributes.instinct, creature.physiology.capabilities.manipulation];
+  let score = Math.round(Math.max(...values) / 12);
+  if (creature.traits.includes('protective') || creature.traits.includes('inspiring')) score += 1;
+  if (method.kind === 'action' && method.key === 'mend' && creature.traits.includes('healing')) score += 2;
+  return Math.min(10, score);
+}
+
+export function reactionMatches(creature, reaction) {
+  const value = creature.temperament[reaction.axis];
+  return reaction.direction === 'high' ? value >= 56 : value <= 44;
+}
+
+export function exposureMultiplier(creature, element) {
+  if (!element) return 1;
+  const row = effectiveness[titleCase(element)];
+  if (!row) return 1;
+  const entries = Object.entries(creature.element.affinities);
+  const totalWeight = entries.reduce((sum, [, weight]) => sum + weight, 0);
+  return entries.reduce((sum, [key, weight]) => sum + (row[titleCase(key)] == null ? 1 : row[titleCase(key)]) * weight, 0) / totalWeight;
+}
+
+export function environmentConsequences(creature, environment) {
+  let strain = 0;
+  const notes = [];
+  const physiology = creature.physiology;
+  if (!physiology.ambientMedia.includes(environment.medium)) {
+    strain += 2;
+    notes.push(`cannot safely remain in ${environment.medium}`);
+  } else if (environment.medium === 'liquid' && physiology.breathes.length > 0 && !physiology.breathes.includes('liquid')) {
+    strain += 1;
+    notes.push('must cross the liquid without breathing');
+  }
+  if (environment.temperatureC < physiology.temperatureC.min || environment.temperatureC > physiology.temperatureC.max) {
+    strain += 1;
+    notes.push('operates outside its normal temperature band');
+  }
+  const multiplier = exposureMultiplier(creature, environment.element);
+  if (multiplier >= 1.75) {
+    strain += 2;
+    notes.push(`is highly exposed to ${titleCase(environment.element)}`);
+  } else if (multiplier >= 1.35) {
+    strain += 1;
+    notes.push(`is vulnerable to ${titleCase(environment.element)}`);
+  } else if (multiplier <= 0.5) {
+    notes.push(`is naturally well-suited to ${titleCase(environment.element)} exposure`);
+  }
+  if (creature.traits.includes('resistant') && strain > 0) {
+    strain -= 1;
+    notes.push('resistance absorbs one exposure consequence');
+  }
+  return { strain, notes, multiplier };
+}
+
+export function resolveScene({ scene, route, lead, support, method, scan, useCommand, leadLoad = 0, supportLoad = 0 }) {
+  const leadReadiness = readinessState(leadLoad);
+  const supportReadiness = readinessState(supportLoad);
+  const rawMethodScore = Math.max(0, methodScore(lead, method) - leadReadiness.scorePenalty);
+  const supportBonus = Math.max(0, supportScore(support, method) - supportReadiness.supportPenalty);
+  const totalScore = rawMethodScore + supportBonus;
+  const margin = totalScore - route.difficulty;
+  let leadStrain = margin >= 14 ? 0 : margin >= 0 ? 1 : margin >= -14 ? 2 : 3;
+  let supportStrain = margin < -8 ? 1 : 0;
+  let pressure = route.pressure;
+  const unseenHazards = scene.hazards.filter((hazard) => route.hazardIds.includes(hazard.id) && !scan.revealedIds.includes(hazard.id));
+  unseenHazards.forEach((hazard) => {
+    leadStrain += hazard.strain;
+    pressure += hazard.pressure;
+  });
+
+  const environment = environmentConsequences(lead, route.environment);
+  leadStrain += environment.strain;
+
+  const naturalReaction = reactionMatches(lead, route.reaction);
+  const reactionControlled = naturalReaction || useCommand;
+  if (!reactionControlled) pressure += 1;
+  if (naturalReaction && leadStrain > 0) leadStrain -= 1;
+
+  const quality = margin >= 14 ? 'clean' : margin >= 0 ? 'costly' : margin >= -14 ? 'rough' : 'critical';
+  return {
+    quality,
+    rawMethodScore,
+    supportBonus,
+    totalScore,
+    margin,
+    leadStrain,
+    supportStrain,
+    pressure,
+    salvage: route.salvage,
+    abilityId: method.abilityId,
+    unseenHazards,
+    environment,
+    naturalReaction,
+    reactionControlled,
+    readiness: { lead: leadReadiness, support: supportReadiness },
+    summary: quality === 'clean'
+      ? `${lead.species} executes the method cleanly and keeps the scene stable.`
+      : quality === 'costly'
+        ? `${lead.species} gets the crew through, but the work leaves a mark.`
+        : quality === 'rough'
+          ? `The method works only after ${support.species} intervenes. The annex notices.`
+          : `The crew forces a way through as the scene collapses around them.`
+  };
+}
+
+export function assignmentStatus({ route, lead, support, method }) {
+  if (!route) return { ready: false, step: 'route', message: 'Choose a route to begin the assignment.' };
+  if (!lead) return { ready: false, step: 'lead', message: 'Step 1 of 3 — choose a lead creature from the crew rail.' };
+  if (!support) return { ready: false, step: 'support', message: 'Step 2 of 3 — choose a support creature. Support is required for every crossing.' };
+  if (!method) return { ready: false, step: 'method', message: 'Step 3 of 3 — choose how the lead will cross.' };
+  return { ready: true, step: 'ready', message: 'Assignment complete — review the score, then commit the crew.' };
+}
+
+export function highestCapabilities(creature, count = 3) {
+  return Object.entries(creature.physiology.capabilities)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, count);
+}
+
+export function temperamentPhrase(creature) {
+  const axes = Object.entries(creature.temperament).sort((a, b) => b[1] - a[1]);
+  const words = {
+    boldness: 'bold', curiosity: 'curious', energy: 'energetic', aggression: 'confrontational', sociability: 'social'
+  };
+  const lowWords = {
+    boldness: 'cautious', curiosity: 'focused', energy: 'patient', aggression: 'gentle', sociability: 'independent'
+  };
+  const highest = axes[0];
+  const lowest = [...axes].sort((a, b) => a[1] - b[1])[0];
+  return `${words[highest[0]]}; ${lowWords[lowest[0]]}`;
+}

--- a/my-app/src/components/games/longReturn/longReturnEngine.test.js
+++ b/my-app/src/components/games/longReturn/longReturnEngine.test.js
@@ -1,0 +1,276 @@
+import { CREATURES, MISSION } from './longReturnData';
+import { applyMissionMemory, assignmentStatus, canRelay, decisionForecast, encounterOptions, encounterOutlook, environmentConsequences, instabilityState, methodOptions, outcomeForMargin, readinessState, resolveScene, scanReport, scanScene, scoutProfile } from './longReturnEngine';
+
+const creature = (species) => CREATURES.find((entry) => entry.species === species);
+
+describe('Long Return prototype engine', () => {
+  test.each([
+    [14, 'clean', 0],
+    [13, 'costly', 1],
+    [0, 'costly', 1],
+    [-1, 'rough', 2],
+    [-14, 'rough', 2],
+    [-15, 'critical', 3]
+  ])('maps a margin of %i to the tutorial outcome bands', (margin, quality, baseLeadStrain) => {
+    expect(outcomeForMargin(margin)).toMatchObject({ quality, baseLeadStrain });
+  });
+
+  test('forecasts every available first-scene crew plan for Simple mode', () => {
+    const scene = MISSION.scenes[0];
+    const scan = scanScene(scene, creature('Graviclaw'));
+    scene.routes.forEach((route) => {
+      CREATURES.forEach((lead) => {
+        CREATURES.filter((support) => support.id !== lead.id).forEach((support) => {
+          methodOptions(lead, route, []).forEach((method) => {
+            expect(decisionForecast({ route, lead, support, method, scan })).toEqual(expect.objectContaining({
+              teamScore: expect.any(Number),
+              margin: expect.any(Number)
+            }));
+          });
+        });
+      });
+    });
+  });
+
+  test('special senses reveal a hazard when the scout can relay it', () => {
+    const scene = MISSION.scenes[0];
+    const result = scanScene(scene, creature('Xylum'));
+    expect(result.revealedIds).toContain('conductive-brine');
+  });
+
+  test('a sensed hazard stays trapped when communication cannot cross the scene', () => {
+    const scene = MISSION.scenes[1];
+    const ectoghoul = creature('Ectoghoul');
+    expect(canRelay(scene, ectoghoul)).toBe(false);
+    const result = scanScene(scene, ectoghoul);
+    expect(result.trappedCount).toBe(1);
+    expect(result.revealedIds).toHaveLength(0);
+  });
+
+  test('non-breathers do not drown in liquid', () => {
+    const result = environmentConsequences(creature('Ectoghoul'), { medium: 'liquid', temperatureC: 10, element: 'ghost' });
+    expect(result.notes.join(' ')).not.toMatch(/without breathing/);
+  });
+
+  test('spent abilities are removed from method choices', () => {
+    const route = MISSION.scenes[0].routes[0];
+    const chromocat = creature('Chromocat');
+    const before = methodOptions(chromocat, route, []);
+    const after = methodOptions(chromocat, route, ['chroma-beam']);
+    expect(before.some((method) => method.abilityId === 'chroma-beam')).toBe(true);
+    expect(after.some((method) => method.abilityId === 'chroma-beam')).toBe(false);
+  });
+
+  test('revealed hazards do not add their surprise pressure', () => {
+    const scene = MISSION.scenes[0];
+    const route = scene.routes[1];
+    const lead = creature('Hippochamp');
+    const support = creature('Graviclaw');
+    const method = methodOptions(lead, route, [])[0];
+    const hidden = resolveScene({ scene, route, lead, support, method, scan: { revealedIds: [] }, useCommand: true });
+    const revealed = resolveScene({ scene, route, lead, support, method, scan: { revealedIds: ['conductive-brine'] }, useCommand: true });
+    expect(hidden.pressure).toBe(revealed.pressure + 1);
+    expect(hidden.leadStrain).toBeGreaterThan(revealed.leadStrain);
+  });
+
+  test('assignment status explains each required choice, including support', () => {
+    const route = MISSION.scenes[0].routes[0];
+    const lead = creature('Hippochamp');
+    const support = creature('Chromocat');
+    const method = methodOptions(lead, route, [])[0];
+
+    expect(assignmentStatus({ route }).step).toBe('lead');
+    expect(assignmentStatus({ route, lead }).step).toBe('support');
+    expect(assignmentStatus({ route, lead }).message).toMatch(/support is required/i);
+    expect(assignmentStatus({ route, lead, support }).step).toBe('method');
+    expect(assignmentStatus({ route, lead, support, method }).ready).toBe(true);
+  });
+
+  test('every scene, route, creature, support, scan, and command combination resolves safely', () => {
+    const qualities = ['clean', 'costly', 'rough', 'critical'];
+    let resolutions = 0;
+
+    MISSION.scenes.forEach((scene) => {
+      const hazardIds = scene.hazards.map((hazard) => hazard.id);
+      scene.routes.forEach((route) => {
+        expect(route.hazardIds.every((id) => hazardIds.includes(id))).toBe(true);
+
+        CREATURES.forEach((lead) => {
+          const methods = methodOptions(lead, route, []);
+          const spentIds = lead.abilities.map((ability) => ability.id);
+          const methodsAfterSpendingEveryAbility = methodOptions(lead, route, spentIds);
+          expect(methods.length).toBeGreaterThan(0);
+          expect(methodsAfterSpendingEveryAbility.length).toBeGreaterThan(0);
+          expect(methodsAfterSpendingEveryAbility.some((method) => spentIds.includes(method.abilityId))).toBe(false);
+
+          CREATURES.filter((support) => support.id !== lead.id).forEach((support) => {
+            methods.forEach((method) => {
+              [[], hazardIds].forEach((revealedIds) => {
+                [false, true].forEach((useCommand) => {
+                  const result = resolveScene({
+                    scene,
+                    route,
+                    lead,
+                    support,
+                    method,
+                    scan: { revealedIds },
+                    useCommand
+                  });
+                  expect(qualities).toContain(result.quality);
+                  expect(Number.isFinite(result.totalScore)).toBe(true);
+                  expect(result.leadStrain).toBeGreaterThanOrEqual(0);
+                  expect(result.supportStrain).toBeGreaterThanOrEqual(0);
+                  expect(result.pressure).toBeGreaterThanOrEqual(0);
+                  expect(result.salvage).toBeGreaterThanOrEqual(0);
+                  resolutions += 1;
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    expect(resolutions).toBeGreaterThan(2000);
+  });
+
+  test('every concealed hazard can be revealed by at least one registry creature', () => {
+    MISSION.scenes.forEach((scene) => {
+      scene.hazards.forEach((hazard) => {
+        const scouts = CREATURES.filter((candidate) => scanScene(scene, candidate).revealedIds.includes(hazard.id));
+        expect(scouts.map((candidate) => candidate.species)).not.toHaveLength(0);
+      });
+    });
+  });
+
+  test('scan reports explain revealed, trapped, quiet, and blind outcomes', () => {
+    const firstScene = MISSION.scenes[0];
+    const revealedScan = { ...scanScene(firstScene, creature('Xylum')), mode: 'scan' };
+    const revealed = scanReport(firstScene, creature('Xylum'), revealedScan);
+    expect(revealed.outcome).toBe('revealed');
+    expect(revealed.revealed[0].label).toBe('Conductive brine');
+    expect(revealed.affectedRoutes.map((route) => route.id)).toEqual(['intake']);
+    expect(revealed.decision).toMatch(/Ride the intake current/);
+
+    const trappedScene = MISSION.scenes[1];
+    const trappedScan = { ...scanScene(trappedScene, creature('Ectoghoul')), mode: 'scan' };
+    expect(scanReport(trappedScene, creature('Ectoghoul'), trappedScan).outcome).toBe('trapped');
+
+    const quietScan = { ...scanScene(firstScene, creature('Graviclaw')), mode: 'scan' };
+    expect(scanReport(firstScene, creature('Graviclaw'), quietScan).outcome).toBe('quiet');
+
+    const unrelayedScan = { ...scanScene(firstScene, creature('Ectoghoul')), mode: 'scan' };
+    expect(scanReport(firstScene, creature('Ectoghoul'), unrelayedScan).outcome).toBe('unrelayed');
+
+    const blind = scanReport(firstScene, null, {
+      mode: 'blind',
+      hazards: firstScene.hazards.map((hazard) => ({ ...hazard, revealed: false, sensed: false })),
+      revealedIds: []
+    });
+    expect(blind.outcome).toBe('blind');
+    expect(blind.strainCost).toBe(0);
+    expect(blind.decision).toMatch(/crew energy and annex stability/i);
+  });
+
+  test('readiness creates visible degradation before a creature becomes spent', () => {
+    expect(readinessState(0).label).toBe('Ready');
+    expect(readinessState(3)).toMatchObject({ label: 'Worn', scorePenalty: 4 });
+    expect(readinessState(5)).toMatchObject({ label: 'Critical', scorePenalty: 9 });
+    expect(readinessState(6).label).toBe('Spent');
+    expect(instabilityState(0).label).toBe('Stable');
+    expect(instabilityState(9).label).toBe('Collapse imminent');
+    expect(instabilityState(10).label).toBe('Collapse');
+  });
+
+  test('worn leads and support contribute less to the same crossing', () => {
+    const scene = MISSION.scenes[0];
+    const route = scene.routes[0];
+    const lead = creature('Chromocat');
+    const support = creature('Ectoghoul');
+    const method = methodOptions(lead, route, []).find((entry) => entry.key === 'leap');
+    const ready = decisionForecast({ route, lead, support, method, scan: { revealedIds: [] } });
+    const worn = decisionForecast({ route, lead, support, method, scan: { revealedIds: [] }, leadLoad: 3, supportLoad: 3 });
+    expect(worn.leadScore).toBe(ready.leadScore - 4);
+    expect(worn.supportBonus).toBe(ready.supportBonus - 2);
+    expect(worn.margin).toBe(ready.margin - 6);
+  });
+
+  test('creature details produce distinct scout roles and encounter tradeoffs', () => {
+    const scene = MISSION.scenes[1];
+    const profiles = ['Chromocat', 'Graviclaw', 'Hippochamp'].map((name) => scoutProfile(scene, creature(name)));
+    expect(new Set(profiles.map((profile) => profile.role)).size).toBeGreaterThan(1);
+    expect(encounterOutlook(scene, creature('Chromocat'))).toEqual(expect.objectContaining({ posture: expect.any(String), surpriseStrain: expect.any(Number) }));
+    const options = encounterOptions(scene, creature('Ectoghoul'), CREATURES, 'scout');
+    expect(options.some((option) => option.companion)).toBe(true);
+    expect(options.some((option) => option.resolution === 'unresolved')).toBe(true);
+    expect(options.some((option) => option.resolution === 'cleared')).toBe(true);
+  });
+
+  test('earlier routes change later targets without mutating mission data', () => {
+    const turbine = MISSION.scenes[1];
+    const remembered = applyMissionMemory(turbine, ['quiet-entry']);
+    expect(remembered.routes.find((route) => route.id === 'catwalk')).toMatchObject({ difficulty: 63, originalDifficulty: 68 });
+    expect(remembered.routes.find((route) => route.id === 'underdeck').difficulty).toBe(61);
+    expect(turbine.routes.find((route) => route.id === 'catwalk').difficulty).toBe(68);
+
+    const vestibule = applyMissionMemory(MISSION.scenes[2], ['maintenance-codes']);
+    expect(vestibule.routes.find((route) => route.id === 'decode').difficulty).toBe(65);
+    expect(vestibule.routes.find((route) => route.id === 'decode').activeEffects[0].label).toBe('Recovered codes');
+  });
+
+  test('trapped and territorial encounters offer distinct non-combat responses', () => {
+    const trapped = encounterOptions(MISSION.scenes[2], creature('Hypnopet'), CREATURES, 'scout');
+    const territorial = encounterOptions(MISSION.scenes[3], creature('Chromocat'), CREATURES, 'scout');
+    expect(trapped.map((option) => option.id)).toEqual(expect.arrayContaining(['release', 'mark', 'force-arms']));
+    expect(territorial.map((option) => option.id)).toEqual(expect.arrayContaining(['withdraw', 'challenge']));
+    expect([...trapped, ...territorial].every((option) => option.summary.length > 35)).toBe(true);
+  });
+
+  test('a physical scout debrief converts sensed details into usable route intelligence', () => {
+    const scene = MISSION.scenes[1];
+    const scout = creature('Ectoghoul');
+    const initial = scanScene(scene, scout);
+    expect(initial.trappedCount).toBeGreaterThan(0);
+    const returned = { ...initial, mode: 'debrief', returned: true, hazards: initial.hazards.map((hazard) => ({ ...hazard, revealed: hazard.sensed })), revealedIds: initial.hazards.filter((hazard) => hazard.sensed).map((hazard) => hazard.id) };
+    const report = scanReport(scene, scout, returned);
+    expect(report.outcome).toBe('revealed');
+    expect(report.channel).toBe('physical return');
+    expect(report.strainCost).toBe(2);
+  });
+
+  test('every scene explains the immediate objective, survey focus, and route destination', () => {
+    const trackLabels = new Set();
+    MISSION.scenes.forEach((scene) => {
+      expect(scene.goal.length).toBeGreaterThan(30);
+      expect(scene.destination.length).toBeGreaterThan(20);
+      expect(scene.surveyFocus.length).toBeGreaterThan(20);
+      expect(scene.trackLabel.length).toBeGreaterThan(5);
+      trackLabels.add(scene.trackLabel);
+    });
+    expect(trackLabels.size).toBe(MISSION.scenes.length);
+  });
+
+  test('decision forecasts translate the visible method equation into an outcome', () => {
+    const route = MISSION.scenes[0].routes[0];
+    const lead = creature('Chromocat');
+    const support = creature('Ectoghoul');
+    const methods = methodOptions(lead, route, []);
+    const climb = methods.find((entry) => entry.key === 'climb');
+    const leap = methods.find((entry) => entry.key === 'leap');
+    const beam = methods.find((entry) => entry.key === 'beam');
+    const scan = { revealedIds: [] };
+
+    const climbForecast = decisionForecast({ route, lead, support, method: climb, scan });
+    const leapForecast = decisionForecast({ route, lead, support, method: leap, scan });
+    const beamForecast = decisionForecast({ route, lead, support, method: beam, scan });
+
+    expect([climbForecast.leadScore, leapForecast.leadScore, beamForecast.leadScore]).toEqual([73, 86, 59]);
+    expect(beamForecast.supportBonus).toBe(7);
+    expect(beamForecast.teamScore).toBe(66);
+    expect(beamForecast.difficulty).toBe(63);
+    expect(beamForecast.margin).toBe(3);
+    expect(beamForecast.quality).toBe('costly');
+    expect(beamForecast.label).toBe('Narrow advantage');
+    expect(leapForecast.quality).toBe('clean');
+  });
+});

--- a/my-app/src/components/games/longReturn/longReturnGame.js
+++ b/my-app/src/components/games/longReturn/longReturnGame.js
@@ -1,0 +1,1406 @@
+import React, { useMemo, useState } from 'react';
+import XalianImage from '../../xalianImage';
+import * as svgUtil from '../../../utils/svgUtil';
+import { ATTRIBUTE_LABELS, CAPABILITY_LABELS, CREATURES, MAX_INSTABILITY, MAX_PRESSURE, MAX_STRAIN, MISSION } from './longReturnData';
+import { applyMissionMemory, assignmentStatus, decisionForecast, encounterOptions, encounterOutlook, highestCapabilities, instabilityState, methodOptions, reactionMatches, readinessState, resolveScene, scanReport, scanScene, scoutProfile, temperamentPhrase } from './longReturnEngine';
+import './longReturn.css';
+
+const initialCrew = ['graviclaw-213', 'chromocat-088', 'hippochamp-041'];
+
+const GUIDANCE_LEVELS = [
+  { id: 'simple', label: 'Simple', badge: 'Recommended', description: 'Shows only the current choice, our recommendation, and its likely cost.' },
+  { id: 'guided', label: 'Guided', description: 'Explains the math, ranks known options, and recommends the safest available decision.' },
+  { id: 'standard', label: 'Standard', description: 'Explains scores and expected outcomes, but leaves comparisons and choices to you.' },
+  { id: 'expert', label: 'Expert', description: 'Shows raw operational data with minimal interpretation or recommendations.' }
+];
+
+const cap = (value) => Math.max(0, Math.min(MAX_STRAIN, value));
+const labelCase = (value = '') => value ? `${value.charAt(0).toUpperCase()}${value.slice(1)}` : '';
+
+const creatureReaction = (creature, quality, route) => {
+  if (quality === 'clean') {
+    if (creature.temperament.sociability >= 70) return `${creature.species} checks every crew member before looking ahead.`;
+    if (creature.temperament.energy >= 75) return `${creature.species} is already testing the next threshold.`;
+    return `${creature.species} pauses at the far side and studies what changed.`;
+  }
+  if (creature.temperament.boldness >= 70) return `${creature.species} shakes off the crossing and refuses to yield the lead.`;
+  if (creature.traits.includes('protective')) return `${creature.species} stays between the damaged route and the rest of the crew.`;
+  return `${creature.species} keeps close to support after the effort of ${route.title.toLowerCase()}.`;
+};
+
+function Meter({ value, max, label, danger, depleted = false }) {
+  const shownValue = depleted ? Math.max(0, max - value) : value;
+  const percent = Math.min(100, Math.round((shownValue / max) * 100));
+  return (
+    <div className={`lr-meter${danger ? ' lr-meter--danger' : ''}`}>
+      <div className="lr-meter-label"><span>{label}</span><strong>{shownValue} / {max}</strong></div>
+      <div className="lr-meter-track"><span style={{ width: `${percent}%` }} /></div>
+    </div>
+  );
+}
+
+function GuidanceSelector({ value, onChange, compact = false }) {
+  return (
+    <div className={`lr-guidance-selector${compact ? ' lr-guidance-selector--compact' : ''}`}>
+      {GUIDANCE_LEVELS.map((level) => (
+        <button key={level.id} type="button" className={value === level.id ? 'is-selected' : ''} onClick={() => onChange(level.id)} aria-pressed={value === level.id}>
+          <span>{level.label}{level.badge && <em>{level.badge}</em>}</span>
+          {!compact && <small>{level.description}</small>}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ThresholdTrack({ value, max, danger = false, label, kind = 'annex' }) {
+  const percent = Math.min(100, Math.round((value / max) * 100));
+  return (
+    <span className={`lr-threshold-track is-${kind}${danger ? ' is-danger' : ''}`} aria-label={`${label}: ${value} of ${max}`}>
+      <i style={{ width: `${percent}%` }} />
+      <b className="at-warning" aria-hidden="true" />
+      <b className="at-danger" aria-hidden="true" />
+      <b className="at-critical" aria-hidden="true" />
+    </span>
+  );
+}
+
+function ProjectionTrack({ value, added, max, label, kind }) {
+  const current = Math.max(0, max - value);
+  const after = Math.max(0, current - added);
+  return (
+    <span className={`lr-projection-track is-${kind}`} aria-label={`${label}: currently ${current} of ${max}, projected to ${after} of ${max}`}>
+      {Array.from({ length: max }, (_, index) => {
+        const filled = index < after;
+        const projected = index >= after && index < current;
+        return <i key={index} className={filled ? 'is-current' : projected ? 'is-projected' : ''} aria-hidden="true" />;
+      })}
+    </span>
+  );
+}
+
+function SignalGauge({ value, label }) {
+  const filled = Math.max(1, Math.min(5, Math.ceil(value / 20)));
+  return (
+    <span className="lr-signal-gauge" aria-label={`${label}: ${filled} of 5`}>
+      {Array.from({ length: 5 }, (_, index) => <i key={index} className={`bi ${index < filled ? 'bi-eye-fill is-filled' : 'bi-eye'}`} aria-hidden="true" />)}
+    </span>
+  );
+}
+
+function SalvageGauge({ value, label = 'Salvage recovered' }) {
+  const filled = Math.max(0, Math.min(10, value));
+  return (
+    <span className="lr-salvage-gauge" aria-label={`${label}: ${value}`}>
+      {Array.from({ length: 10 }, (_, index) => <i key={index} className={`bi ${index < filled ? 'bi-box-seam-fill is-filled' : 'bi-box-seam'}`} aria-hidden="true" />)}
+    </span>
+  );
+}
+
+const scoutRoleIcon = (role) => role === 'Quiet scout' ? 'bi-eye-slash-fill' : role === 'Defensive scout' ? 'bi-shield-fill' : 'bi-chat-heart-fill';
+
+function CurrentAction({ stage, title, hint, icon, resolved = false, onHelp }) {
+  return (
+    <section className={`lr-current-action${resolved ? ' is-resolved' : ''}`} aria-live="polite">
+      <i className={`bi ${icon}`} />
+      <div><span>{stage}</span><strong>{title}</strong><small>{hint}</small></div>
+      <button type="button" onClick={onHelp}><i className="bi bi-info-circle" /> Game rules</button>
+    </section>
+  );
+}
+
+const signed = (value) => `${value >= 0 ? '+' : ''}${value}`;
+const scorePosition = (value) => `${Math.max(0, Math.min(100, (value / 110) * 100))}%`;
+
+function ForecastBar({ forecast }) {
+  return (
+    <div className="lr-forecast-bar-wrap" aria-label={`Team score ${forecast.teamScore}; route target ${forecast.difficulty}; margin ${signed(forecast.margin)}`}>
+      <div className={`lr-forecast-bar is-${forecast.quality}`} aria-hidden="true">
+        <span style={{ width: scorePosition(forecast.teamScore) }} />
+        <i style={{ left: scorePosition(forecast.difficulty) }} />
+      </div>
+      <div className="lr-forecast-bar-labels"><span>Team {forecast.teamScore}</span><span>Target {forecast.difficulty}</span></div>
+    </div>
+  );
+}
+
+function CrossingEquation({ leadScore, supportBonus, teamScore, target, margin, compact = false }) {
+  const resolved = Number.isFinite(teamScore) && Number.isFinite(margin);
+  return (
+    <div className={`lr-crossing-equation${compact ? ' lr-crossing-equation--compact' : ''}`} aria-label={resolved ? `Lead method ${leadScore} plus support ${supportBonus} equals team score ${teamScore}, against route target ${target}, margin ${signed(margin)}` : `Build a team score that meets or beats route target ${target}`}>
+      <div><small>Lead method</small><strong>{Number.isFinite(leadScore) ? leadScore : '?'}</strong></div>
+      <i>+</i>
+      <div><small>Support</small><strong>{Number.isFinite(supportBonus) ? supportBonus : '?'}</strong></div>
+      <i>=</i>
+      <div className="is-team"><small>Team score</small><strong>{Number.isFinite(teamScore) ? teamScore : '?'}</strong></div>
+      <i>vs</i>
+      <div className="is-target"><small>Route target</small><strong>{target}</strong></div>
+      <div className={`lr-crossing-result${resolved && margin < 0 ? ' is-behind' : ''}`}>
+        {resolved ? <><small>Margin</small><strong>{signed(margin)}</strong><span>{margin >= 0 ? 'Target met' : 'Below target'}</span></> : <><small>Your objective</small><strong>Team ≥ {target}</strong><span>Build the score</span></>}
+      </div>
+    </div>
+  );
+}
+
+function CrossingPrimer({ detailed = false }) {
+  return (
+    <section className={`lr-crossing-primer${detailed ? ' lr-crossing-primer--detailed' : ''}`}>
+      <div className="lr-primer-head">
+        <div><p className="g-kicker">The one crossing rule</p><h2>Make your crew score at least as high as the route target</h2></div>
+        <span>Higher above target = less energy spent</span>
+      </div>
+      <p className="lr-primer-takeaway">Choose one lead method, then add one support creature. Together, they need to meet or beat the number printed on the route.</p>
+      <div className="lr-primer-example" aria-label="Example: Chromocat's Leap score of 86 plus Ectoghoul's support of 7 makes a crew score of 93. That beats the route target of 63 by 30, producing a clean crossing.">
+        <div className="lr-primer-build">
+          <div><small>Lead method</small><span>Chromocat · Leap</span><strong>86</strong></div>
+          <i>+</i>
+          <div><small>Support creature</small><span>Ectoghoul</span><strong>7</strong></div>
+          <i>=</i>
+          <div className="is-crew"><small>Your crew score</small><span>Combined</span><strong>93</strong></div>
+        </div>
+        <div className="lr-primer-compare">
+          <div><small>Your crew</small><strong>93</strong></div>
+          <i className="bi bi-chevron-right" />
+          <div><small>Route target</small><strong>63</strong></div>
+          <i className="bi bi-arrow-right" />
+          <div className="is-result"><small>30 points over</small><strong><i className="bi bi-check-circle-fill" /> Clean crossing</strong><span>No base energy cost</span></div>
+        </div>
+      </div>
+      {detailed ? <>
+        <div className="lr-margin-scale" aria-label="Margin outcomes: plus 14 or more is clean; zero to plus 13 is narrow; minus 1 to minus 14 is rough; minus 15 or less is severe">
+          <span className="is-clean"><b>+14↑</b><small>Clean · energy 0</small></span>
+          <span className="is-costly"><b>0…+13</b><small>Narrow · energy −1</small></span>
+          <span className="is-rough"><b>−1…−14</b><small>Rough · energy −2</small></span>
+          <span className="is-critical"><b>−15↓</b><small>Severe · energy −3</small></span>
+        </div>
+        <div className="lr-primer-modifiers"><span>After the score check</span><b><i className="bi bi-thermometer-half" /> Environment</b><b><i className="bi bi-compass" /> Temperament</b><b><i className="bi bi-question-diamond" /> Hidden hazards</b></div>
+      </> : <div className="lr-primer-next"><strong>First: beat the target.</strong><span>Then review the visible energy, annex stability, and risk warnings before committing.</span></div>}
+    </section>
+  );
+}
+
+function SimplePrimer() {
+  return (
+    <section className="lr-simple-primer">
+      <i className="bi bi-signpost-2-fill" />
+      <div><p className="g-kicker">Simple command view</p><h2>Make one choice at a time</h2><p>We will mark our recommendation and show its likely cost before you commit. Open details only when you want them.</p></div>
+      <div className="lr-simple-primer-steps"><span><b>1</b> Scout</span><i className="bi bi-arrow-right" /><span><b>2</b> Choose route</span><i className="bi bi-arrow-right" /><span><b>3</b> Approve plan</span></div>
+    </section>
+  );
+}
+
+function conditionChange(current, added) {
+  const before = readinessState(current);
+  const afterValue = cap(current + added);
+  const after = readinessState(afterValue);
+  return { before, after, afterValue, changed: before.id !== after.id };
+}
+
+function instabilityChange(current, added) {
+  const before = instabilityState(current);
+  const afterValue = Math.min(MAX_INSTABILITY, current + added);
+  const after = instabilityState(afterValue);
+  return { before, after, afterValue, changed: before.id !== after.id };
+}
+
+function SimpleRunStatus({ crew, strain, pressure, objectiveReached, companion, motionCue }) {
+  const annex = instabilityState(pressure);
+  const stabilityLoss = motionCue ? motionCue.stability || 0 : 0;
+  return (
+    <section className="lr-simple-status" aria-label="Expedition status">
+      <div className="lr-simple-status-crew">
+        <span>CREW READINESS</span>
+        <div>{crew.map((member) => {
+          const value = strain[member.id] || 0;
+          const state = readinessState(value);
+          const recentLoss = motionCue && motionCue.energy ? motionCue.energy[member.id] || 0 : 0;
+          return <span className={`is-${state.id}${recentLoss ? ' is-changing' : ''}`} key={member.id} title={state.detail}><b>{member.species}</b><em>{state.label} · {MAX_STRAIN - value}/{MAX_STRAIN} energy</em><ProjectionTrack value={Math.max(0, value - recentLoss)} added={recentLoss} max={MAX_STRAIN} label={`${member.species} energy`} kind="strain" />{recentLoss > 0 && <small className="lr-status-delta">−{recentLoss} energy</small>}</span>;
+        })}</div>
+      </div>
+      <div className={`lr-simple-status-clock is-${annex.id}${stabilityLoss ? ' is-changing' : ''}`}>
+        <span>ANNEX STABILITY</span><strong>{annex.label} · {MAX_INSTABILITY - pressure}/{MAX_INSTABILITY}</strong><ProjectionTrack value={Math.max(0, pressure - stabilityLoss)} added={stabilityLoss} max={MAX_INSTABILITY} label="Annex stability" kind="annex" /><small>{pressure >= MAX_INSTABILITY ? 'Forced extraction' : `${MAX_INSTABILITY - pressure} stability remaining`}</small>{stabilityLoss > 0 && <small className="lr-status-delta">−{stabilityLoss} stability</small>}
+      </div>
+      <div className={`lr-simple-status-objective${objectiveReached ? ' is-secured' : ''}`}>
+        <span>MISSION</span><strong>{objectiveReached ? 'Index secured' : 'Index not secured'}</strong><small>{objectiveReached ? 'Extraction preserves the objective.' : 'Forced extraction now means failure.'}</small>
+      </div>
+      {companion && <div className="lr-simple-status-companion"><span>FIELD COMPANION</span><strong>{companion.creature.species}</strong><small>{companion.ready ? companion.benefit : 'Intervention used · remains with the crew'}</small></div>}
+    </section>
+  );
+}
+
+function ActionFeedback({ cue, crew }) {
+  if (!cue) return null;
+  const energyChanges = Object.entries(cue.energy || {}).filter(([, amount]) => amount > 0);
+  if (!energyChanges.length && !cue.stability && !cue.salvage) return null;
+  return (
+    <section className="lr-action-feedback" role="status" aria-live="polite">
+      <i className="bi bi-stars" />
+      <div>
+        <span>Just changed</span>
+        <div>
+          {energyChanges.map(([id, amount]) => <b className="is-energy" key={id}><i className="bi bi-lightning-charge-fill" /> {crew.find((member) => member.id === id)?.species || 'Crew'} −{amount} energy</b>)}
+          {cue.stability > 0 && <b className="is-stability"><i className="bi bi-buildings-fill" /> −{cue.stability} stability</b>}
+          {cue.salvage > 0 && <b className="is-salvage"><i className="bi bi-box-seam-fill" /> +{cue.salvage} salvage</b>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function safestPlanForRoute(route, crew, strain, spentAbilities, scan) {
+  const standing = crew.filter((member) => (strain[member.id] || 0) < MAX_STRAIN);
+  const plans = [];
+  standing.forEach((lead) => {
+    standing.filter((member) => member.id !== lead.id).forEach((support) => {
+      methodOptions(lead, route, spentAbilities).forEach((method) => {
+        const forecast = decisionForecast({ route, lead, support, method, scan, leadLoad: strain[lead.id] || 0, supportLoad: strain[support.id] || 0 });
+        const knownLeadStrain = Math.max(0, forecast.baseLeadStrain + forecast.environment.strain - (forecast.naturalReaction ? 1 : 0));
+        const knownPressure = route.pressure + (forecast.naturalReaction ? 0 : 1);
+        const risk = knownLeadStrain * 18 + forecast.baseSupportStrain * 12 + knownPressure * 8 + forecast.unresolvedHazards.length * 14 - Math.min(30, forecast.margin) * .15;
+        plans.push({ ...forecast, route, lead, support, method, knownLeadStrain, knownPressure, risk });
+      });
+    });
+  });
+  return plans.sort((a, b) => a.risk - b.risk || b.margin - a.margin)[0] || null;
+}
+
+function routeAdvantage(plan, plans) {
+  if (plan.route.activeEffects && plan.route.activeEffects.length) return plan.route.activeEffects[0].label;
+  const crewCost = plan.knownLeadStrain + plan.baseSupportStrain;
+  const lowestCrew = Math.min(...plans.map((entry) => entry.knownLeadStrain + entry.baseSupportStrain));
+  const lowestInstability = Math.min(...plans.map((entry) => entry.knownPressure));
+  const highestSalvage = Math.max(...plans.map((entry) => entry.route.salvage));
+  if (crewCost === lowestCrew && plans.filter((entry) => entry.knownLeadStrain + entry.baseSupportStrain === lowestCrew).length === 1) return 'Easier on the crew';
+  if (plan.knownPressure === lowestInstability && plans.filter((entry) => entry.knownPressure === lowestInstability).length === 1) return 'Keeps the annex quieter';
+  if (plan.route.salvage === highestSalvage && plans.filter((entry) => entry.route.salvage === highestSalvage).length === 1) return 'More salvage';
+  return plan.unresolvedHazards.length || plan.nativeRisk ? 'Uncertain route' : 'Balanced approach';
+}
+
+function recommendationFor(plans) {
+  if (plans.length < 2) return plans[0] ? { plan: plans[0], reason: 'This is the only viable route.' } : null;
+  const ranked = [...plans].sort((a, b) => a.risk - b.risk);
+  const [best, second] = ranked;
+  if (second.risk - best.risk < 10) return null;
+  const bestUncertainty = best.unresolvedHazards.length + (best.nativeRisk ? 1 : 0);
+  const secondUncertainty = second.unresolvedHazards.length + (second.nativeRisk ? 1 : 0);
+  if (bestUncertainty > secondUncertainty) return null;
+  const crewDifference = (second.knownLeadStrain + second.baseSupportStrain) - (best.knownLeadStrain + best.baseSupportStrain);
+  const instabilityDifference = second.knownPressure - best.knownPressure;
+  const reasons = [];
+  if (crewDifference > 0) reasons.push(`${crewDifference} less projected energy use`);
+  if (instabilityDifference > 0) reasons.push(`${instabilityDifference} less stability loss`);
+  if (best.unresolvedHazards.length < second.unresolvedHazards.length) reasons.push('fewer unresolved hazards');
+  if (best.nativeRisk !== second.nativeRisk && !best.nativeRisk) reasons.push('avoids likely native contact');
+  return { plan: best, reason: reasons.length ? reasons.join(' and ') : 'a substantially safer known crossing' };
+}
+
+function MechanicsModal({ open, onClose }) {
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const closeOnEscape = (event) => { if (event.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', closeOnEscape);
+    return () => document.removeEventListener('keydown', closeOnEscape);
+  }, [open, onClose]);
+  if (!open) return null;
+  return (
+    <div className="lr-modal-backdrop" onMouseDown={(event) => { if (event.target === event.currentTarget) onClose(); }}>
+      <section className="lr-detail-modal lr-mechanics-modal" role="dialog" aria-modal="true" aria-labelledby="lr-mechanics-title">
+        <button type="button" className="lr-modal-close" onClick={onClose} aria-label="Close crossing rules" autoFocus><i className="bi bi-x-lg" /></button>
+        <p className="g-kicker">How to play</p>
+        <h2 id="lr-mechanics-title">How every crossing works</h2>
+        <CrossingPrimer detailed />
+        <div className="lr-mechanics-survival">
+          <div><i className="bi bi-heart-pulse" /><span><strong>Readiness states</strong>At 3 energy a creature is Worn and contributes less; at 1 it is Critical and cannot scout; at 0 it is Spent and cannot act.</span></div>
+          <div><i className="bi bi-buildings" /><span><strong>Annex stability</strong>This is the mission’s external safety reserve. Failing structure and waking systems drain it. At 0, the crew must extract.</span></div>
+          <div><i className="bi bi-lightning-charge-fill" /><span><strong>Creature energy</strong>Actions consume energy. At 0, a creature is spent and cannot act. The run ends if fewer than two crew members can continue.</span></div>
+          <div><i className="bi bi-box-seam-fill" /><span><strong>Salvage</strong>Optional mission loot. It does not improve a crossing; it increases the haul banked when the crew extracts.</span></div>
+        </div>
+        <button type="button" className="g-btn g-btn--primary" onClick={onClose}>Return to mission</button>
+      </section>
+    </div>
+  );
+}
+
+function MethodDetailModal({ forecast, lead, support, route, onClose }) {
+  React.useEffect(() => {
+    if (!forecast) return undefined;
+    const closeOnEscape = (event) => { if (event.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', closeOnEscape);
+    return () => document.removeEventListener('keydown', closeOnEscape);
+  }, [forecast, onClose]);
+  if (!forecast || !lead || !route) return null;
+  return (
+    <div className="lr-modal-backdrop" onMouseDown={(event) => { if (event.target === event.currentTarget) onClose(); }}>
+      <section className="lr-detail-modal" role="dialog" aria-modal="true" aria-labelledby="lr-method-detail-title">
+        <button type="button" className="lr-modal-close" onClick={onClose} aria-label="Close method details" autoFocus><i className="bi bi-x-lg" /></button>
+        <p className="g-kicker">Calculation details</p>
+        <h2 id="lr-method-detail-title">{forecast.method.label}</h2>
+        <div className="lr-detail-equation">
+          <span><small>Lead</small><b>{forecast.leadScore}</b></span><i>+</i>
+          <span><small>Support</small><b>{forecast.supportBonus}</b></span><i>=</i>
+          <span><small>Team</small><b>{forecast.teamScore}</b></span><i>vs</i>
+          <span><small>Target</small><b>{forecast.difficulty}</b></span>
+        </div>
+        <div className="lr-detail-section">
+          <div className="lr-detail-heading"><span>{lead.species} · lead-score inputs</span><strong>{forecast.leadScore}</strong></div>
+          {forecast.inputs.map((input) => (
+            <div className="lr-detail-input" key={input.label}>
+              <div><span>{input.label}</span><small>{input.weight == null ? 'fixed modifier' : `${input.weight}% weight`}</small><b>{input.value}</b></div>
+              <div aria-hidden="true"><span style={{ width: `${Math.max(0, Math.min(100, input.value))}%` }} /></div>
+            </div>
+          ))}
+        </div>
+        <ul className="lr-detail-notes">
+          <li><strong>Lead {forecast.leadScore}</strong> combines the creature stats above for this method.</li>
+          <li><strong>Support +{forecast.supportBonus}</strong> comes from {support ? `${support.species}'s coordination stats` : 'the assigned support'} and is capped at 10.</li>
+          {forecast.readiness.lead.scorePenalty > 0 && <li><strong>{forecast.readiness.lead.label} penalty −{forecast.readiness.lead.scorePenalty}</strong> is already included in the lead score.</li>}
+          {forecast.readiness.support.supportPenalty > 0 && <li><strong>{forecast.readiness.support.label} support penalty −{forecast.readiness.support.supportPenalty}</strong> is already included in support.</li>}
+          <li><strong>Target {forecast.difficulty}</strong> is the route requirement. The final margin is <strong>{signed(forecast.margin)}</strong>.</li>
+          <li>Hidden hazards are not included until the crew encounters them.</li>
+        </ul>
+        <div className="lr-detail-flags">
+          <span className={`is-${forecast.quality}`}>{forecast.label}</span>
+          <span>Base lead energy −{forecast.baseLeadStrain}</span>
+          <span>{forecast.unresolvedHazards.length} hidden risk{forecast.unresolvedHazards.length === 1 ? '' : 's'}</span>
+        </div>
+        <button type="button" className="g-btn g-btn--primary" onClick={onClose}>Return to decision</button>
+      </section>
+    </div>
+  );
+}
+
+function CreaturePortrait({ creature, compact = false }) {
+  return (
+    <div className={`lr-portrait lr-portrait--${creature.species.toLowerCase()} g-el-${creature.element.primary}${compact ? ' lr-portrait--compact' : ''}`}>
+      <XalianImage colored speciesName={creature.species} primaryType={creature.element.primary} moreClasses="lr-portrait-image" />
+      <span className="lr-element-mark" title={`${creature.element.primary} element`} aria-label={`${creature.element.primary} element`}>{svgUtil.getSpeciesTypeSymbol(creature.element.primary, false, compact ? 18 : 23, 'lr-element-symbol')}</span>
+    </div>
+  );
+}
+
+function SetupCard({ creature, selected, onToggle, disabled, disabledReason }) {
+  const capabilities = highestCapabilities(creature);
+  return (
+    <button
+      type="button"
+      className={`lr-crew-choice g-el-${creature.element.primary}${selected ? ' lr-crew-choice--selected' : ''}`}
+      onClick={onToggle}
+      disabled={disabled}
+      aria-pressed={selected}
+      title={disabled ? disabledReason : selected ? `Remove ${creature.species} from the crew` : `Add ${creature.species} to the crew`}
+    >
+      <CreaturePortrait creature={creature} />
+      <div className="lr-crew-choice-body">
+        <span className="lr-choice-check"><i className={`bi ${selected ? 'bi-check-lg' : 'bi-plus-lg'}`} /></span>
+        <p className="g-kicker">{creature.planet} / {creature.element.primary}</p>
+        <h3>{creature.species}</h3>
+        <p className="lr-role">{creature.role}</p>
+        <div className="lr-chip-row">
+          {capabilities.map(([key, value]) => <span key={key}>{CAPABILITY_LABELS[key]} {value}</span>)}
+        </div>
+        <div className="lr-choice-footer">
+          <span><i className="bi bi-broadcast" /> {creature.physiology.communication.join(' / ') || 'mute'}</span>
+          <span><i className="bi bi-compass" /> {temperamentPhrase(creature)}</span>
+        </div>
+        {disabled && <span className="lr-choice-disabled"><i className="bi bi-lock-fill" /> {disabledReason}</span>}
+      </div>
+    </button>
+  );
+}
+
+function CrewMember({ creature, strain, selected, role, onClick, disabled, spentAbilities }) {
+  const remaining = creature.abilities.filter((ability) => !spentAbilities.includes(ability.id)).length;
+  const readiness = readinessState(strain);
+  return (
+    <button
+      type="button"
+      className={`lr-crew-member g-el-${creature.element.primary}${selected ? ' lr-crew-member--selected' : ''}${strain >= MAX_STRAIN ? ' lr-crew-member--spent' : ''}`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <CreaturePortrait creature={creature} compact />
+      <div className="lr-crew-member-main">
+        <span className="lr-member-role">{role || creature.role}</span>
+        <strong>{creature.species}</strong>
+        <span className="lr-member-detail">{readiness.label} · {temperamentPhrase(creature)} · {remaining}/{creature.abilities.length} tools</span>
+        <Meter value={strain} max={MAX_STRAIN} label="Energy" danger={strain >= 4} depleted />
+      </div>
+    </button>
+  );
+}
+
+function RouteCard({ route, selected, onSelect, scan }) {
+  const hazards = route.hazardIds.map((id) => scan.hazards.find((hazard) => hazard.id === id)).filter(Boolean);
+  const methodKeys = [...new Set(route.methods.map((method) => method.key))];
+  return (
+    <button type="button" className={`lr-route${selected ? ' lr-route--selected' : ''}`} onClick={onSelect} aria-pressed={selected}>
+      <span className="lr-route-select"><i className={`bi ${selected ? 'bi-record-circle-fill' : 'bi-circle'}`} /></span>
+      <div className="lr-route-title-row">
+        <h3>{route.title}</h3>
+        <span className="lr-difficulty">Target {route.difficulty}</span>
+      </div>
+      <p>{route.description}</p>
+      <div className="lr-env-row">
+        <span><i className="bi bi-cloud" /> {route.environment.medium}</span>
+        <span><i className="bi bi-thermometer-half" /> {route.environment.temperatureC}°C</span>
+        <span className={`g-el-${route.environment.element}`}><i className="bi bi-lightning" /> {route.environment.element}</span>
+      </div>
+      {hazards.map((hazard) => hazard.revealed ? (
+        <div className="lr-hazard lr-hazard--revealed" key={hazard.id}>
+          <i className="bi bi-exclamation-triangle-fill" />
+          <span><strong>{hazard.label}</strong>{hazard.detail}</span>
+        </div>
+      ) : (
+        <div className="lr-hazard" key={hazard.id}>
+          <i className="bi bi-question-diamond" />
+          <span><strong>Unresolved signal</strong>Scout data did not reach command.</span>
+        </div>
+      ))}
+      <div className="lr-route-methods"><span>Best tools</span><div>{methodKeys.map((key) => <b key={key}>{key}</b>)}</div></div>
+      <div className="lr-route-cost"><span><i className="bi bi-buildings" /> Instability +{route.pressure}</span><span><i className="bi bi-box-seam" /> Salvage {route.salvage}</span></div>
+    </button>
+  );
+}
+
+function MissionTrack({ sceneIndex, objectiveReached }) {
+  const current = MISSION.scenes[sceneIndex];
+  return (
+    <div className="lr-track" aria-label="Mission progress">
+      <div className="lr-track-summary">
+        <div><span>Current position</span><strong>Scene {sceneIndex + 1} of {MISSION.scenes.length} · {current.title}</strong></div>
+        <small>Primary objective at scene 5 · scenes 6–7 are optional depth</small>
+      </div>
+      <div className="lr-track-line">
+        {MISSION.scenes.map((scene, index) => {
+          const zone = scene.optional ? 'OPTIONAL' : scene.objective ? 'PRIMARY' : scene.deck.split(' ')[0];
+          const active = index === sceneIndex;
+          return (
+            <div
+              className={`lr-track-node${index < sceneIndex ? ' lr-track-node--done' : ''}${active ? ' lr-track-node--active' : ''}${scene.objective ? ' lr-track-node--objective' : ''}`}
+              key={scene.id}
+              aria-current={active ? 'step' : undefined}
+              aria-label={`Scene ${index + 1}: ${scene.title}. ${zone}${active ? '. Current position' : ''}`}
+            >
+              <span>{index < sceneIndex || (scene.objective && objectiveReached) ? <i className="bi bi-check-lg" /> : index + 1}</span>
+              <div className="lr-track-copy"><strong>{scene.trackLabel}</strong><small>{zone}</small></div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function LongReturnGame() {
+  const sceneRef = React.useRef(null);
+  const [selectedCrew, setSelectedCrew] = useState(initialCrew);
+  const [started, setStarted] = useState(false);
+  const [sceneIndex, setSceneIndex] = useState(0);
+  const [phase, setPhase] = useState('scout');
+  const [scoutId, setScoutId] = useState(null);
+  const [scan, setScan] = useState(null);
+  const [routeId, setRouteId] = useState(null);
+  const [pendingRouteId, setPendingRouteId] = useState(null);
+  const [leadId, setLeadId] = useState(null);
+  const [supportId, setSupportId] = useState(null);
+  const [methodId, setMethodId] = useState(null);
+  const [useCommand, setUseCommand] = useState(false);
+  const [strain, setStrain] = useState({});
+  const [spentAbilities, setSpentAbilities] = useState([]);
+  const [pressure, setPressure] = useState(0);
+  const [salvage, setSalvage] = useState(0);
+  const [commands, setCommands] = useState(2);
+  const [objectiveReached, setObjectiveReached] = useState(false);
+  const [lastResult, setLastResult] = useState(null);
+  const [status, setStatus] = useState('playing');
+  const [log, setLog] = useState([]);
+  const [guidanceLevel, setGuidanceLevel] = useState('simple');
+  const [detailMethodId, setDetailMethodId] = useState(null);
+  const [mechanicsOpen, setMechanicsOpen] = useState(false);
+  const [simpleCustomizing, setSimpleCustomizing] = useState(false);
+  const [encounterState, setEncounterState] = useState(null);
+  const [encounterResolution, setEncounterResolution] = useState(null);
+  const [companion, setCompanion] = useState(null);
+  const [runFlags, setRunFlags] = useState([]);
+  const [transition, setTransition] = useState(null);
+  const [motionCue, setMotionCue] = useState(null);
+  const motionTimerRef = React.useRef(null);
+
+  const cueChanges = (changes) => {
+    if (motionTimerRef.current) clearTimeout(motionTimerRef.current);
+    setMotionCue((current) => ({ id: (current ? current.id : 0) + 1, energy: {}, stability: 0, salvage: 0, ...changes }));
+    motionTimerRef.current = setTimeout(() => setMotionCue(null), 3600);
+  };
+
+  React.useEffect(() => () => {
+    if (motionTimerRef.current) clearTimeout(motionTimerRef.current);
+  }, []);
+
+  const crew = useMemo(() => selectedCrew.map((id) => CREATURES.find((entry) => entry.id === id)).filter(Boolean), [selectedCrew]);
+  const standingCrewCount = crew.filter((member) => (strain[member.id] || 0) < MAX_STRAIN).length;
+  const missionCannotContinue = pressure >= MAX_PRESSURE || standingCrewCount < 2;
+  const baseScene = MISSION.scenes[sceneIndex];
+  const scene = useMemo(() => applyMissionMemory(baseScene, runFlags), [baseScene, runFlags]);
+  const route = scene && scene.routes.find((entry) => entry.id === routeId);
+  const lead = crew.find((entry) => entry.id === leadId);
+  const support = crew.find((entry) => entry.id === supportId);
+  const methods = useMemo(() => lead && route ? methodOptions(lead, route, spentAbilities) : [], [lead, route, spentAbilities]);
+  const method = methods.find((entry) => entry.id === methodId);
+  const reserve = leadId && supportId ? crew.find((entry) => entry.id !== leadId && entry.id !== supportId) : null;
+  const scanScout = crew.find((entry) => entry.id === scoutId);
+  const report = scene && scan ? scanReport(scene, scanScout, scan) : null;
+  const encounterCreature = scene && scene.encounter ? CREATURES.find((entry) => entry.id === scene.encounter.creatureId) : null;
+  const activeEncounterOptions = encounterState && !encounterState.result
+    ? encounterOptions(scene, encounterState.scout, crew, encounterState.mode, encounterState.informed)
+    : [];
+  const currentAction = phase === 'transition'
+    ? { stage: `Scene ${sceneIndex + 1} of ${MISSION.scenes.length} · Arrival`, title: 'See what your last choice changed', hint: 'This beat connects the previous result to the situation now in front of the crew.', icon: 'bi-arrow-down-right-circle', resolved: true }
+    : phase === 'scout'
+    ? { stage: 'Step 1 of 3 · Intelligence', title: 'Choose a scout—or keep the crew together', hint: 'Every large card is an available action. Compare clue finding, reporting, and energy cost.', icon: 'bi-binoculars' }
+    : phase === 'encounter' && !encounterState.result
+      ? { stage: 'Field event · Response required', title: 'Choose how the crew responds', hint: 'Each option shows its crew and annex consequences before you commit.', icon: 'bi-exclamation-diamond' }
+      : phase === 'encounter'
+        ? { stage: 'Field event · Resolved', title: 'Review the outcome, then continue', hint: 'The highlighted button advances to the report or crossing plan.', icon: 'bi-check-circle', resolved: true }
+        : phase === 'scan-result'
+          ? { stage: 'Step 1 complete · Scout report', title: 'Review what the scout learned', hint: scan && !scan.returned && scan.mode !== 'blind' ? 'The scout must return before the crew can use the report.' : 'Use the primary button to move to route selection.', icon: 'bi-broadcast-pin', resolved: true }
+          : phase === 'assign' && !routeId
+            ? { stage: 'Step 2 of 3 · Route', title: 'Choose one route', hint: 'Select a card to preview your choice. Command recommends a route only when the known advantage is clear.', icon: 'bi-signpost-split' }
+            : phase === 'assign'
+              ? { stage: 'Step 3 of 3 · Plan', title: 'Approve the plan—or customize it', hint: 'The selected route is locked in below. You can still change the route or build another crew plan.', icon: 'bi-people' }
+              : { stage: 'Crossing resolved', title: objectiveReached ? 'Review the result, then continue or extract' : 'Review the result, then continue', hint: 'Read “What changed” before deciding how far to push the crew.', icon: 'bi-clipboard-check', resolved: true };
+
+  React.useEffect(() => {
+    if (!started || status !== 'playing' || !sceneRef.current) return;
+    const root = sceneRef.current;
+    let target = root;
+    if (guidanceLevel === 'simple') {
+      if (phase === 'assign' && routeId) target = root.querySelector('.lr-simple-plan') || root.querySelector('.lr-current-action') || root;
+      else target = root.querySelector('.lr-current-action') || root;
+    }
+    if (typeof target.scrollIntoView === 'function') target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [started, status, guidanceLevel, phase, sceneIndex, routeId, encounterState && encounterState.result]);
+  const methodForecasts = useMemo(() => lead && route ? methods.map((entry) => ({
+    method: entry,
+    ...decisionForecast({ route, lead, support, method: entry, scan, leadLoad: strain[lead.id] || 0, supportLoad: support ? strain[support.id] || 0 : 0 })
+  })) : [], [lead, route, support, methods, scan, strain]);
+  const selectedForecast = methodForecasts.find((entry) => entry.method.id === methodId);
+  const detailForecast = methodForecasts.find((entry) => entry.method.id === detailMethodId);
+  const recommendedForecast = methodForecasts.reduce((best, entry) => !best || entry.teamScore > best.teamScore ? entry : best, null);
+  const simpleScoutOptions = useMemo(() => scene ? crew
+    .filter((member) => (strain[member.id] || 0) < MAX_STRAIN - 1)
+    .map((member) => {
+      const preview = scanScene(scene, member);
+      const profile = scoutProfile(scene, member);
+      const outlook = encounterOutlook(scene, member);
+      const encounterScore = outlook ? Math.max(outlook.stealth, outlook.hold, outlook.contact) + outlook.detect * .25 : 0;
+      return { member, preview, profile, outlook, score: preview.revealedIds.length * 100 + (preview.relay ? 20 : 0) - preview.trappedCount * 10 + encounterScore };
+    })
+    .sort((a, b) => b.score - a.score) : [], [scene, crew, strain]);
+  const simpleRoutePlans = useMemo(() => scene && scan ? scene.routes.map((entry) => {
+    const plan = safestPlanForRoute(entry, crew, strain, spentAbilities, scan);
+    if (!plan) return null;
+    const nativeRisk = scene.encounter && scene.encounter.routeId === entry.id && (!encounterResolution || encounterResolution.resolution === 'unresolved');
+    return { ...plan, nativeRisk, risk: plan.risk + (nativeRisk ? encounterResolution ? 18 : 26 : 0) };
+  }).filter(Boolean) : [], [scene, scan, crew, strain, spentAbilities, encounterResolution]);
+  const routeRecommendation = useMemo(() => recommendationFor(simpleRoutePlans), [simpleRoutePlans]);
+  const lowestRiskPlan = simpleRoutePlans.reduce((best, entry) => !best || entry.risk < best.risk ? entry : best, null);
+  const pendingRoutePlan = simpleRoutePlans.find((entry) => entry.route.id === pendingRouteId) || null;
+  const suggestedPlan = route ? simpleRoutePlans.find((entry) => entry.route.id === route.id) : null;
+  const suggestedPlanApplied = suggestedPlan && leadId === suggestedPlan.lead.id && supportId === suggestedPlan.support.id && methodId === suggestedPlan.method.id;
+
+  const resetDecision = (nextPhase = 'scout') => {
+    setPhase(nextPhase); setScoutId(null); setScan(null); setRouteId(null); setPendingRouteId(null); setLeadId(null); setSupportId(null); setMethodId(null); setUseCommand(false); setLastResult(null); setSimpleCustomizing(false); setEncounterState(null); setEncounterResolution(null);
+  };
+
+  const startExpedition = () => {
+    const initialStrain = {};
+    selectedCrew.forEach((id) => { initialStrain[id] = 0; });
+    setStrain(initialStrain); setSpentAbilities([]); setPressure(0); setSalvage(0); setCommands(2); setObjectiveReached(false); setCompanion(null); setRunFlags([]); setTransition(null); setMotionCue(null);
+    setSceneIndex(0); setStatus('playing'); setLog([{ title: 'ANNEX ENTRY', text: 'Crew seal confirmed. The Black Archive mission has begun.' }]);
+    resetDecision(); setStarted(true);
+  };
+
+  const toggleCrew = (id) => {
+    setSelectedCrew((current) => current.includes(id) ? current.filter((entry) => entry !== id) : current.length < 3 ? [...current, id] : current);
+  };
+
+  const proceedBlind = () => {
+    setScoutId(null);
+    setScan({ mode: 'blind', relay: false, returned: true, hazards: scene.hazards.map((hazard) => ({ ...hazard, revealed: false, sensed: false })), revealedIds: [], trappedCount: 0 });
+    setPhase('scan-result');
+    setLog((current) => [{ title: `${scene.deck} / NO SCAN`, text: `The crew preserved its strength and accepted incomplete intelligence at ${scene.title}.` }, ...current].slice(0, 8));
+  };
+
+  const performScanFor = (scout) => {
+    if (!scout) return;
+    const scanned = scanScene(scene, scout);
+    const result = { ...scanned, mode: 'scan', returned: !!scanned.relay };
+    setScoutId(scout.id);
+    setScan(result);
+    setStrain((current) => ({ ...current, [scout.id]: cap((current[scout.id] || 0) + 1) }));
+    cueChanges({ energy: { [scout.id]: 1 } });
+    if (scene.encounter && !encounterResolution) {
+      setEncounterState({ mode: 'scout', scout, informed: true, postPhase: 'scan-result', outlook: encounterOutlook(scene, scout), result: null });
+      setPhase('encounter');
+    } else {
+      setPhase('scan-result');
+    }
+    setLog((current) => [{
+      title: `${scene.deck} / SCAN`,
+      text: result.revealedIds.length
+        ? `${scout.species} relayed ${result.revealedIds.length} actionable hazard signature${result.revealedIds.length > 1 ? 's' : ''}.`
+        : result.trappedCount
+          ? `${scout.species} detected a signal, but ${scout.physiology.communication.join(' / ') || 'silence'} could not carry it back.`
+          : `${scout.species} found no actionable signature. The scene is not necessarily safe.`
+    }, ...current].slice(0, 8));
+  };
+
+  const performScan = () => performScanFor(crew.find((entry) => entry.id === scoutId));
+
+  const recoverScout = () => {
+    if (!scanScout || !scan || scan.returned) return;
+    const hazards = scan.hazards.map((hazard) => hazard.sensed ? { ...hazard, revealed: true } : hazard);
+    setScan({ ...scan, mode: 'debrief', returned: true, hazards, revealedIds: hazards.filter((hazard) => hazard.revealed).map((hazard) => hazard.id) });
+    setStrain((current) => ({ ...current, [scanScout.id]: cap((current[scanScout.id] || 0) + 1) }));
+    setPressure((current) => Math.min(MAX_INSTABILITY, current + 1));
+    cueChanges({ energy: { [scanScout.id]: 1 }, stability: 1 });
+    setLog((current) => [{ title: `${scene.deck} / SCOUT RETURN`, text: `${scanScout.species} returned physically to deliver its report. The delay consumed energy and annex stability.` }, ...current].slice(0, 8));
+  };
+
+  const resolveEncounter = (option) => {
+    if (!encounterState || !option || !encounterCreature) return;
+    let affected = encounterState.scout;
+    if (encounterState.mode === 'scout') {
+      const added = option.scoutStrain || 0;
+      if (added && affected) setStrain((current) => ({ ...current, [affected.id]: cap((current[affected.id] || 0) + added) }));
+    } else if (option.crewStrain) {
+      affected = [...crew].sort((a, b) => scoutProfile(scene, b).hold - scoutProfile(scene, a).hold)[0];
+      if (affected) setStrain((current) => ({ ...current, [affected.id]: cap((current[affected.id] || 0) + option.crewStrain) }));
+    }
+    if (option.instability) setPressure((current) => Math.min(MAX_INSTABILITY, current + option.instability));
+    cueChanges({ energy: affected && (option.scoutStrain || option.crewStrain) ? { [affected.id]: option.scoutStrain || option.crewStrain } : {}, stability: option.instability || 0 });
+    if (option.companion) setCompanion({ creature: encounterCreature, ready: true, benefit: scene.encounter.companionBenefit });
+    const archetype = scene.encounter.archetype || 'injured';
+    const narrative = option.companion
+      ? `${encounterCreature.species} accepts the crew's help and follows at a cautious distance. It may intervene once during a later crossing.`
+      : archetype === 'territorial' && option.resolution === 'cleared'
+        ? `${affected ? affected.species : 'The crew'} establishes a boundary the ${encounterCreature.species} accepts. It withdraws into the hull and leaves the passage open.`
+        : archetype === 'trapped' && option.resolution === 'cleared'
+          ? `${affected ? affected.species : 'The crew'} stills the authentication arms. The ${encounterCreature.species} escapes into a side duct and its panicked signal fades from the lock.`
+      : option.resolution === 'cleared'
+        ? `${affected ? affected.species : 'The crew'} forces enough space to continue. The native retreats deeper into the machinery.`
+        : option.resolution === 'detour'
+          ? 'The crew backs away before the encounter escalates and returns to the route junction.'
+          : `${encounterState.scout.species} breaks contact and returns with a warning. The native still occupies the underdeck.`;
+    const result = { ...option, affected, narrative };
+    setEncounterResolution(result);
+    setEncounterState((current) => ({ ...current, result }));
+    setLog((current) => [{ title: `${scene.deck} / FIELD ENCOUNTER`, text: narrative }, ...current].slice(0, 8));
+  };
+
+  const continueEncounter = () => {
+    if (!encounterState || !encounterState.result) return;
+    if (encounterState.result.resolution === 'detour') { setRouteId(null); setPendingRouteId(null); }
+    setPhase(encounterState.postPhase || 'assign');
+    setEncounterState(null);
+  };
+
+  const chooseRoute = (id) => {
+    setRouteId(id); setPendingRouteId(null); setLeadId(null); setSupportId(null); setMethodId(null); setUseCommand(false); setSimpleCustomizing(false);
+    if (scene.encounter && scene.encounter.routeId === id && (!encounterResolution || encounterResolution.resolution === 'unresolved')) {
+      setEncounterState({ mode: 'group', scout: null, informed: !!encounterResolution, postPhase: 'assign', result: null });
+      setPhase('encounter');
+    }
+  };
+
+  const changeRoute = () => {
+    setRouteId(null); setPendingRouteId(null); setLeadId(null); setSupportId(null); setMethodId(null); setUseCommand(false); setSimpleCustomizing(false);
+  };
+
+  const previewSimpleRoute = (id) => {
+    setPendingRouteId(id);
+  };
+
+  const confirmSimpleRoute = () => {
+    if (pendingRouteId) chooseRoute(pendingRouteId);
+  };
+
+  const applySuggestedPlan = () => {
+    if (!suggestedPlan) return;
+    setLeadId(suggestedPlan.lead.id); setSupportId(suggestedPlan.support.id); setMethodId(suggestedPlan.method.id); setUseCommand(false);
+  };
+
+  const chooseLead = (id) => {
+    setLeadId(id); if (supportId === id) setSupportId(null); setMethodId(null); setUseCommand(false);
+  };
+
+  const commit = () => {
+    if (!scene || !route || !lead || !support || !method || !scan) return;
+    let result = resolveScene({ scene, route, lead, support, method, scan, useCommand, leadLoad: strain[lead.id] || 0, supportLoad: strain[support.id] || 0 });
+    let companionHelp = null;
+    if (companion && companion.ready && result.leadStrain > 0) {
+      result = { ...result, leadStrain: result.leadStrain - 1 };
+      companionHelp = `${companion.creature.species} braces the crossing and preserves 1 energy.`;
+      setCompanion((current) => ({ ...current, ready: false }));
+    }
+    const nextPressure = Math.min(MAX_PRESSURE, pressure + result.pressure);
+    const nextStrain = {
+      ...strain,
+      [lead.id]: cap((strain[lead.id] || 0) + result.leadStrain),
+      [support.id]: cap((strain[support.id] || 0) + result.supportStrain)
+    };
+    const reached = objectiveReached || !!scene.objective;
+    const totalStrain = result.leadStrain + result.supportStrain;
+    const impactQuality = totalStrain === 0 && result.pressure === 0 ? 'clean' : totalStrain + result.pressure <= 3 ? 'costly' : 'dangerous';
+    const causes = [
+      `${lead.species} chose ${method.label} for the “${route.title}” route.`,
+      result.margin >= 14 ? `The crew beat the route target by ${result.margin}, so the crossing itself consumed no base energy.` : result.margin >= 0 ? `The crew beat the route target by only ${result.margin}, so the lead spent extra energy.` : `The crew fell ${Math.abs(result.margin)} below the route target, forcing a costly passage.`,
+      ...result.environment.notes.map((note) => `${lead.species} ${note}.`),
+      ...result.unseenHazards.map((hazard) => `${hazard.label} was not identified before the crew entered the route.`),
+      companionHelp
+    ].filter(Boolean);
+    const authoredStory = route.outcomes && (route.outcomes[result.quality] || route.outcomes.rough);
+    result = {
+      ...result,
+      companionHelp,
+      impactQuality,
+      impactLabel: impactQuality === 'clean' ? 'Clean success' : impactQuality === 'costly' ? 'Costly success' : 'Dangerous success',
+      story: authoredStory || `${lead.species} leads the crew along “${route.title}” using ${method.label}.`,
+      reaction: creatureReaction(lead, result.quality, route),
+      consequence: route.consequence || null,
+      causes,
+      crewChanges: [
+        { creature: lead, added: result.leadStrain, before: strain[lead.id] || 0, after: nextStrain[lead.id], beforeState: readinessState(strain[lead.id] || 0), afterState: readinessState(nextStrain[lead.id]) },
+        { creature: support, added: result.supportStrain, before: strain[support.id] || 0, after: nextStrain[support.id], beforeState: readinessState(strain[support.id] || 0), afterState: readinessState(nextStrain[support.id]) }
+      ],
+      instabilityChange: { added: result.pressure, before: pressure, after: nextPressure, beforeState: instabilityState(pressure), afterState: instabilityState(nextPressure) },
+      salvageAfter: salvage + result.salvage
+    };
+
+    setPressure(nextPressure);
+    setStrain(nextStrain);
+    setSalvage((current) => current + result.salvage);
+    cueChanges({ energy: { [lead.id]: result.leadStrain, [support.id]: result.supportStrain }, stability: result.pressure, salvage: result.salvage });
+    setObjectiveReached(reached);
+    if (result.abilityId) setSpentAbilities((current) => [...current, result.abilityId]);
+    if (useCommand && !result.naturalReaction) setCommands((current) => Math.max(0, current - 1));
+    if (route.consequence) setRunFlags((current) => current.includes(route.consequence.id) ? current : [...current, route.consequence.id]);
+    setLastResult(result);
+    setPhase('result');
+    setSimpleCustomizing(false);
+    setLog((current) => [{ title: `${scene.deck} / ${route.title}`, text: `${result.impactLabel}: ${result.story}` }, ...current].slice(0, 8));
+
+  };
+
+  const continueRun = () => {
+    if (missionCannotContinue) {
+      setStatus('failed');
+      return;
+    }
+    if (sceneIndex >= MISSION.scenes.length - 1) {
+      setStatus('complete');
+      return;
+    }
+    const nextIndex = sceneIndex + 1;
+    setTransition({
+      from: scene.title,
+      to: MISSION.scenes[nextIndex].title,
+      consequence: lastResult && lastResult.consequence,
+      lead: lastResult && lastResult.crewChanges[0].creature,
+      reaction: lastResult && lastResult.reaction
+    });
+    setSceneIndex(nextIndex);
+    resetDecision('transition');
+  };
+
+  const enterScene = () => {
+    setTransition(null);
+    setPhase('scout');
+  };
+
+  const extract = () => setStatus(objectiveReached ? 'extracted' : 'aborted');
+
+  const returnToCrew = () => {
+    setStarted(false); setStatus('playing');
+  };
+
+  if (!started) {
+    return (
+      <main className={`lr-shell lr-mode-${guidanceLevel}`}>
+        <section className="lr-briefing g-panel g-panel--bolted">
+          <div className="lr-briefing-copy">
+            <p className="g-kicker">Wayfinder Operations / Prototype Mission</p>
+            <h1 className="g-title">The Long Return</h1>
+            <p className="lr-lead">Bring three creatures into a dying End-Wars annex. Read what they can perceive. Trust what their bodies can do. Recover the index, then decide how much farther you dare to go.</p>
+            <div className="lr-mission-stamp">
+              <span>CONTRACT</span><strong>{MISSION.title}</strong><small>{MISSION.location}</small>
+            </div>
+          </div>
+          <div className="g-screen lr-briefing-screen">
+            <p className="g-screen-line">OBJECTIVE :: {MISSION.objective}</p>
+            <p className="g-screen-line g-screen-line--dim">{MISSION.briefing}</p>
+            <div className={`lr-howto${guidanceLevel === 'simple' ? ' lr-simple-hidden' : ''}`}>
+              <span><b>1</b> Scout or move blind</span>
+              <span><b>2</b> Choose a route target</span>
+              <span><b>3</b> Build a team score</span>
+              <span><b>4</b> Meet or beat the target</span>
+              <span><b>5</b> Resolve energy / stability</span>
+              <span><b>6</b> Push or extract</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="lr-crew-select">
+          <div className="lr-section-head">
+            <div><p className="g-kicker">Crew manifest</p><h2 className="g-h2">Choose three Xalians</h2></div>
+            <div className="lr-selection-count"><strong>{selectedCrew.length}</strong><span>/ 3 assigned</span></div>
+          </div>
+          {guidanceLevel === 'simple' ? <SimplePrimer /> : <CrossingPrimer />}
+          <div className="lr-choice-grid">
+            {CREATURES.map((creature) => (
+              <SetupCard
+                key={creature.id}
+                creature={creature}
+                selected={selectedCrew.includes(creature.id)}
+                disabled={!selectedCrew.includes(creature.id) && selectedCrew.length >= 3}
+                disabledReason="Crew full — deselect one creature first"
+                onToggle={() => toggleCrew(creature.id)}
+              />
+            ))}
+          </div>
+          <div className="lr-guidance-setup g-panel g-panel--recessed">
+            <div>
+              <p className="g-kicker">Decision support</p>
+              <h2>Choose how much command explains</h2>
+              <p>Guidance changes the analysis shown to you, not the mission math, creature stats, rewards, or consequences. You can change it during crew assignment.</p>
+            </div>
+            <GuidanceSelector value={guidanceLevel} onChange={setGuidanceLevel} />
+          </div>
+          <div className="lr-launch-row">
+            <p><i className="bi bi-info-circle" /> Prototype records are authored for this mission from the ratified creature schema.</p>
+            <button className="g-btn g-btn--primary lr-launch" type="button" disabled={selectedCrew.length !== 3} title={selectedCrew.length !== 3 ? `Choose ${3 - selectedCrew.length} more creature${3 - selectedCrew.length === 1 ? '' : 's'}` : 'Begin the expedition'} onClick={startExpedition}>
+              {selectedCrew.length === 3 ? 'Seal Crew & Enter Annex' : `Choose ${3 - selectedCrew.length} More`} <i className={`bi ${selectedCrew.length === 3 ? 'bi-arrow-right' : 'bi-lock-fill'}`} />
+            </button>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  if (status !== 'playing') {
+    const success = status === 'complete' || status === 'extracted';
+    const banked = status === 'failed' ? (objectiveReached ? Math.ceil(salvage / 2) : 0) : salvage;
+    return (
+      <main className="lr-shell lr-end-shell">
+        <section className={`g-panel g-panel--bolted lr-end-card${success ? ' lr-end-card--success' : ''}`}>
+          <p className="g-kicker">Mission report / {MISSION.id}</p>
+          <div className="lr-end-seal"><i className={`bi ${success ? 'bi-check2-circle' : 'bi-exclamation-octagon'}`} /></div>
+          <h1 className="g-title">{status === 'complete' ? 'Deep Retrieval Complete' : status === 'extracted' ? 'Crew Extracted' : status === 'aborted' ? 'Mission Aborted' : 'Forced Extraction'}</h1>
+          <p className="lr-end-copy">
+            {objectiveReached
+              ? 'The Nemesis Index made it out. Whatever the annex took from the crew, the mission mattered.'
+              : 'The crew returned without the Nemesis Index. No creature record was changed; the failure belongs to this run alone.'}
+          </p>
+          <div className="lr-end-stats">
+            <div><span>Objective</span><strong>{objectiveReached ? 'SECURED' : 'LOST'}</strong></div>
+            <div><span>Salvage banked</span><strong>{banked} · {banked >= 20 ? 'Exceptional haul' : banked >= 10 ? 'Strong haul' : banked > 0 ? 'Light haul' : 'None'}</strong></div>
+            <div><span>Annex stability</span><strong>{MAX_INSTABILITY - pressure} / {MAX_INSTABILITY}</strong></div>
+            <div><span>Scenes crossed</span><strong>{sceneIndex + (phase === 'result' ? 1 : 0)} / {MISSION.scenes.length}</strong></div>
+          </div>
+          <div className="lr-end-crew">
+            {crew.map((member) => <CrewMember key={member.id} creature={member} strain={strain[member.id] || 0} spentAbilities={spentAbilities} disabled />)}
+          </div>
+          <div className="lr-end-actions">
+            <button type="button" className="g-btn" onClick={returnToCrew}>Change Crew</button>
+            <button type="button" className="g-btn g-btn--primary" onClick={startExpedition}>Run Contract Again</button>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  const leadReactionMatch = lead && route ? reactionMatches(lead, route.reaction) : null;
+  const assignment = assignmentStatus({ route, lead, support, method });
+  const canCommit = assignment.ready;
+  return (
+    <main className={`lr-shell lr-play-shell lr-mode-${guidanceLevel}${simpleCustomizing ? ' lr-is-customizing' : ''}`}>
+      <header className="lr-mission-head">
+        <div><p className="g-kicker">{MISSION.location}</p><h1>{MISSION.title}</h1></div>
+        <div className="lr-head-readouts">
+          <button type="button" className="lr-rules-button" onClick={() => setMechanicsOpen(true)}><i className="bi bi-question-circle" /> How crossings work</button>
+          <Meter value={pressure} max={MAX_INSTABILITY} label="Annex stability" danger={pressure >= 7} depleted />
+          <div className={`lr-counter lr-salvage-counter${motionCue && motionCue.salvage ? ' is-changing' : ''}`} title="Optional mission loot. It is banked when the crew extracts and does not make crossings easier."><span>Mission loot</span><strong>{salvage}</strong>{motionCue && motionCue.salvage > 0 && <em key={motionCue.id}>+{motionCue.salvage}</em>}</div>
+          <div className="lr-counter"><span>Commands</span><strong>{commands}</strong></div>
+        </div>
+      </header>
+
+      <MissionTrack sceneIndex={sceneIndex} objectiveReached={objectiveReached} />
+
+      {guidanceLevel === 'simple' && <SimpleRunStatus crew={crew} strain={strain} pressure={pressure} objectiveReached={objectiveReached} companion={companion} motionCue={motionCue} />}
+
+      <div className="lr-game-grid">
+        <aside className="lr-crew-rail g-panel g-panel--recessed">
+          <div className="lr-rail-title"><p className="g-kicker">Crew status</p><span>{phase === 'scout' ? 'SELECT SCOUT' : phase === 'scan-result' ? 'SCAN REPORT' : phase === 'assign' ? 'ASSIGN ROLES' : 'SCENE CLEAR'}</span></div>
+          {crew.map((member) => {
+            let selected = false;
+            let role = null;
+            let click = null;
+            let disabled = (strain[member.id] || 0) >= MAX_STRAIN;
+            if (phase === 'scout' && (strain[member.id] || 0) >= MAX_STRAIN - 1) disabled = true;
+            if (phase === 'scout') { selected = scoutId === member.id; role = selected ? 'Scout assigned' : 'Select as scout'; click = () => setScoutId(member.id); }
+            if (phase === 'assign' && route) { selected = leadId === member.id; role = selected ? 'Lead assigned' : supportId === member.id ? 'Support assigned' : reserve && reserve.id === member.id ? 'Reserve' : 'Select as lead'; click = () => chooseLead(member.id); }
+            return <CrewMember key={member.id} creature={member} strain={strain[member.id] || 0} selected={selected} role={role} onClick={click} disabled={disabled || !click} spentAbilities={spentAbilities} />;
+          })}
+          <div className="lr-ability-ledger">
+            <p className="g-label">Expedition tools</p>
+            {crew.flatMap((member) => member.abilities.map((ability) => (
+              <div key={ability.id} className={spentAbilities.includes(ability.id) ? 'is-spent' : ''}>
+                <span className={`g-el-${ability.medium}`}>{ability.action}</span><strong>{ability.name}</strong><small>{spentAbilities.includes(ability.id) ? 'SPENT' : ability.intensity}</small>
+              </div>
+            )))}
+          </div>
+        </aside>
+
+        <section className="lr-scene g-panel g-panel--bolted" ref={sceneRef}>
+          <div className="lr-scene-heading">
+            <div><p className="g-kicker">{scene.deck} / Scene {sceneIndex + 1} of {MISSION.scenes.length}</p><h2 className="g-h2">{scene.title}</h2></div>
+            {scene.objective && <span className="lr-objective-badge">PRIMARY OBJECTIVE</span>}
+            {scene.optional && <span className="lr-optional-badge">OPTIONAL DEPTH</span>}
+          </div>
+          <p className="lr-scene-copy">{scene.description}</p>
+          <div className="lr-scene-orientation">
+            <div><span>Immediate objective</span><strong>{scene.goal}</strong></div>
+            <div><span>All routes converge at</span><strong>{scene.destination}</strong></div>
+          </div>
+
+          {guidanceLevel === 'simple' && <CurrentAction key={`${phase}-${sceneIndex}-${encounterState && encounterState.result ? 'resolved' : 'active'}-${routeId || 'none'}`} {...currentAction} onHelp={() => setMechanicsOpen(true)} />}
+          {guidanceLevel === 'simple' && motionCue && <ActionFeedback key={motionCue.id} cue={motionCue} crew={crew} />}
+
+          {phase === 'transition' && transition && (
+            <div className="lr-transition-beat">
+              <div className="lr-transition-route"><span>{transition.from}</span><i className="bi bi-arrow-right" /><strong>{transition.to}</strong></div>
+              <p>{scene.arrival || scene.description}</p>
+              {transition.reaction && <blockquote><i className="bi bi-chat-quote" /> “{transition.reaction}”</blockquote>}
+              {transition.consequence && <div className="lr-memory-card">
+                <i className="bi bi-diagram-3-fill" />
+                <div><span>Your earlier route matters here</span><strong>{transition.consequence.label}</strong><p>{transition.consequence.detail}</p></div>
+              </div>}
+              {scene.routes.some((entry) => entry.activeEffects && entry.activeEffects.length) && <div className="lr-memory-effects">
+                <span>Changed in this scene</span>
+                {scene.routes.flatMap((entry) => entry.activeEffects.map((effect) => <div key={`${entry.id}-${effect.flag}`}><strong>{entry.title}</strong><b>{effect.difficulty < 0 ? 'Easier' : 'Harder'} by {Math.abs(effect.difficulty)}</b><small>{effect.detail}</small></div>))}
+              </div>}
+              <button type="button" className="g-btn g-btn--primary" onClick={enterScene}>Enter {scene.title} <i className="bi bi-arrow-right" /></button>
+            </div>
+          )}
+
+          {phase === 'encounter' && encounterState && encounterCreature && (
+            <div className={`lr-field-encounter${encounterState.result ? ' is-resolved' : ''}`}>
+              {!encounterState.result ? <>
+                <div className="lr-encounter-heading">
+                  <CreaturePortrait creature={encounterCreature} compact />
+                  <div><span>{encounterState.mode === 'scout' ? 'Scout encounter' : encounterState.informed ? 'Prepared crew encounter' : 'Unexpected crew encounter'}</span><h3>{scene.encounter.title}</h3><p>{scene.encounter.description}</p></div>
+                </div>
+                {encounterState.mode === 'scout' && encounterState.outlook && <div className={`lr-encounter-posture is-${encounterState.outlook.posture}`}>
+                  <strong>{encounterState.outlook.label}</strong>
+                  <span>{encounterState.outlook.posture === 'scout-first' ? `${encounterState.scout.species} sees the native before being cornered.` : encounterState.outlook.posture === 'native-first' ? `The native catches ${encounterState.scout.species} out of position. The surprise costs 1 extra energy.` : `${encounterState.scout.species} and the native notice one another at the same moment.`}</span>
+                  <small>{encounterState.outlook.channel ? `Crew contact available through ${encounterState.outlook.channel}.` : 'No remote crew contact. Getting help requires a physical return.'}</small>
+                </div>}
+                {encounterState.mode === 'group' && <div className="lr-encounter-posture"><strong>{encounterState.informed ? 'The crew arrives prepared' : 'The native acts before the crew can organize'}</strong><span>{encounterState.informed ? 'The scout’s warning prevents a surprise energy cost.' : 'The most defensive crew member will absorb the first consequence.'}</span></div>}
+                <div className="lr-encounter-options">
+                  {activeEncounterOptions.map((option) => {
+                    const affectedCreature = encounterState.scout || [...crew].sort((a, b) => scoutProfile(scene, b).hold - scoutProfile(scene, a).hold)[0];
+                    const strainCost = option.scoutStrain || option.crewStrain || 0;
+                    const instabilityCost = option.instability || 0;
+                    return <button type="button" key={option.id} className={option.recommended ? 'is-recommended' : ''} onClick={() => resolveEncounter(option)}>
+                      <span>{option.recommended ? 'Recommended response' : 'Alternate response'}</span><strong>{option.label}</strong><p>{option.summary}</p>
+                      <div className="lr-encounter-choice-signals">
+                        {strainCost > 0 && affectedCreature && <span className="lr-route-projection is-crew"><span><i className="bi bi-lightning-charge-fill" /><small>{affectedCreature.species} energy</small><strong>−{strainCost}</strong></span><ProjectionTrack value={strain[affectedCreature.id] || 0} added={strainCost} max={MAX_STRAIN} label={`${affectedCreature.species} energy`} kind="strain" /></span>}
+                        {instabilityCost > 0 && <span className="lr-route-projection is-annex"><span><i className="bi bi-buildings" /><small>Annex stability</small><strong>−{instabilityCost}</strong></span><ProjectionTrack value={pressure} added={instabilityCost} max={MAX_INSTABILITY} label="Annex stability" kind="annex" /></span>}
+                        {!strainCost && !instabilityCost && <span className="lr-route-no-cost"><i className="bi bi-check-circle-fill" /> No immediate cost</span>}
+                        {option.companion && <span className="lr-encounter-companion"><i className="bi bi-person-plus-fill" /><span><small>Possible benefit</small><strong>Field companion may join</strong></span></span>}
+                      </div>
+                    </button>;
+                  })}
+                </div>
+              </> : <>
+                <div className="lr-encounter-result-head"><i className={`bi ${encounterState.result.companion ? 'bi-person-check-fill' : encounterState.result.resolution === 'detour' ? 'bi-sign-turn-right-fill' : 'bi-shield-check'}`} /><div><span>Encounter resolved</span><h3>{encounterState.result.companion ? 'The native chooses to follow' : encounterState.result.resolution === 'unresolved' ? 'The scout returns with a warning' : encounterState.result.resolution === 'detour' ? 'The crew avoids contact' : 'The route is clear'}</h3></div></div>
+                <p className="lr-simple-story">{encounterState.result.narrative}</p>
+                <div className="lr-encounter-impact">
+                  {(encounterState.result.scoutStrain || encounterState.result.crewStrain) > 0 ? <span><i className="bi bi-lightning-charge-fill" /><strong>Energy spent</strong> −{encounterState.result.scoutStrain || encounterState.result.crewStrain}</span> : <span className="is-good"><i className="bi bi-check-circle" /><strong>No energy spent</strong></span>}
+                  {encounterState.result.instability > 0 ? <span><i className="bi bi-buildings" /><strong>Stability lost</strong> −{encounterState.result.instability}</span> : <span className="is-good"><i className="bi bi-check-circle" /><strong>No stability lost</strong></span>}
+                  {encounterState.result.companion && <span className="is-good"><i className="bi bi-person-plus-fill" /><strong>Field companion</strong> {scene.encounter.companionBenefit}</span>}
+                </div>
+                <button type="button" className="g-btn g-btn--primary" onClick={continueEncounter}>{encounterState.result.resolution === 'detour' ? 'Compare routes again' : encounterState.mode === 'scout' ? 'Review scout report' : 'Plan the crossing'} <i className="bi bi-arrow-right" /></button>
+              </>}
+            </div>
+          )}
+
+          {phase === 'scout' && (guidanceLevel === 'simple' ? (
+            <div className="lr-simple-decision">
+              <div className="lr-simple-question"><span>Decision now</span><h3>Who should scout—or should the crew stay together?</h3><p>Compare what each creature can discover, how it reports back, and the resources its trip will consume.</p></div>
+              {scene.encounterHint && <div className="lr-field-sign"><i className="bi bi-binoculars-fill" /><div><span>Field sign</span><strong>Native contact is possible</strong><p>{scene.encounterHint}</p></div></div>}
+              <div className="lr-simple-scouts">
+                {simpleScoutOptions.map((option, index) => {
+                  return <button type="button" key={option.member.id} className={index === 0 ? 'is-recommended' : ''} onClick={() => performScanFor(option.member)}>
+                    <CreaturePortrait creature={option.member} compact />
+                    <span className="lr-scout-card-copy">
+                      <span className="lr-scout-card-head">
+                        {index === 0 && <em>Recommended</em>}
+                        <strong>{option.member.species}</strong>
+                        <small><i className={`bi ${scoutRoleIcon(option.profile.role)}`} /> {option.profile.role}</small>
+                        {option.outlook && <span className="lr-scout-contact"><i className="bi bi-exclamation-diamond" /><span><small>If a native appears</small><strong>{option.outlook.label}</strong></span></span>}
+                      </span>
+                      <span className={`lr-scout-relay ${option.preview.relay ? 'is-good' : 'is-warning'}`} aria-label={`${option.member.species} has a ${option.profile.detect >= 80 ? 'excellent' : option.profile.detect >= 65 ? 'strong' : 'limited'} chance to find hidden danger and spends 1 energy scouting; ${option.preview.relay ? `its ${option.profile.channel} communication reaches the crew and the report arrives without a return trip` : 'it has no compatible relay, so it returns physically and spends 1 additional energy while the annex loses 1 stability'}`}>
+                        <small>Likely trip</small>
+                        <span className="lr-scout-storyline">
+                          <span className="lr-scout-story-step is-discovery">
+                            <i className="bi bi-binoculars-fill" />
+                            <span><small>Scout for danger</small><b>{option.profile.detect >= 80 ? 'Excellent chance' : option.profile.detect >= 65 ? 'Strong chance' : 'Limited chance'}</b></span>
+                            <SignalGauge value={option.profile.detect} label={`${option.member.species} chance to find hidden danger`} />
+                            <em className="is-energy"><i className="bi bi-lightning-charge-fill" /> Uses 1 energy</em>
+                          </span>
+                          <i className="bi bi-chevron-right" aria-hidden="true" />
+                          <span className="lr-scout-story-step is-communication">
+                            <i className={`bi ${option.preview.relay ? 'bi-broadcast-pin' : 'bi-broadcast'}`} />
+                            <span><small>Communication</small><b>{option.preview.relay ? `${labelCase(option.profile.channel)} connects` : 'No compatible relay'}</b></span>
+                          </span>
+                          <i className="bi bi-chevron-right" aria-hidden="true" />
+                          <span className="lr-scout-story-step is-followup">
+                            <i className={`bi ${option.preview.relay ? 'bi-check-circle-fill' : 'bi-arrow-return-left'}`} />
+                            <span><small>{option.preview.relay ? 'Follow-up' : 'Must return'}</small><b>{option.preview.relay ? 'Report reaches crew' : 'Returns to crew'}</b></span>
+                            {option.preview.relay
+                              ? <em className="is-safe"><i className="bi bi-shield-check" /> No return needed</em>
+                              : <span className="lr-return-cost"><em className="is-energy"><i className="bi bi-lightning-charge-fill" /> Uses 1 more energy</em><em className="is-stability"><i className="bi bi-buildings-fill" /> Loses 1 stability</em></span>}
+                          </span>
+                        </span>
+                      </span>
+                      <b className="lr-scout-action">Choose <i className="bi bi-arrow-right" /></b>
+                    </span>
+                  </button>;
+                })}
+              </div>
+              <button type="button" className="lr-simple-secondary lr-skip-scout" onClick={proceedBlind}><i className="bi bi-people-fill" /><strong>Keep the crew together</strong><span className="lr-skip-scout-signals"><em><i className="bi bi-shield-check" /> No energy spent</em><em><i className="bi bi-eye-slash" /> Route danger stays hidden</em>{scene.encounter && <em><i className="bi bi-exclamation-diamond" /> Meet natives as a group</em>}</span><b>Choose no scout <i className="bi bi-arrow-right" /></b></button>
+            </div>
+          ) : (
+            <div className="lr-phase-panel">
+              <div className="lr-phase-intro"><span className="lr-step-number">01</span><div><h3>Read the scene</h3><p>Scanning costs the scout 1 energy. A strong sense still needs a communication channel that can cross this chamber.</p></div></div>
+              <div className="lr-signal-board">
+                <div><span>Relay accepts</span><strong>{scene.relayChannels.join(' / ')}</strong></div>
+                <div><span>Known facets</span><strong>{scene.routes.length} routes / {scene.hazards.length} concealed signal</strong></div>
+              </div>
+              {scoutId && (() => {
+                const preview = scanScene(scene, crew.find((member) => member.id === scoutId));
+                return <div className={`lr-scan-preview${preview.relay ? ' is-good' : ''}`}><i className={`bi ${preview.relay ? 'bi-broadcast-pin' : 'bi-broadcast'}`} /><span>{preview.relay ? 'Relay channel established.' : 'No compatible relay. Detected details may be trapped with the scout.'}</span></div>;
+              })()}
+              <div className="lr-action-row">
+                <button type="button" className="g-btn" onClick={proceedBlind}>Proceed Blind</button>
+                <button type="button" className="g-btn g-btn--primary" disabled={!scoutId} title={!scoutId ? 'Select a scout from the crew rail first' : `Send ${scanScout.species} to scout`} onClick={performScan}>{scoutId ? 'Run Field Scan' : 'Select Scout to Enable Scan'} <i className={`bi ${scoutId ? 'bi-arrow-right' : 'bi-lock-fill'}`} /></button>
+              </div>
+            </div>
+          ))}
+
+          {phase === 'scan-result' && report && (guidanceLevel === 'simple' ? (
+            <div className={`lr-simple-decision lr-simple-report is-${report.outcome}`}>
+              <div className="lr-simple-report-result"><i className={`bi ${report.revealed.length ? 'bi-shield-exclamation' : report.outcome === 'blind' ? 'bi-eye-slash' : 'bi-check-circle'}`} /><div><span>Scout result</span><h3>{report.title}</h3></div></div>
+              <p className="lr-simple-story">{report.narrative}</p>
+              <div className="lr-simple-finding">
+                <span>What matters for your next choice</span>
+                {report.revealed.length ? report.revealed.map((hazard) => <strong key={hazard.id}><i className="bi bi-exclamation-triangle-fill" /> {hazard.label}</strong>) : <strong><i className="bi bi-question-circle" /> No route danger was confirmed</strong>}
+                <p>{report.decision}</p>
+              </div>
+              {!scan.returned && scan.mode !== 'blind' ? <button type="button" className="g-btn g-btn--primary" onClick={recoverScout}>Wait for {scanScout.species} to return <span>−1 energy · −1 stability</span> <i className="bi bi-arrow-right" /></button> : <button type="button" className="g-btn g-btn--primary" onClick={() => setPhase('assign')}>Choose a route <i className="bi bi-arrow-right" /></button>}
+            </div>
+          ) : (
+            <div className={`lr-phase-panel lr-scan-report lr-scan-report--${report.outcome}`}>
+              <div className="lr-report-head">
+                <span className="lr-report-seal"><i className={`bi ${report.outcome === 'revealed' ? 'bi-broadcast-pin' : report.outcome === 'trapped' || report.outcome === 'unrelayed' ? 'bi-reception-1' : report.outcome === 'blind' ? 'bi-eye-slash' : 'bi-check2-circle'}`} /></span>
+                <div><p className="g-kicker">Step 02 / Field report / {scene.deck}</p><h3>{report.title}</h3></div>
+              </div>
+              <p className="lr-report-narrative">{report.narrative}</p>
+              <div className="lr-report-readouts">
+                <div><span>Scout</span><strong>{scanScout ? scanScout.species : 'None committed'}</strong></div>
+                <div><span>Energy spent</span><strong>−{report.strainCost}</strong></div>
+                <div><span>Relay</span><strong>{report.channel || (report.outcome === 'blind' ? 'Not attempted' : 'Failed')}</strong></div>
+                <div><span>Actionable hazards</span><strong>{report.revealed.length} / {scene.hazards.length}</strong></div>
+              </div>
+              {report.revealed.map((hazard) => (
+                <div className="lr-intel-card" key={hazard.id}>
+                  <i className="bi bi-exclamation-triangle-fill" />
+                  <div><span>Confirmed hazard</span><strong>{hazard.label}</strong><p>{hazard.detail}</p><small>Affects: {report.affectedRoutes.filter((entry) => entry.hazardIds.includes(hazard.id)).map((entry) => entry.title).join(' / ')}</small></div>
+                </div>
+              ))}
+              {report.trapped.map((hazard) => (
+                <div className="lr-intel-card lr-intel-card--trapped" key={hazard.id}>
+                  <i className="bi bi-broadcast" />
+                  <div><span>Scout-only impression</span><strong>Unresolved in command view</strong><p>The scout sensed a field response, but no usable description reached the crew.</p></div>
+                </div>
+              ))}
+              <div className="lr-report-analysis">
+                <div><span>Finding</span><p>{report.finding}</p></div>
+                <div><span>How this changes your decision</span><p>{report.decision}</p></div>
+              </div>
+              <div className="lr-action-row">
+                {!scan.returned && scan.mode !== 'blind' ? <button type="button" className="g-btn g-btn--primary" onClick={recoverScout}>Wait for scout return · −1 energy / −1 stability</button> : <button type="button" className="g-btn g-btn--primary" onClick={() => setPhase('assign')}>
+                  {report.outcome === 'blind' ? 'Accept Unknowns & Compare Routes' : 'Acknowledge Report & Compare Routes'} <i className="bi bi-arrow-right" />
+                </button>}
+              </div>
+            </div>
+          ))}
+
+          {phase === 'assign' && scan && (
+            <div className="lr-phase-panel">
+              {guidanceLevel === 'simple' ? <div className="lr-simple-question"><span>Decision now</span><h3>How should the crew cross?</h3><p>Compare how much energy and stability each route consumes against the optional salvage it recovers.</p></div> : <>
+                <div className="lr-phase-intro"><span className="lr-step-number">03</span><div><h3>Choose the way through</h3><p>Compare the two routes, then assign the crossing crew.</p></div></div>
+                <div className="lr-decision-brief">
+                  <i className="bi bi-signpost-split" />
+                  <div><span>Objective</span><strong className="lr-decision-destination">{scene.title} <i className="bi bi-arrow-right" /> {scene.destination}</strong><div className="lr-decision-steps"><b>1 · Route</b><b>2 · Crew</b><b>3 · Method</b></div></div>
+                </div>
+                {scan.revealedIds.length > 0 && <div className="lr-scan-strip"><i className="bi bi-broadcast-pin" /><span>{scan.revealedIds.length} hazard signature relayed to command.</span></div>}
+              </>}
+              {guidanceLevel === 'simple' && route ? <div className="lr-route-confirmed" role="status">
+                <i className="bi bi-check-circle-fill" />
+                <span><small>Route selected</small><strong>{route.title}</strong></span>
+                <button type="button" onClick={changeRoute}><i className="bi bi-arrow-left-right" /> Change route</button>
+              </div> : guidanceLevel === 'simple' ? <>
+                <div className={`lr-route-guidance${routeRecommendation ? ' has-recommendation' : ''}`}>
+                  <i className={`bi ${routeRecommendation ? 'bi-stars' : 'bi-signpost-split'}`} />
+                  <div>{routeRecommendation ? <><span>Command recommendation</span><strong>{routeRecommendation.plan.route.title}</strong><p>Recommended because it has {routeRecommendation.reason}.</p></> : <><span>Meaningful trade-off</span><strong>No clear best route</strong><p>These routes exchange crew energy, annex stability, uncertainty, and mission loot. Choose what matters most for this run.</p></>}</div>
+                </div>
+                <div className="lr-salvage-explainer"><i className="bi bi-box-seam-fill" /><div><strong>What is salvage?</strong><span>Optional mission loot. It does not make this crossing easier; it increases the haul you bank when you extract.</span></div></div>
+                <div className="lr-simple-routes">
+                  {simpleRoutePlans.map((plan) => {
+                    const recommended = routeRecommendation && routeRecommendation.plan.route.id === plan.route.id;
+                    const selected = pendingRouteId === plan.route.id;
+                    const crewCost = plan.knownLeadStrain + plan.baseSupportStrain;
+                    const riskLabel = plan.nativeRisk ? encounterResolution ? 'Known native encounter' : 'Possible native contact' : plan.unresolvedHazards.length ? 'Unresolved route danger' : null;
+                    const advantage = routeAdvantage(plan, simpleRoutePlans);
+                    return <article key={plan.route.id} data-lowest-risk={lowestRiskPlan && lowestRiskPlan.route.id === plan.route.id ? 'true' : undefined} className={`${selected ? 'is-selected' : ''}${recommended ? ' is-recommended' : ''}`}>
+                      <button type="button" className="lr-route-choice-main" onClick={() => previewSimpleRoute(plan.route.id)} aria-pressed={selected}>
+                        <span className="lr-simple-route-head"><em>{recommended ? 'Recommended' : advantage}</em><b>{plan.route.title}</b></span>
+                        <p>{plan.route.description}</p>
+                        {plan.route.activeEffects && plan.route.activeEffects.map((effect) => <span className="lr-route-memory" key={effect.flag}><i className="bi bi-diagram-3-fill" /><b>{effect.label}:</b> {effect.difficulty < 0 ? `this route is easier by ${Math.abs(effect.difficulty)}` : `this route is harder by ${effect.difficulty}`}</span>)}
+                        <div className="lr-route-signals">
+                          {plan.knownLeadStrain > 0 && <span className="lr-route-projection is-crew"><span><i className="bi bi-lightning-charge-fill" /><small>{plan.lead.species} energy</small><strong>−{plan.knownLeadStrain}</strong></span><ProjectionTrack value={strain[plan.lead.id] || 0} added={plan.knownLeadStrain} max={MAX_STRAIN} label={`${plan.lead.species} energy`} kind="strain" /></span>}
+                          {plan.baseSupportStrain > 0 && <span className="lr-route-projection is-crew"><span><i className="bi bi-lightning-charge-fill" /><small>{plan.support.species} energy</small><strong>−{plan.baseSupportStrain}</strong></span><ProjectionTrack value={strain[plan.support.id] || 0} added={plan.baseSupportStrain} max={MAX_STRAIN} label={`${plan.support.species} energy`} kind="strain" /></span>}
+                          {plan.knownPressure > 0 && <span className="lr-route-projection is-annex"><span><i className="bi bi-buildings" /><small>Annex stability</small><strong>−{plan.knownPressure}</strong></span><ProjectionTrack value={pressure} added={plan.knownPressure} max={MAX_INSTABILITY} label="Annex stability" kind="annex" /></span>}
+                          {riskLabel && <span className="lr-route-risk"><i className="bi bi-question-diamond" /><span><small>Uncertainty</small><strong>{riskLabel}</strong></span></span>}
+                          {!crewCost && !plan.knownPressure && !riskLabel && <span className="lr-route-no-cost"><i className="bi bi-check-circle-fill" /> No immediate cost</span>}
+                          <span className="lr-route-reward"><i className="bi bi-box-seam-fill" /><span><small>Mission haul</small><strong>+{plan.route.salvage} salvage</strong><SalvageGauge value={plan.route.salvage} label={`${plan.route.title} salvage`} /><b>Banked on extraction</b></span></span>
+                        </div>
+                        <b className="lr-simple-route-action">{selected ? <><i className="bi bi-check-circle-fill" /> Selected</> : <>Select this route <i className="bi bi-arrow-right" /></>}</b>
+                      </button>
+                      <details className="lr-route-analysis"><summary><i className="bi bi-info-circle" /> See analysis</summary><p>Best available plan: {plan.lead.species} leads with {plan.method.label}, supported by {plan.support.species}. Crew score {plan.teamScore} against target {plan.difficulty}. {plan.unresolvedHazards.length ? 'Hidden danger may still change the final cost.' : 'All route hazards are accounted for.'}</p></details>
+                    </article>;
+                  })}
+                </div>
+                {pendingRoutePlan && <div className="lr-route-continue" role="status">
+                  <span><i className="bi bi-check-circle-fill" /><span><small>Selected route</small><strong>{pendingRoutePlan.route.title}</strong></span></span>
+                  <button type="button" className="g-btn g-btn--primary" onClick={confirmSimpleRoute}>Proceed with {pendingRoutePlan.route.title} <i className="bi bi-arrow-right" /></button>
+                </div>}
+              </> : <div className="lr-route-grid">
+                {scene.routes.map((entry) => <RouteCard key={entry.id} route={entry} selected={routeId === entry.id} onSelect={() => chooseRoute(entry.id)} scan={scan} />)}
+              </div>}
+
+              {route && guidanceLevel === 'simple' && !simpleCustomizing && suggestedPlan && (
+                <div className="lr-simple-plan">
+                  <div className="lr-simple-plan-head"><i className="bi bi-stars" /><div><span>Recommended crew plan for this route</span><h3>{suggestedPlan.lead.species} leads with {suggestedPlan.method.label}</h3></div></div>
+                  <p className="lr-simple-plan-reason"><strong>Why this crew?</strong> {suggestedPlan.lead.species} is the best fit for this crossing; {suggestedPlan.support.species} makes the attempt {suggestedPlan.label.toLowerCase()}.</p>
+                  <div className="lr-simple-plan-crew"><span><small>Lead</small><strong>{suggestedPlan.lead.species}</strong></span><i className="bi bi-plus" /><span><small>Support</small><strong>{suggestedPlan.support.species}</strong></span><i className="bi bi-arrow-right" /><span><small>Likely passage</small><strong>{suggestedPlan.label}</strong></span></div>
+                  <div className="lr-simple-plan-projections">
+                    {suggestedPlan.knownLeadStrain > 0 && <span className="lr-route-projection is-crew"><span><i className="bi bi-lightning-charge-fill" /><small>{suggestedPlan.lead.species} energy</small><strong>−{suggestedPlan.knownLeadStrain}</strong></span><ProjectionTrack value={strain[suggestedPlan.lead.id] || 0} added={suggestedPlan.knownLeadStrain} max={MAX_STRAIN} label={`${suggestedPlan.lead.species} energy`} kind="strain" /></span>}
+                    {suggestedPlan.baseSupportStrain > 0 && <span className="lr-route-projection is-crew"><span><i className="bi bi-lightning-charge-fill" /><small>{suggestedPlan.support.species} energy</small><strong>−{suggestedPlan.baseSupportStrain}</strong></span><ProjectionTrack value={strain[suggestedPlan.support.id] || 0} added={suggestedPlan.baseSupportStrain} max={MAX_STRAIN} label={`${suggestedPlan.support.species} energy`} kind="strain" /></span>}
+                    {Math.max(0, suggestedPlan.knownPressure - (useCommand && !suggestedPlan.naturalReaction ? 1 : 0)) > 0 && <span className="lr-route-projection is-annex"><span><i className="bi bi-buildings" /><small>Annex stability</small><strong>−{Math.max(0, suggestedPlan.knownPressure - (useCommand && !suggestedPlan.naturalReaction ? 1 : 0))}</strong></span><ProjectionTrack value={pressure} added={Math.max(0, suggestedPlan.knownPressure - (useCommand && !suggestedPlan.naturalReaction ? 1 : 0))} max={MAX_INSTABILITY} label="Annex stability" kind="annex" /></span>}
+                    {suggestedPlan.unresolvedHazards.length > 0 && <span className="lr-route-risk"><i className="bi bi-question-diamond" /><span><small>Uncertainty</small><strong>Unresolved route danger</strong></span></span>}
+                    {!suggestedPlan.knownLeadStrain && !suggestedPlan.baseSupportStrain && !Math.max(0, suggestedPlan.knownPressure - (useCommand && !suggestedPlan.naturalReaction ? 1 : 0)) && !suggestedPlan.unresolvedHazards.length && <span className="lr-route-no-cost"><i className="bi bi-check-circle-fill" /> No immediate cost</span>}
+                  </div>
+                  <details className="lr-plan-analysis"><summary><i className="bi bi-info-circle" /> See score analysis</summary><p>{suggestedPlan.lead.species} contributes the strongest available match for {suggestedPlan.method.label}. {suggestedPlan.support.species} adds {suggestedPlan.supportBonus} support, producing team score {suggestedPlan.teamScore} against target {suggestedPlan.difficulty}.</p></details>
+                  {!suggestedPlan.naturalReaction && commands > 0 && suggestedPlanApplied && <label className="lr-simple-override"><input type="checkbox" checked={useCommand} onChange={(event) => setUseCommand(event.target.checked)} /><span>Use 1 command to preserve 1 annex stability</span></label>}
+                  <div className="lr-simple-plan-actions">
+                    <button type="button" className="lr-simple-secondary" onClick={() => setSimpleCustomizing(true)}><i className="bi bi-sliders" /> Customize crew plan</button>
+                    {!suggestedPlanApplied ? <button type="button" className="g-btn g-btn--primary" onClick={applySuggestedPlan}>Use this plan</button> : <button type="button" className="g-btn g-btn--primary" onClick={commit}>Cross with this plan <i className="bi bi-arrow-right" /></button>}
+                  </div>
+                </div>
+              )}
+
+              {route && (guidanceLevel !== 'simple' || simpleCustomizing) && (
+                <div className="lr-assignment-board">
+                  <div className="lr-assignment-head">
+                    <div><p className="g-label">Crew assignment</p><span title="The lead performs the method, support contributes up to 10, and reserve spends no crossing energy.">Pick a lead, support, and method <i className="bi bi-info-circle" /></span></div>
+                    <div className="lr-assignment-mode"><small>Decision support</small><GuidanceSelector value={guidanceLevel} onChange={setGuidanceLevel} compact /></div>
+                  </div>
+                  <CrossingEquation
+                    compact
+                    leadScore={selectedForecast ? selectedForecast.leadScore : null}
+                    supportBonus={selectedForecast ? selectedForecast.supportBonus : null}
+                    teamScore={selectedForecast ? selectedForecast.teamScore : null}
+                    target={route.difficulty}
+                    margin={selectedForecast ? selectedForecast.margin : null}
+                  />
+                  <div className={`lr-assignment-guidance${assignment.ready ? ' is-ready' : ''}`} role="status" aria-live="polite">
+                    <i className={`bi ${assignment.ready ? 'bi-check-circle-fill' : 'bi-arrow-right-circle-fill'}`} />
+                    <strong>{assignment.message}</strong>
+                  </div>
+                  <div className="lr-role-picker">
+                    <div className={assignment.step === 'lead' ? 'is-current' : ''}><span>1 · Lead</span><strong>{lead ? lead.species : 'Select from crew rail'}</strong></div>
+                    <div className={`lr-support-select${assignment.step === 'support' ? ' is-current' : ''}`}>
+                      <span>2 · Support <b>Required</b></span>
+                      <div>{crew.filter((member) => member.id !== leadId && (strain[member.id] || 0) < MAX_STRAIN).map((member) => (
+                        <button
+                          key={member.id}
+                          type="button"
+                          className={supportId === member.id ? 'is-selected' : ''}
+                          disabled={!lead}
+                          title={!lead ? 'Choose a lead creature first' : `Assign ${member.species} as support`}
+                          onClick={() => setSupportId(member.id)}
+                          aria-pressed={supportId === member.id}
+                          aria-label={`Assign ${member.species} as support`}
+                        >
+                          <i className={`bi ${supportId === member.id ? 'bi-check-lg' : 'bi-plus-lg'}`} />
+                          <span><strong>{member.species}</strong><small>{supportId === member.id ? 'Assigned' : 'Assign as support'}</small></span>
+                        </button>
+                      ))}</div>
+                    </div>
+                    <div><span>Auto · Reserve</span><strong>{reserve ? reserve.species : 'Assigned last'}</strong></div>
+                  </div>
+
+                  {lead && (
+                    <div className={`lr-methods${assignment.step === 'method' ? ' is-current' : ''}`}>
+                      <div className="lr-methods-head"><p className="g-label">3 · Method <b>Required</b></p>{guidanceLevel !== 'expert' && <div className="lr-methods-key"><span><i className="is-score" /> Team score</span><span><i className="is-target" /> Route target</span></div>}</div>
+                      {guidanceLevel === 'guided' && support && recommendedForecast && (
+                        <div className="lr-method-recommendation">
+                          <i className="bi bi-compass-fill" />
+                          <div><span>Best known method</span><strong>{recommendedForecast.method.label}</strong><div className="lr-signal-chips"><b>{signed(recommendedForecast.margin)} margin</b><b>{recommendedForecast.label}</b><b>Base energy −{recommendedForecast.baseLeadStrain}</b>{recommendedForecast.unresolvedHazards.length > 0 && <b className="is-unknown"><i className="bi bi-question-diamond" /> Hidden risk</b>}</div></div>
+                        </div>
+                      )}
+                      {methodForecasts.map((forecast) => {
+                        const entry = forecast.method;
+                        const recommended = guidanceLevel === 'guided' && recommendedForecast && recommendedForecast.method.id === entry.id;
+                        return (
+                          <div key={entry.id} className={`lr-method-option${methodId === entry.id ? ' is-selected' : ''}${recommended ? ' is-recommended' : ''}`}>
+                            <button type="button" className="lr-method-select" disabled={!support} title={!support ? 'Assign support before choosing a method' : `Choose ${entry.label}`} onClick={() => setMethodId(entry.id)} aria-pressed={methodId === entry.id}>
+                              <span className="lr-method-icon"><i className={`bi ${entry.kind === 'action' ? 'bi-lightning-charge' : entry.kind === 'capability' ? 'bi-person-walking' : entry.kind === 'trait' ? 'bi-shield-check' : 'bi-tools'}`} /></span>
+                              <span className="lr-method-copy">
+                                <span className="lr-method-name"><strong>{entry.label}</strong>{recommended && <em>Recommended</em>}</span>
+                                <small>{entry.kind} · {entry.attribute ? ATTRIBUTE_LABELS[entry.attribute] : ''}</small>
+                                {guidanceLevel !== 'expert' && <ForecastBar forecast={forecast} />}
+                              </span>
+                              <span className="lr-method-score">{guidanceLevel !== 'expert' && <small>Margin</small>}<b>{guidanceLevel === 'expert' ? forecast.leadScore : signed(forecast.margin)}</b>{guidanceLevel === 'guided' && <em className={`is-${forecast.quality}`}>{forecast.label}</em>}</span>
+                            </button>
+                            <button type="button" className="lr-info-button" onClick={() => setDetailMethodId(entry.id)} aria-label={`See calculation details for ${entry.label}`} title="See calculation details"><i className="bi bi-info-circle" /></button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {lead && support && method && selectedForecast && (
+                    <div className="lr-commit-readout">
+                      {guidanceLevel === 'expert' ? (
+                        <div className="g-screen lr-score-screen">
+                          <span>METHOD {selectedForecast.leadScore}</span><i>+</i><span>SUPPORT {selectedForecast.supportBonus}</span><i>vs</i><strong>DIFFICULTY {selectedForecast.difficulty}</strong>
+                        </div>
+                      ) : (
+                        <div className={`lr-outcome-summary lr-outcome-summary--${selectedForecast.quality}`}>
+                          <div className="lr-outcome-head"><span>Known forecast</span><strong>{selectedForecast.label}</strong><b>{signed(selectedForecast.margin)} margin</b></div>
+                          <div className="lr-outcome-signals">
+                            <div><i className="bi bi-check2-circle" /><span>Passage</span><strong>{selectedForecast.margin >= 0 ? 'Clear' : 'Forced'}</strong></div>
+                            <div><i className="bi bi-lightning-charge-fill" /><span>Known energy cost</span><strong>−{Math.max(0, selectedForecast.baseLeadStrain + selectedForecast.baseSupportStrain + selectedForecast.environment.strain - (selectedForecast.naturalReaction ? 1 : 0))}</strong></div>
+                            <div><i className="bi bi-buildings" /><span>Stability cost</span><strong>−{route.pressure + (!selectedForecast.naturalReaction && !useCommand ? 1 : 0)}</strong></div>
+                            <div className={selectedForecast.unresolvedHazards.length ? 'is-unknown' : ''}><i className="bi bi-question-diamond" /><span>Hidden risks</span><strong>{selectedForecast.unresolvedHazards.length || 'None'}</strong></div>
+                          </div>
+                          <div className="lr-outcome-flags">{selectedForecast.environment.notes.map((note) => <span key={note}><i className="bi bi-exclamation-triangle" /> {note}</span>)}{!selectedForecast.environment.notes.length && <span className="is-good"><i className="bi bi-check-lg" /> Environment compatible</span>}</div>
+                          <button type="button" className="lr-calculation-link" onClick={() => setDetailMethodId(method.id)}><i className="bi bi-info-circle" /> How this was calculated</button>
+                        </div>
+                      )}
+                      <div className={`lr-reaction${leadReactionMatch ? ' is-match' : ''}`}>
+                        <div><span>Temperament · {route.reaction.axis}</span><strong>{route.reaction.label}</strong></div>
+                        <em>{leadReactionMatch ? <><i className="bi bi-check-lg" /> Natural fit</> : <><i className="bi bi-exclamation-triangle" /> Mismatch · stability −1</>}</em>
+                        {guidanceLevel === 'guided' && !leadReactionMatch && <p className="lr-guided-tip"><i className="bi bi-compass" /> Override preserves 1 annex stability</p>}
+                        {!leadReactionMatch && commands > 0 && <label className="lr-command-toggle"><input type="checkbox" checked={useCommand} onChange={(event) => setUseCommand(event.target.checked)} /><span>Spend 1 command override</span></label>}
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="lr-action-row">
+                    <button type="button" className="g-btn" onClick={() => { setRouteId(null); setLeadId(null); setSupportId(null); setMethodId(null); }}>Clear Assignment</button>
+                    <button type="button" className="g-btn g-btn--primary" disabled={!canCommit} onClick={commit}>
+                      {!lead ? 'Choose Lead to Continue' : !support ? 'Choose Support to Continue' : !method ? 'Choose Method to Continue' : 'Commit Crew & Resolve Route'}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          <MethodDetailModal forecast={detailForecast} lead={lead} support={support} route={route} onClose={() => setDetailMethodId(null)} />
+          <MechanicsModal open={mechanicsOpen} onClose={() => setMechanicsOpen(false)} />
+
+          {phase === 'result' && lastResult && (guidanceLevel === 'simple' ? (
+            <div className="lr-simple-decision lr-simple-result">
+              <div className={`lr-simple-result-head is-${lastResult.impactQuality}`}><i className={`bi ${lastResult.impactQuality === 'clean' ? 'bi-check-circle-fill' : 'bi-exclamation-triangle-fill'}`} /><div><span>Crossing complete · {lastResult.impactLabel}</span><h3>{lastResult.impactQuality === 'clean' ? 'The plan worked without a cost' : lastResult.impactQuality === 'costly' ? 'The crew crossed, but paid for it' : 'The crew crossed with little energy left'}</h3></div></div>
+              <p className="lr-simple-story">{lastResult.story}</p>
+              <p className="lr-creature-reaction"><i className="bi bi-chat-quote" /> {lastResult.reaction}</p>
+              <section className="lr-result-explanation"><span>Why this happened</span><ul>{lastResult.causes.map((cause) => <li key={cause}>{cause}</li>)}</ul></section>
+              <section className="lr-result-changes"><span>What changed</span><div>
+                {lastResult.crewChanges.filter((change) => change.added > 0).map((change) => <article key={change.creature.id} className="is-warning"><span><i className="bi bi-lightning-charge-fill" /><strong>{change.creature.species} energy</strong><b>−{change.added}</b></span><ProjectionTrack value={change.before} added={change.added} max={MAX_STRAIN} label={`${change.creature.species} energy`} kind="strain" /></article>)}
+                {lastResult.instabilityChange.added > 0 && <article className="is-warning"><span><i className="bi bi-buildings" /><strong>Annex stability</strong><b>−{lastResult.instabilityChange.added}</b></span><ProjectionTrack value={lastResult.instabilityChange.before} added={lastResult.instabilityChange.added} max={MAX_INSTABILITY} label="Annex stability" kind="annex" /></article>}
+                {!lastResult.crewChanges.some((change) => change.added > 0) && !lastResult.instabilityChange.added && <article className="is-good lr-result-no-cost"><i className="bi bi-check-circle-fill" /><strong>No energy or stability cost</strong></article>}
+                <article className="lr-result-salvage"><span><i className="bi bi-box-seam" /><strong>Salvage secured</strong><b>+{lastResult.salvage}</b></span><SalvageGauge value={lastResult.salvage} /><small>{lastResult.salvageAfter} total banked</small></article>
+              </div></section>
+              {lastResult.companionHelp && <div className="lr-simple-surprise is-good"><i className="bi bi-person-check-fill" /><span><strong>Field companion intervened:</strong> {lastResult.companionHelp}</span></div>}
+              {lastResult.unseenHazards.length > 0 && <div className="lr-simple-surprise"><i className="bi bi-exclamation-triangle-fill" /><span><strong>Unexpected danger:</strong> {lastResult.unseenHazards.map((hazard) => hazard.label).join(', ')}</span></div>}
+              {lastResult.consequence && <div className="lr-consequence-preview"><i className="bi bi-diagram-3-fill" /><div><span>This choice carries forward</span><strong>{lastResult.consequence.label}</strong><p>{lastResult.consequence.future}</p></div></div>}
+              <div className="lr-action-row lr-result-actions">
+                {!missionCannotContinue && (objectiveReached ? <button type="button" className="g-btn" onClick={extract}>Extract now</button> : <button type="button" className="g-btn g-btn--danger" onClick={extract}>Abort mission</button>)}
+                <button type="button" className="g-btn g-btn--primary" onClick={continueRun}>{missionCannotContinue ? 'View mission report' : sceneIndex === MISSION.scenes.length - 1 ? 'Leave with full salvage' : objectiveReached ? 'Continue deeper' : 'Continue mission'} <i className="bi bi-arrow-right" /></button>
+              </div>
+            </div>
+          ) : (
+            <div className="lr-phase-panel lr-result-panel">
+              <div className={`lr-result-banner lr-result-banner--${lastResult.quality}`}>
+                <span>{lastResult.quality.toUpperCase()} PASSAGE</span>
+                <strong>{lastResult.totalScore} <i>vs</i> {route.difficulty}</strong>
+              </div>
+              <h3>{lastResult.summary}</h3>
+              <p className="lr-creature-reaction"><i className="bi bi-chat-quote" /> {lastResult.reaction}</p>
+              <div className="lr-result-grid">
+                <div><span>Lead energy</span><strong>−{lastResult.leadStrain}</strong><small>{lead.species}</small></div>
+                <div><span>Support energy</span><strong>−{lastResult.supportStrain}</strong><small>{support.species}</small></div>
+                <div><span>Annex stability</span><strong>−{lastResult.pressure}</strong><small>external safety reserve</small></div>
+                <div><span>Salvage</span><strong>+{lastResult.salvage}</strong><small>bank on extraction</small></div>
+              </div>
+              {lastResult.unseenHazards.length > 0 && <div className="lr-result-note lr-result-note--danger"><i className="bi bi-exclamation-triangle-fill" /><span><strong>Unseen fallout:</strong> {lastResult.unseenHazards.map((hazard) => hazard.label).join(', ')}.</span></div>}
+              {lastResult.environment.notes.length > 0 && <div className="lr-result-note"><i className="bi bi-thermometer-snow" /><span>{lastResult.environment.notes.join('; ')}.</span></div>}
+              <div className="lr-result-note"><i className="bi bi-compass" /><span>{lastResult.naturalReaction ? 'The lead followed its natural response and preserved 1 energy.' : useCommand ? 'Command override kept the lead on plan.' : 'The lead followed its own nature; annex stability fell.'}</span></div>
+              {lastResult.consequence && <div className="lr-result-note"><i className="bi bi-diagram-3-fill" /><span><strong>{lastResult.consequence.label}:</strong> {lastResult.consequence.future}</span></div>}
+
+              <div className="lr-action-row lr-result-actions">
+                {!missionCannotContinue && (objectiveReached ? <button type="button" className="g-btn" onClick={extract}>Extract With {salvage} Salvage</button> : <button type="button" className="g-btn g-btn--danger" onClick={extract}>Abort Mission</button>)}
+                <button type="button" className="g-btn g-btn--primary" onClick={continueRun}>{missionCannotContinue ? 'View Mission Report' : sceneIndex === MISSION.scenes.length - 1 ? 'Leave With Full Salvage' : objectiveReached ? 'Push Deeper' : 'Advance'}</button>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <aside className="lr-log g-panel g-panel--recessed">
+          <div className="lr-rail-title"><p className="g-kicker">Field printer</p><span>LIVE</span></div>
+          <div className="g-screen lr-log-screen">
+            {log.map((entry, index) => <div key={`${entry.title}-${index}`}><span>{entry.title}</span><p>{entry.text}</p></div>)}
+          </div>
+          <div className="lr-rules-note">
+            <p className="g-label">Run contract</p>
+            <ul>
+              <li>Abilities work once per mission.</li>
+              <li>At 3 energy a creature becomes worn and less effective.</li>
+              <li>At 1 energy it is critical and cannot scout; at 0 it is spent.</li>
+              <li>At 0 annex stability, forced extraction begins.</li>
+              <li>Fewer than two active crew members also forces extraction.</li>
+              <li>The objective survives a post-retrieval collapse.</li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}
+
+export default LongReturnGame;

--- a/my-app/src/components/games/longReturn/longReturnGame.test.js
+++ b/my-app/src/components/games/longReturn/longReturnGame.test.js
@@ -1,0 +1,289 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import LongReturnGame from './longReturnGame';
+
+vi.mock('../../xalianImage', () => ({ default: function MockXalianImage() { return <div data-testid="creature-portrait" />; } }));
+
+function findButton(container, label) {
+  return Array.from(container.querySelectorAll('button')).find((button) => label.test(button.textContent));
+}
+
+function click(container, label) {
+  const button = findButton(container, label);
+  expect(button).toBeTruthy();
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+function clickElement(element) {
+  expect(element).toBeTruthy();
+  act(() => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+function enterSimpleRouteChoice(container, { scan = true } = {}) {
+  click(container, /seal crew/i);
+  if (scan) clickElement(container.querySelector('.lr-simple-scouts .is-recommended'));
+  else click(container, /keep the crew together/i);
+  if (container.querySelector('.lr-field-encounter')) {
+    clickElement(container.querySelector('.lr-encounter-options .is-recommended'));
+    click(container, /review scout report/i);
+  }
+  expect(container.textContent).toContain('Scout result');
+  if (findButton(container, /wait for .* to return/i)) click(container, /wait for .* to return/i);
+  click(container, /choose a route/i);
+  expect(container.querySelectorAll('.lr-simple-routes > article')).toHaveLength(2);
+}
+
+function choosePreferredRoute(container) {
+  const recommended = container.querySelector('.lr-simple-routes > article.is-recommended .lr-route-choice-main');
+  const lowestRisk = container.querySelector('.lr-simple-routes > article[data-lowest-risk="true"] .lr-route-choice-main');
+  clickElement(recommended || lowestRisk || container.querySelector('.lr-simple-routes .lr-route-choice-main'));
+  click(container, /proceed with/i);
+}
+
+function playRecommendedScene(container) {
+  const enterButton = findButton(container, /^enter /i);
+  if (enterButton) clickElement(enterButton);
+  const recommendedScout = container.querySelector('.lr-simple-scouts .is-recommended');
+  if (recommendedScout) clickElement(recommendedScout);
+  else click(container, /keep the crew together/i);
+  if (container.querySelector('.lr-field-encounter')) {
+    clickElement(container.querySelector('.lr-encounter-options .is-recommended'));
+    click(container, /review scout report/i);
+  }
+  if (findButton(container, /wait for .* to return/i)) click(container, /wait for .* to return/i);
+  click(container, /choose a route/i);
+  choosePreferredRoute(container);
+  click(container, /use this plan/i);
+  click(container, /cross with this plan/i);
+  expect(container.textContent).toContain('Crossing complete');
+}
+
+describe('Long Return Simple mode', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    container.remove();
+  });
+
+  function renderGame() {
+    act(() => {
+      ReactDOM.render(<LongReturnGame />, container);
+    });
+  }
+
+  test('plays the recommended Simple plan through a complete crossing', () => {
+    renderGame();
+    enterSimpleRouteChoice(container);
+    choosePreferredRoute(container);
+    expect(container.textContent).toContain('Recommended crew plan for this route');
+    click(container, /use this plan/i);
+    click(container, /cross with this plan/i);
+    expect(container.textContent).toContain('Crossing complete');
+    expect(container.querySelectorAll('.lr-result-changes .lr-projection-track').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toMatch(/Ready → Ready|Stable → Stable|No strain added/);
+    expect(findButton(container, /continue mission/i)).toBeTruthy();
+  });
+
+  test('supports skipping the scan and opening the detailed plan builder', () => {
+    renderGame();
+    enterSimpleRouteChoice(container, { scan: false });
+    clickElement(container.querySelector('.lr-simple-routes > article:not(.is-recommended) .lr-route-choice-main'));
+    click(container, /proceed with/i);
+    click(container, /customize crew plan/i);
+    expect(container.textContent).toContain('Crew assignment');
+    expect(container.textContent).toContain('Pick a lead, support, and method');
+    expect(container.querySelector('main').classList.contains('lr-is-customizing')).toBe(true);
+  });
+
+  test('resolves a manually customized Simple plan and returns to the clean result view', () => {
+    renderGame();
+    enterSimpleRouteChoice(container, { scan: false });
+    clickElement(container.querySelector('.lr-simple-routes > article:not(.is-recommended) .lr-route-choice-main'));
+    click(container, /proceed with/i);
+    click(container, /customize crew plan/i);
+    clickElement(Array.from(container.querySelectorAll('.lr-crew-member')).find((button) => /Hippochamp/.test(button.textContent)));
+    clickElement(Array.from(container.querySelectorAll('button')).find((button) => /Assign Chromocat as support/.test(button.getAttribute('aria-label') || '')));
+    clickElement(Array.from(container.querySelectorAll('.lr-method-select')).find((button) => /Climb the suspension frame/.test(button.textContent)));
+    expect(container.textContent).toContain('Known energy cost−4');
+    click(container, /commit crew & resolve route/i);
+    expect(container.textContent).toContain('Crossing complete');
+    expect(container.querySelector('main').classList.contains('lr-is-customizing')).toBe(false);
+  });
+
+  test('shows every crossing result before a terminal mission report', () => {
+    renderGame();
+    click(container, /seal crew/i);
+
+    for (let scene = 0; scene < 7; scene += 1) {
+      playRecommendedScene(container);
+      if (scene < 6) clickElement(container.querySelector('.lr-result-actions .g-btn--primary'));
+    }
+
+    expect(findButton(container, /view mission report/i)).toBeTruthy();
+    click(container, /view mission report/i);
+    expect(container.textContent).toContain('Forced Extraction');
+    expect(container.textContent).toContain('ObjectiveSECURED');
+  });
+
+  test('supports aborting early and extracting after the objective', () => {
+    renderGame();
+    click(container, /seal crew/i);
+    playRecommendedScene(container);
+    click(container, /abort mission/i);
+    expect(container.textContent).toContain('Mission Aborted');
+
+    click(container, /run contract again/i);
+    for (let scene = 0; scene < 5; scene += 1) {
+      playRecommendedScene(container);
+      if (scene < 4) clickElement(container.querySelector('.lr-result-actions .g-btn--primary'));
+    }
+    click(container, /extract now/i);
+    expect(container.textContent).toContain('Crew Extracted');
+    expect(container.textContent).toContain('ObjectiveSECURED');
+  });
+
+  test('moves from the recommended scout to the simplified report', () => {
+    renderGame();
+    click(container, /seal crew/i);
+    clickElement(container.querySelector('.lr-simple-scouts .is-recommended'));
+    expect(container.textContent).toContain('Scout result');
+    expect(container.querySelector('.lr-action-feedback').textContent).toMatch(/Just changed.*Graviclaw −1 energy/i);
+    expect(container.querySelector('.lr-simple-status-crew .is-changing')).toBeTruthy();
+    expect(findButton(container, /choose a route/i)).toBeTruthy();
+  });
+
+  test('turns the second-scene scout signal into an explained native encounter and field companion', () => {
+    renderGame();
+    click(container, /seal crew/i);
+    playRecommendedScene(container);
+    click(container, /continue mission/i);
+    click(container, /^enter /i);
+    clickElement(container.querySelector('.lr-simple-scouts .is-recommended'));
+    expect(container.textContent).toContain('Stranded Xylum');
+    expect(container.textContent).toMatch(/crew contact|physical return/i);
+    expect(container.querySelectorAll('.lr-encounter-choice-signals .lr-projection-track').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toMatch(/Ready → Ready|Stable → Stable/);
+    clickElement(container.querySelector('.lr-encounter-options .is-recommended'));
+    expect(container.textContent).toContain('Field companion');
+    expect(container.textContent).toContain('The native chooses to follow');
+  });
+
+  test('keeping the crew together makes native contact a group encounter when its route is chosen', () => {
+    renderGame();
+    click(container, /seal crew/i);
+    playRecommendedScene(container);
+    click(container, /continue mission/i);
+    click(container, /^enter /i);
+    click(container, /keep the crew together/i);
+    click(container, /choose a route/i);
+    const nativeRoute = Array.from(container.querySelectorAll('.lr-simple-routes .lr-route-choice-main')).find((button) => /maintenance underdeck/i.test(button.textContent));
+    clickElement(nativeRoute);
+    click(container, /proceed with .*maintenance underdeck/i);
+    expect(container.textContent).toContain('Unexpected crew encounter');
+    expect(container.textContent).toContain('The native acts before the crew can organize');
+  });
+
+  test('preserves the advanced scouting interface in Expert mode', () => {
+    renderGame();
+    click(container, /^expert/i);
+    click(container, /seal crew/i);
+    expect(container.textContent).toContain('Read the scene');
+    expect(findButton(container, /select scout to enable scan/i)).toBeTruthy();
+    expect(container.querySelector('.lr-crew-rail')).toBeTruthy();
+  });
+
+  test('makes the current action and route-selection state explicit', () => {
+    renderGame();
+    click(container, /seal crew/i);
+    expect(container.querySelector('.lr-current-action').textContent).toMatch(/Step 1 of 3.*Choose a scout/i);
+    expect(container.querySelectorAll('.lr-simple-status .lr-projection-track')).toHaveLength(4);
+    clickElement(container.querySelector('.lr-simple-scouts .is-recommended'));
+    click(container, /choose a route/i);
+    expect(container.querySelector('.lr-current-action').textContent).toMatch(/Step 2 of 3.*Choose one route/i);
+    const recommendedOrFirst = container.querySelector('.lr-simple-routes > article.is-recommended .lr-route-choice-main') || container.querySelector('.lr-simple-routes .lr-route-choice-main');
+    clickElement(recommendedOrFirst);
+    expect(container.querySelector('.lr-simple-routes')).toBeTruthy();
+    expect(container.querySelector('.lr-simple-routes > article.is-selected')).toBeTruthy();
+    expect(findButton(container, /proceed with/i)).toBeTruthy();
+    click(container, /proceed with/i);
+    expect(container.querySelector('.lr-simple-routes')).toBeFalsy();
+    expect(container.querySelector('.lr-route-confirmed').textContent).toMatch(/Route selected/i);
+    expect(findButton(container, /change route/i)).toBeTruthy();
+    click(container, /change route/i);
+    expect(container.querySelectorAll('.lr-simple-routes > article')).toHaveLength(2);
+  });
+
+  test('shows visual projections, hides zero costs, and avoids false certainty', () => {
+    renderGame();
+    expect(container.querySelectorAll('.lr-element-mark svg')).toHaveLength(6);
+    expect(container.querySelector('.lr-element-mark').textContent).toBe('');
+    click(container, /seal crew/i);
+    expect(container.textContent).toMatch(/GraviclawReady · 6\/6 energy/i);
+    expect(container.textContent).toMatch(/Annex stabilityStable · 10\/10/i);
+    expect(container.querySelectorAll('.lr-simple-scouts > button')).toHaveLength(3);
+    expect(container.querySelectorAll('.lr-signal-gauge')).toHaveLength(3);
+    expect(container.querySelectorAll('.lr-signal-gauge .bi-eye-fill').length).toBeGreaterThan(0);
+    expect(container.querySelector('.lr-scout-visuals')).toBeNull();
+    expect(container.querySelector('.lr-projection-legend')).toBeNull();
+    expect(container.querySelector('.lr-scout-impact')).toBeNull();
+    expect(container.querySelectorAll('.lr-scout-storyline')).toHaveLength(3);
+    expect(container.querySelector('.lr-simple-scouts .is-recommended .lr-scout-storyline').textContent).toMatch(/Scout for danger.*Strong chance.*Uses 1 energy.*Vibration connects.*Report reaches crew.*No return needed/i);
+    expect(container.querySelectorAll('.lr-scout-relay')).toHaveLength(3);
+    expect(container.querySelector('.lr-simple-scouts .is-recommended .lr-scout-relay').getAttribute('aria-label')).toMatch(/strong chance.*spends 1 energy.*vibration communication reaches the crew.*without a return trip/i);
+    expect(container.querySelectorAll('.lr-scout-relay.is-warning')).toHaveLength(2);
+    expect(container.querySelector('.lr-scout-relay.is-warning').textContent).toMatch(/No compatible relay.*Returns to crew.*Uses 1 more energy.*Loses 1 stability/i);
+    expect(container.querySelectorAll('.lr-simple-scouts .lr-projection-track')).toHaveLength(0);
+    expect(container.textContent).not.toMatch(/The scan costs|Ready 0\/6 → Ready/);
+    clickElement(container.querySelector('.lr-simple-scouts .is-recommended'));
+    click(container, /choose a route/i);
+    expect(container.querySelector('.lr-route-guidance').textContent).toMatch(/No clear best route/i);
+    expect(container.querySelector('.lr-salvage-explainer').textContent).toMatch(/optional mission loot.*bank/i);
+    expect(container.querySelectorAll('.lr-salvage-gauge')).toHaveLength(2);
+    expect(container.querySelectorAll('.lr-salvage-gauge .is-filled')).toHaveLength(3);
+    expect(container.querySelectorAll('.lr-projection-track').length).toBeGreaterThan(0);
+    expect(container.textContent).not.toMatch(/Ready → Ready|Stable → Stable/);
+    expect(container.querySelectorAll('.lr-route-analysis')).toHaveLength(2);
+    choosePreferredRoute(container);
+    expect(container.querySelector('.lr-simple-plan-projections')).toBeTruthy();
+    expect(container.textContent).not.toMatch(/No strain expected|No change expected/);
+    expect(container.querySelector('.lr-plan-analysis')).toBeTruthy();
+  });
+
+  test('shows the previous route consequence before entering the next scene', () => {
+    renderGame();
+    click(container, /seal crew/i);
+    playRecommendedScene(container);
+    expect(container.textContent).toContain('This choice carries forward');
+    click(container, /continue mission/i);
+    expect(container.querySelector('.lr-transition-beat').textContent).toMatch(/Your earlier route matters here/i);
+    expect(container.querySelector('.lr-memory-effects').textContent).toMatch(/easier by/i);
+    click(container, /^enter /i);
+    expect(container.querySelector('.lr-simple-scouts')).toBeTruthy();
+  });
+
+  test('presents the trapped vestibule native as a distinct field decision', () => {
+    renderGame();
+    click(container, /seal crew/i);
+    playRecommendedScene(container);
+    click(container, /continue mission/i);
+    playRecommendedScene(container);
+    click(container, /continue mission/i);
+    click(container, /^enter /i);
+    clickElement(container.querySelector('.lr-simple-scouts .is-recommended'));
+    expect(container.textContent).toContain('Trapped Signal-Mimic');
+    expect(container.textContent).toMatch(/Release it from the arms|Mark the safe controls/i);
+  });
+});

--- a/my-app/src/components/navbar.js
+++ b/my-app/src/components/navbar.js
@@ -110,6 +110,7 @@ class XalianNavbar extends React.Component {
 										<Nav.Link href="/duel">Duel</Nav.Link>
 										<Nav.Link href="/tribute">Tribute</Nav.Link>
 										<Nav.Link href="/reclamation">Reclamation</Nav.Link>
+										<Nav.Link href="/long-return">Expedition</Nav.Link>
 										<Nav.Link href="/train">Training</Nav.Link>
 										{/* <Nav.Link href="/faq">FAQ</Nav.Link> */}
 										{/* <Nav.Link href="/login">Login</Nav.Link> */}

--- a/my-app/src/pages/games/longReturnPage.js
+++ b/my-app/src/pages/games/longReturnPage.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import XalianNavbar from '../../components/navbar';
+import LongReturnGame from '../../components/games/longReturn/longReturnGame';
+
+function LongReturnPage() {
+  return (
+    <div className="g-console lr-console">
+      <XalianNavbar />
+      <LongReturnGame />
+    </div>
+  );
+}
+
+export default LongReturnPage;


### PR DESCRIPTION
## Summary
- add the playable Long Return expedition prototype
- integrate creature senses, communication, capabilities, traits, temperament, and abilities into exploration decisions
- provide Simple through Expert guidance modes, native encounters, mission consequences, and animated outcome feedback
- add the Expedition route and navigation entry
- include the game-design brief and engine/UI regression coverage

## Validation
- 456 tests passed with \yarn test --run\`n- production build completed with \yarn build\`n- completed manual end-to-end play-through and responsive UX checks