### PR TITLE
Art mounts: restore the vignette, silhouette fills the square

### DIFF
--- a/my-app/public/assets/css/system.css
+++ b/my-app/public/assets/css/system.css
@@ -816,17 +816,23 @@
    color of their own, so there is never a second square inside the mount. */
 .g-page .xalian-image-wrapper[class*='-color'] { background: transparent !important; }
 
+/* The square keeps the old plate's soft vignette (the hue at the center,
+   falling to a darker rim) and the silhouette fills it edge to edge, with
+   just enough margin that limbs do not touch the frame. */
 .g-page .enc-tile-art,
 .g-page .enc-species-mount,
 .g-page .home-species-plate,
 .g-page .account-tile-plate,
 .g-page .gen-record-plate {
-	background: var(--g-el);
-	padding: 12%;
+	background-color: var(--g-el);
+	background-image: radial-gradient(circle at 50% 50%, transparent 58%, rgba(0, 0, 0, 0.28) 100%);
+	padding: 4%;
 }
 
 .g-page .gen-record-plate {
-	background: linear-gradient(160deg, var(--g-el), var(--g-el-2, var(--g-el)));
+	background-image:
+		radial-gradient(circle at 50% 50%, transparent 58%, rgba(0, 0, 0, 0.28) 100%),
+		linear-gradient(160deg, var(--g-el), var(--g-el-2, var(--g-el)));
 }
 
 .g-page .enc-tile-art-img,


### PR DESCRIPTION
## Summary

Follow-up to #135 from Nick's review: the flat square had lost the old plate's soft vignette and the creature sat too small inside it.

- A radial vignette (hue at the center, darker rim) sits over every art mount, including over the two-element gradient on the generator plate.
- Mount padding drops from 12% to 4%, so the silhouette fills the square edge to edge with just enough margin that limbs do not touch the frame.

## Verification
- `yarn test --run`: 871 passing.
- Paint check at 1440 on the bestiary and the generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)