### PR TITLE
Art mounts: black silhouette on one flat element-hue square

### DIFF
--- a/my-app/public/assets/css/system.css
+++ b/my-app/public/assets/css/system.css
@@ -810,23 +810,33 @@
 .g-page .g-legend { font-family: var(--g-font-legend); color: var(--g-text-2); }
 
 
-/* Art mounts on chrome pages: the legacy .<element>-color wrappers (typeColors.css)
-   sit on a half-strength wash of the revised hue over level 0, so a black
-   silhouette still reads and the tint matches the rest of the system. */
-.g-page .fire-color { background: color-mix(in srgb, var(--g-el-fire) 52%, var(--g-s0)) !important; }
-.g-page .water-color { background: color-mix(in srgb, var(--g-el-water) 52%, var(--g-s0)) !important; }
-.g-page .air-color { background: color-mix(in srgb, var(--g-el-air) 52%, var(--g-s0)) !important; }
-.g-page .electric-color { background: color-mix(in srgb, var(--g-el-electric) 52%, var(--g-s0)) !important; }
-.g-page .rock-color { background: color-mix(in srgb, var(--g-el-rock) 52%, var(--g-s0)) !important; }
-.g-page .plant-color { background: color-mix(in srgb, var(--g-el-plant) 52%, var(--g-s0)) !important; }
-.g-page .chemical-color { background: color-mix(in srgb, var(--g-el-chemical) 52%, var(--g-s0)) !important; }
-.g-page .light-color { background: color-mix(in srgb, var(--g-el-light) 52%, var(--g-s0)) !important; }
-.g-page .dark-color { background: color-mix(in srgb, var(--g-el-dark) 52%, var(--g-s0)) !important; }
-.g-page .metal-color { background: color-mix(in srgb, var(--g-el-metal) 52%, var(--g-s0)) !important; }
-.g-page .psychic-color { background: color-mix(in srgb, var(--g-el-psychic) 52%, var(--g-s0)) !important; }
-.g-page .ghost-color { background: color-mix(in srgb, var(--g-el-ghost) 52%, var(--g-s0)) !important; }
-.g-page .ice-color { background: color-mix(in srgb, var(--g-el-ice) 52%, var(--g-s0)) !important; }
-.g-page .sand-color { background: color-mix(in srgb, var(--g-el-sand) 52%, var(--g-s0)) !important; }
+/* Art mounts on chrome pages (Nick, 2026-09-09): one flat square in the
+   element hue with the black silhouette on it. The legacy .<element>-color
+   wrapper (typeColors.css) and the component's inline gradient carry no
+   color of their own, so there is never a second square inside the mount. */
+.g-page .xalian-image-wrapper[class*='-color'] { background: transparent !important; }
+
+.g-page .enc-tile-art,
+.g-page .enc-species-mount,
+.g-page .home-species-plate,
+.g-page .account-tile-plate,
+.g-page .gen-record-plate {
+	background: var(--g-el);
+	padding: 12%;
+}
+
+.g-page .gen-record-plate {
+	background: linear-gradient(160deg, var(--g-el), var(--g-el-2, var(--g-el)));
+}
+
+.g-page .enc-tile-art-img,
+.g-page .enc-species-portrait,
+.g-page .home-species-plate-img,
+.g-page .gen-record-plate-img,
+.g-page .account-tile-plate .xalian-image-wrapper {
+	width: 100%;
+	height: auto;
+}
 
 /* A chip with no element in scope is neutral, never the accent. */
 .g-page { --g-el: var(--g-neutral-status); }


### PR DESCRIPTION
## Summary

Nick's ruling: creatures go back to a black silhouette on their colored background, with no second square inside the mount.

- One rule set in `system.css` under `.g-page`: the legacy `.<element>-color` wrapper and the component's inline gradient are made transparent, and the mount itself (bestiary and fauna tiles, species record, home strip, account tiles, generator plate) is the element hue at full strength. The generator plate keeps its two-element gradient in full hues.
- The 14 per-element `color-mix` overrides from #129 are removed.
- Silhouette fills the mount with 12% padding.

## Verification
- `yarn test --run`: 847 passing.
- Paint check at 1440 and 390 on home, generator, bestiary and a species record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)