### PR TITLE
Design system v4: mobile pass at 390px

### DIFF
--- a/my-app/public/assets/css/pages/encyclopedia-page.css
+++ b/my-app/public/assets/css/pages/encyclopedia-page.css
@@ -128,8 +128,20 @@
    stepping down as the shell narrows. */
 
 .enc-card-grid {
-	gap: var(--g-5) var(--g-4);
-	grid-template-columns: repeat(3, 1fr);
+	gap: var(--g-4) var(--g-3);
+	grid-template-columns: repeat(2, 1fr);
+}
+
+@media (min-width: 520px) {
+	.enc-card-grid { grid-template-columns: repeat(3, 1fr); gap: var(--g-5) var(--g-4); }
+}
+
+/* Phones: the record's section tab is the way back, so the trailing back
+   link stays off the scrolling tabs row. */
+@media (max-width: 700px) {
+	.enc-shell-tabs-back { display: none; }
+	.g-page .enc-tile-name { font-size: 16px; }
+	.enc-tile-meta { padding: var(--g-2) var(--g-3) var(--g-3); }
 }
 
 @media (min-width: 720px) {

--- a/my-app/public/assets/css/pages/generator.css
+++ b/my-app/public/assets/css/pages/generator.css
@@ -210,17 +210,10 @@
 		grid-template-columns: 1fr;
 	}
 
-	/* The masthead's action row does not wrap on its own (it is a fixed
-	   flex row, by design, on desktop); below 700px stack the keys full
-	   width instead of letting three shrink-to-fit buttons overflow the
-	   shell. */
-	.gen-shell .g-masthead-aside {
-		flex-direction: column;
-		align-items: stretch;
-		width: 100%;
-	}
-
-	.gen-shell .g-masthead-aside .g-btn {
-		width: 100%;
+	/* The masthead's keys sit in one row of equal widths under the title
+	   (system.css .g-page .g-masthead-aside); nothing to add here. A move's
+	   description wraps instead of truncating where the row is narrow. */
+	.gen-moves .move-description {
+		white-space: normal;
 	}
 }

--- a/my-app/public/assets/css/pages/home.css
+++ b/my-app/public/assets/css/pages/home.css
@@ -56,8 +56,16 @@
 
 .home-worlds-grid {
 	display: grid;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: repeat(4, 1fr);
 	gap: var(--g-2);
+}
+
+/* Phones: fourteen small tiles, art and name only; the chip returns at 560. */
+@media (max-width: 559px) {
+	.home-world-tile { padding-bottom: var(--g-2); }
+	.home-world-name { font-size: 10px; letter-spacing: 0.04em; margin-top: var(--g-1); padding: 0 var(--g-1); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+	.home-world-chip { display: none; }
+	.home-world-art-img { width: 76%; height: 76%; }
 }
 
 @media (min-width: 560px) {
@@ -131,6 +139,20 @@
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	gap: var(--g-2);
+}
+
+/* Phones: one horizontal strip, scrolled by touch, instead of a tall grid. */
+@media (max-width: 559px) {
+	.home-species-strip {
+		display: flex;
+		overflow-x: auto;
+		scroll-snap-type: x mandatory;
+		scrollbar-width: none;
+		margin: 0 calc(-1 * var(--g-5));
+		padding: 0 var(--g-5);
+	}
+	.home-species-strip::-webkit-scrollbar { display: none; }
+	.home-species-tile { flex: 0 0 140px; scroll-snap-align: start; }
 }
 
 @media (min-width: 560px) {

--- a/my-app/public/assets/css/system.css
+++ b/my-app/public/assets/css/system.css
@@ -872,6 +872,16 @@
 .g-page .g-record:hover { background: transparent; }
 .g-page .g-record-body { font-family: var(--g-font-body); font-size: var(--g-size-small-v4); color: var(--g-text-2); }
 
+/* Phones: the masthead's action row wraps under the title as one row of
+   equal keys, never a stack of full-width buttons. Meter names take a
+   narrower column so the strip keeps its length. */
+@media (max-width: 720px) {
+	.g-page .g-masthead-aside { width: 100%; flex-wrap: wrap; }
+	.g-page .g-masthead-aside .g-btn { flex: 1 1 0; min-width: 0; padding-left: var(--g-3); padding-right: var(--g-3); font-size: 12px; white-space: nowrap; }
+	.g-page .g-meter-row { grid-template-columns: 7rem 1fr 3.5rem; gap: var(--g-2); }
+	.g-page .g-meter-name { font-size: var(--g-size-legend); letter-spacing: var(--g-track-legend); }
+}
+
 /* A chip that is also a link keeps the chip's ink. */
 .g-page a.g-chip { color: var(--g-ink-invert); text-decoration: none; }
 .g-page a.g-chip--outline { color: var(--g-el); }

--- a/my-app/src/components/encyclopedia/Bestiary.css
+++ b/my-app/src/components/encyclopedia/Bestiary.css
@@ -30,18 +30,15 @@
 }
 
 @media (max-width: 700px) {
-	.enc-filters {
-		flex-direction: column;
-		align-items: stretch;
+	.enc-bestiary-filters {
+		flex-direction: row;
+		flex-wrap: wrap;
+		align-items: center;
 	}
 
-	.enc-bestiary-count { margin-left: 0; }
+	.enc-bestiary-world-select { flex: 1 1 100%; }
 
-	.enc-filters .g-segmented.enc-scrollrow {
-		display: flex;
-		width: 100%;
-		max-width: 100%;
-	}
+	.enc-bestiary-count { flex: 1 1 100%; margin-left: 0; }
 
 	.enc-filters .g-segment {
 		white-space: nowrap;

--- a/my-app/src/components/encyclopedia/EntryView.css
+++ b/my-app/src/components/encyclopedia/EntryView.css
@@ -62,10 +62,7 @@
 }
 
 .enc-entry-story-point {
-	display: flex;
-	align-items: baseline;
-	gap: var(--g-3);
-	flex-wrap: wrap;
+	display: block;
 }
 
 .g-page .enc-entry-story-point-link {

--- a/my-app/src/components/encyclopedia/SpeciesView.css
+++ b/my-app/src/components/encyclopedia/SpeciesView.css
@@ -22,6 +22,10 @@
 
 @media (max-width: 900px) {
 	.enc-species-dossier { grid-template-columns: minmax(0, 1fr); }
+	/* One column: plate, then the prose, then the signature card. */
+	.enc-species-plate-col { display: contents; }
+	.enc-species-signature { order: 2; }
+	.enc-species-plate { max-width: 320px; }
 }
 
 .enc-species > .enc-section { margin-top: var(--g-6); }

--- a/my-app/src/components/encyclopedia/Story.css
+++ b/my-app/src/components/encyclopedia/Story.css
@@ -164,21 +164,37 @@
 	position: static;
 	max-height: none;
 	overflow-y: visible;
-	margin-bottom: var(--g-6);
-	padding: 0;
+	margin-bottom: var(--g-5);
+	padding: var(--g-3) var(--g-4);
+	gap: 0;
 }
 
-.enc-story-rail-summary {
+.enc-story-rail--phone .enc-story-rail-summary {
 	cursor: pointer;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--g-3);
+	margin: 0;
+	padding: 0;
+	border: 0;
+	list-style: none;
 }
+
+.enc-story-rail-summary::-webkit-details-marker { display: none; }
+.enc-story-rail-summary::marker { content: ''; }
+.enc-story-rail-summary .g-h3 { margin: 0; font-size: var(--g-size-legend); letter-spacing: var(--g-track-legend); color: var(--g-text-2); }
+.enc-story-rail-summary::after { content: ''; width: 8px; height: 8px; border-right: 1px solid var(--g-text-2); border-bottom: 1px solid var(--g-text-2); transform: rotate(45deg); margin-left: auto; }
+.enc-story-rail--phone[open] .enc-story-rail-summary { margin-bottom: var(--g-3); padding-bottom: var(--g-3); border-bottom: var(--g-hairline) solid var(--g-rule-faint); }
+.enc-story-rail--phone[open] .enc-story-rail-summary::after { transform: rotate(-135deg); }
 
 .enc-story-rail--phone .enc-story-rail-stations,
 .enc-story-rail--phone .enc-story-rail-block {
-	padding: 0 var(--g-5) var(--g-5);
+	padding: 0 0 var(--g-4);
 }
 
 .enc-story-rail--phone .enc-story-rail-progress {
-	margin: 0 var(--g-5) var(--g-4);
+	margin: 0 0 var(--g-3);
 	padding-top: 0;
 	border-top: none;
 }
@@ -221,10 +237,11 @@
 	margin: var(--g-2) 0 0;
 	padding: 0 var(--g-2);
 	max-width: 70ch;
-	color: var(--g-ink-low);
-	font-size: var(--g-size-tiny);
+	font-family: var(--g-font-body);
+	color: var(--g-text-2);
+	font-size: var(--g-size-small-v4);
 	text-align: left;
-	line-height: 1.6;
+	line-height: 1.5;
 }
 
 /* ---- narrator beats -------------------------------------------------------- */

--- a/my-app/src/components/encyclopedia/WorldView.css
+++ b/my-app/src/components/encyclopedia/WorldView.css
@@ -243,17 +243,38 @@
 		top: auto;
 	}
 
-	.enc-world-chapter-index-summary {
+	.enc-world-chapter-index { padding: var(--g-3) var(--g-4); }
+
+	.enc-world-chapter-index .enc-world-chapter-index-summary {
 		cursor: pointer;
 		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
 		align-items: center;
+		gap: var(--g-3);
+		text-align: left;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		list-style: none;
 	}
+
+	.enc-world-chapter-index-summary::-webkit-details-marker { display: none; }
+	.enc-world-chapter-index-summary::marker { content: ''; }
 
 	.enc-world-chapter-index-summary .g-h3 {
 		margin: 0;
+		font-size: var(--g-size-legend);
+		letter-spacing: var(--g-track-legend);
+		color: var(--g-text-2);
 	}
 
-	.enc-world-chapter-index[open] .enc-world-chapter-index-summary {
-		margin-bottom: var(--g-2);
+	.enc-world-chapter-index-summary::after { content: ''; width: 8px; height: 8px; border-right: 1px solid var(--g-text-2); border-bottom: 1px solid var(--g-text-2); transform: rotate(45deg); margin-left: auto; }
+
+	.enc-world-chapter-index[open] .enc-world-chapter-index-summary.g-panel-head {
+		margin-bottom: var(--g-3);
+		padding-bottom: var(--g-3);
+		border-bottom: var(--g-hairline) solid var(--g-rule-faint);
 	}
+	.enc-world-chapter-index[open] .enc-world-chapter-index-summary::after { transform: rotate(-135deg); }
 }


### PR DESCRIPTION
## Summary

Full pass over every route at 390px (iPhone width, touch emulation) in 844px scrolled slices, after #132. Nothing overflows horizontally except rows that are meant to scroll (section tabs, element filter, trail).

**System**
- The masthead's action keys sit in one row of equal widths under the title on phones instead of two stacked full-width buttons. Meter name column narrows so the strip keeps its length.

**Home**
- The world field is four small art tiles across (name only, chip returns at 560px) instead of a 2×7 grid that ran two screens tall. The species strip is a horizontal touch-scroll row with snap.

**Encyclopedia**
- Card grids (worlds, bestiary, native fauna) drop to two columns under 520px with 16px names, so names and terrain no longer truncate mid-word.
- The "Back to <section>" link stays off the scrolling tabs row on phones; the section tab is the way back.
- Bestiary controls wrap on one row (world select full width, then sort, ratified, count).
- Species record on one column reads plate, prose, then the signature card.
- Chapter rail (world) and part rail (story) are compact folds with a chevron, no empty box under the summary.
- Story plate caption is body face, not mono. Entry fixed points are block lines with an inline mark.

**Generator**
- Move descriptions wrap on phones instead of truncating with an ellipsis.

## Verification
- `yarn test --run`: 847 passing.
- 390px scrolled slices of every route, plus a 1440 recapture of home, generator, worlds, world, bestiary and story part to confirm no desktop regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)