### PR TITLE
API: read JWT claims from payload format 1.0 events

### DIFF
--- a/lambda/src/auth.js
+++ b/lambda/src/auth.js
@@ -14,12 +14,13 @@ class ApiError extends Error {
 // responseBuilder.buildXalianUsersTableItem), so lowercasing here maps onto them with no
 // migration needed.
 function getSubject(event) {
-	const claims =
-		event &&
-		event.requestContext &&
-		event.requestContext.authorizer &&
-		event.requestContext.authorizer.jwt &&
-		event.requestContext.authorizer.jwt.claims;
+	// The HTTP API integrations use Lambda payload format 1.0, which puts JWT claims at
+	// requestContext.authorizer.claims. Payload format 2.0 nests them one level deeper at
+	// requestContext.authorizer.jwt.claims. Read both so a format change cannot lock every
+	// caller out (a valid token produced this handler's own 401 on 2026-09-10 for exactly
+	// that reason).
+	const authorizer = event && event.requestContext && event.requestContext.authorizer;
+	const claims = authorizer && ((authorizer.jwt && authorizer.jwt.claims) || authorizer.claims);
 
 	const username = claims && claims['cognito:username'];
 	return username ? String(username).toLowerCase() : null;

--- a/lambda/test/auth.test.js
+++ b/lambda/test/auth.test.js
@@ -41,3 +41,12 @@ test('requireSubject returns the lowercased subject when present', () => {
 	};
 	assert.equal(requireSubject(event), 'nick');
 });
+
+test('getSubject reads payload format 1.0 claims at requestContext.authorizer.claims', () => {
+	const event = {
+		requestContext: {
+			authorizer: { claims: { 'cognito:username': 'King_Kozrak' }, scopes: null },
+		},
+	};
+	assert.equal(getSubject(event), 'king_kozrak');
+});


### PR DESCRIPTION
## Summary
After #155 deployed, an end-to-end smoke test (temporary Cognito user, SRP sign-in, bearer ID token, user deleted afterward) showed every valid token getting this API's own `401 UNAUTHORIZED` body rather than API Gateway's. The authorizer accepted the token; the handler could not find the claims. The routes' integrations use Lambda payload format 1.0, where claims sit at `requestContext.authorizer.claims`; the code read only the 2.0 path `requestContext.authorizer.jwt.claims`.

`getSubject` now reads both shapes, with a test for the 1.0 layout (14 backend tests pass). The TypeScript rewrite (C2) will pin `payload_format_version = "2.0"` on the integrations and type the event accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)