### PR TITLE
Infra: grant the CI role CloudWatch log-delivery actions

### DIFF
--- a/github-oidc.tf
+++ b/github-oidc.tf
@@ -136,6 +136,20 @@ resource "aws_iam_role_policy" "github_terraform" {
         Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:*"
       },
       {
+        # API Gateway stage access logging is delivered through the CloudWatch Logs
+        # "log delivery" API, whose actions are not resource-scoped. UpdateStage on a
+        # stage with access_log_settings fails without these (seen on the 2026-09-10
+        # apply that added throttling to both stages).
+        Sid    = "LogDelivery"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogDelivery", "logs:GetLogDelivery", "logs:UpdateLogDelivery",
+          "logs:DeleteLogDelivery", "logs:ListLogDeliveries", "logs:PutResourcePolicy",
+          "logs:DescribeResourcePolicies", "logs:DescribeLogGroups",
+        ]
+        Resource = "*"
+      },
+      {
         Sid    = "Route53Zone"
         Effect = "Allow"
         Action = [


### PR DESCRIPTION
## Summary
The backend apply for #152 failed on both `aws_apigatewayv2_stage` updates with `not authorized to perform: logs:CreateLogDelivery`. Stages with `access_log_settings` go through the CloudWatch Logs delivery API, whose actions are not resource-scoped, so the existing `Logs` statement (scoped to log-group ARNs) does not cover them. This adds a `LogDelivery` statement with those actions on `*`.

Everything else in that apply landed: `nodejs22.x` on all seven functions, the scoped DynamoDB policy, and both tables imported with point-in-time recovery enabled (verified read-only with the AWS CLI). The throttling settings will apply on the next backend deploy after this merges. If IAM propagation lags behind the same run, a `workflow_dispatch` of Deploy backend finishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)