### PR TITLE
ui: toggle group wears the segmented-control contract

### DIFF
--- a/my-app/src/components/ui/toggle-group.tsx
+++ b/my-app/src/components/ui/toggle-group.tsx
@@ -36,7 +36,7 @@ function ToggleGroup({
       data-spacing={spacing}
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
-        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))]",
         className
       )}
       {...props}
@@ -70,7 +70,7 @@ function ToggleGroupItem({
           size: context.size || size,
         }),
         "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
-        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        "data-[spacing=0]:-ml-px data-[spacing=0]:first:ml-0",
         className
       )}
       {...props}

--- a/my-app/src/components/ui/toggle.tsx
+++ b/my-app/src/components/ui/toggle.tsx
@@ -4,18 +4,17 @@ import { cn } from "@/lib/utils"
 import { Toggle as TogglePrimitive } from "radix-ui"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex items-center justify-center gap-2 border border-edge bg-s2 px-3 font-legend text-[13px] font-medium uppercase tracking-legend whitespace-nowrap text-ink-2 transition-[background-color,color] duration-1 ease-out outline-none hover:bg-s3 hover:text-ink focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-40 data-[state=on]:border-edge-strong data-[state=on]:bg-s0 data-[state=on]:text-ink data-[state=on]:shadow-[inset_0_-2px_0_var(--color-viable)] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
-        outline:
-          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+        default: "",
+        outline: "bg-transparent",
       },
       size: {
-        default: "h-9 min-w-9 px-2",
-        sm: "h-8 min-w-8 px-1.5",
-        lg: "h-10 min-w-10 px-2.5",
+        default: "h-9 min-w-9",
+        sm: "h-8 min-w-8 px-2",
+        lg: "h-11 min-w-11 px-4",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Toggle and ToggleGroup items now read the contract for a segmented control (docs/DESIGN_SYSTEM.md section 6): legend face, level 2 face on a hairline, pressed item on level 0 with the viable underline, never an accent fill. Seen on the duel setup page after PR #140, where the items were in the body face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)