### PR TITLE
Infra: bring the DynamoDB tables into Terraform (Wave A, PR A1b)

### DIFF
--- a/github-oidc.tf
+++ b/github-oidc.tf
@@ -96,6 +96,21 @@ resource "aws_iam_role_policy" "github_terraform" {
         Resource = "arn:aws:apigateway:${var.aws_region}::/*"
       },
       {
+        Sid    = "DynamoDB"
+        Effect = "Allow"
+        Action = ["dynamodb:*"]
+        Resource = [
+          "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/Xalian*",
+          "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/Xalian*/index/*",
+        ]
+      },
+      {
+        Sid      = "DynamoDBListTables"
+        Effect   = "Allow"
+        Action   = ["dynamodb:ListTables"]
+        Resource = "*"
+      },
+      {
         Sid    = "LambdaExecRole"
         Effect = "Allow"
         Action = [
@@ -146,13 +161,24 @@ resource "aws_iam_role_policy" "github_terraform" {
       # Deliberately excludes Delete*/CreateRole so a bad plan cannot
       # destroy the credentials CI depends on.
       {
+        # This statement grants the role permission to manage its own policy
+        # document, including this very statement. That is a one-time
+        # bootstrap problem: the CI role cannot grant itself a new
+        # permission it does not already have, so the change that ADDS
+        # iam:DeleteRolePolicy (and the DynamoDB/table-management actions
+        # elsewhere in this file) has to be applied once from Nick's
+        # machine with his own credentials:
+        #   terraform apply -target=aws_iam_role_policy.github_terraform
+        # After that one apply, CI can plan and apply further changes to
+        # this policy itself, same as everything else in the account.
         Sid    = "SelfManageOidcRole"
         Effect = "Allow"
         Action = [
           "iam:GetRole", "iam:UpdateRole", "iam:UpdateAssumeRolePolicy",
-          "iam:GetRolePolicy", "iam:PutRolePolicy", "iam:ListRolePolicies",
-          "iam:ListAttachedRolePolicies", "iam:ListRoleTags", "iam:TagRole",
-          "iam:UntagRole", "iam:ListInstanceProfilesForRole",
+          "iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+          "iam:ListRolePolicies", "iam:ListAttachedRolePolicies",
+          "iam:ListRoleTags", "iam:TagRole", "iam:UntagRole",
+          "iam:ListInstanceProfilesForRole",
         ]
         Resource = aws_iam_role.github_terraform.arn
       },

--- a/main.tf
+++ b/main.tf
@@ -858,31 +858,73 @@ resource "aws_s3_bucket_cors_configuration" "react_bucket" {
 
 
 
-// ###################
-// #     database    #
-// ###################
+#########################################################
+#####                  DATABASE                     #####
+#########################################################
+# Both tables were created by hand outside Terraform. Key schema and settings
+# below were verified against the live tables with describe-table on
+# 2026-09-10: PAY_PER_REQUEST billing, no GSIs, no streams, no TTL, no SSE
+# configured (defaults), and point-in-time recovery currently DISABLED on
+# both. This resource turns PITR on, which is a real, intended change on
+# import, not a drift correction.
+#
+# The `import` blocks below adopt the live tables into state on the next
+# apply. prevent_destroy guards against a future change to these resources
+# (for example the key-design rework tracked in issue #20) accidentally
+# planning a destroy/recreate of tables that hold real user data.
 
-// // resource "aws_dynamodb_table" "xalian_table" {
-// //   name             = "XalianTable"
-// //   hash_key         = "speciesId"
-// //   range_key        = "xalianId"
-// //   billing_mode     = "PAY_PER_REQUEST"
+resource "aws_dynamodb_table" "xalian_table" {
+  name         = "XalianTable"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "speciesId"
+  range_key    = "xalianId"
 
-// //   attribute {
-// //     name = "speciesId"
-// //     type = "S"
-// //   }
+  attribute {
+    name = "speciesId"
+    type = "S"
+  }
 
-// //   attribute {
-// //     name = "xalianId"
-// //     type = "S"
-// //   }
+  attribute {
+    name = "xalianId"
+    type = "S"
+  }
 
-// //   // replica {
-// //   //   region_name = "us-east-2"
-// //   // }
+  point_in_time_recovery {
+    enabled = true
+  }
 
-// //   // replica {
-// //   //   region_name = "us-west-2"
-// //   // }
-// // }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_dynamodb_table" "xalian_users_table" {
+  name         = "XalianUsersTable"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "userId"
+
+  attribute {
+    name = "userId"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+import {
+  to = aws_dynamodb_table.xalian_table
+  id = "XalianTable"
+}
+
+import {
+  to = aws_dynamodb_table.xalian_users_table
+  id = "XalianUsersTable"
+}
+#####                                               #####
+#########################################################


### PR DESCRIPTION
## Summary

Wave A, PR A1b of the backend modernization plan. Branched from `infra/runtime-hardening` (PR #152) per the plan; base this PR against that branch until #152 merges, then it will retarget to `main` automatically. Closes finding F11 (the remaining part: the tables themselves, not just the excludes list from A1).

- `main.tf`: replaced the commented-out table blocks at the bottom of the database section with live `aws_dynamodb_table` resources for `XalianTable` and `XalianUsersTable`, plus `import` blocks to adopt the existing tables into state.
  - `XalianTable`: hash key `speciesId` (S), range key `xalianId` (S), `PAY_PER_REQUEST`, no GSIs/streams/TTL/SSE, matching the live table verified today with describe-table (70 items).
  - `XalianUsersTable`: hash key `userId` (S), `PAY_PER_REQUEST`, no GSIs/streams/TTL, matching the live table (6 items).
  - Both get `point_in_time_recovery { enabled = true }` (currently disabled live -- this is a deliberate change, not a drift correction) and `lifecycle { prevent_destroy = true }`.
- `github-oidc.tf`: added statement Sid `DynamoDB` granting `dynamodb:*` on `arn:aws:dynamodb:<region>:<account>:table/Xalian*` and `.../table/Xalian*/index/*`, plus statement Sid `DynamoDBListTables` granting `dynamodb:ListTables` on `*`. Extended the existing `SelfManageOidcRole` statement (scoped to the GitHub role's own ARN) with `iam:DeleteRolePolicy`; it already had `iam:GetRolePolicy`, `iam:PutRolePolicy`, `iam:GetRole`, `iam:ListRolePolicies`, `iam:ListAttachedRolePolicies`, and `iam:UpdateAssumeRolePolicy`, which covers the rest of what the brief asked for.

## Manual step required (read before merging)

**Terraform plan in CI will fail on this PR until Nick runs `terraform apply -target=aws_iam_role_policy.github_terraform` locally from the repo root, then re-runs the Terraform plan check.**

This is a one-time bootstrap problem: the CI role's own policy document is what's changing here (it's gaining `dynamodb:*` and `iam:DeleteRolePolicy` on itself), and a role can't grant itself a permission it doesn't already have. There's a comment on the `SelfManageOidcRole` statement in `github-oidc.tf` explaining this. Once that one apply lands from Nick's machine, CI can plan and apply everything else in this PR (and future changes to this policy) on its own.

Auto-merge is enabled anyway; it will merge once the plan check goes green after that manual step.

## Verification

- `terraform fmt -check -recursive`: clean.
- `terraform init -backend=false` and `terraform validate`: both pass.
- `git diff --stat` against `infra/runtime-hardening`: only `main.tf` and `github-oidc.tf`.
- Never ran `terraform plan`, `terraform apply`, `aws`, or `amplify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)