### PR TITLE
Style guide: 16:9 plate uncropped, tiles lose the top strip

### DIFF
--- a/my-app/src/components/encyclopedia/Bestiary.js
+++ b/my-app/src/components/encyclopedia/Bestiary.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import * as lore from '../../lore';
 import XalianImage from '../xalianImage';
 import { useReadMark } from './trail';
-import { Tile, TileBar, TileArt, TileMeta, EmptyState } from '@/components/system/record';
+import { Tile, TileArt, TileMeta, EmptyState } from '@/components/system/record';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -19,7 +19,6 @@ function BestiaryTile({ species: s }) {
     const read = useReadMark('species', s.key);
     return (
         <Tile as={Link} to={lore.routeFor('species', s.key)} className={`el-${s.element}`}>
-            <TileBar />
             <TileArt className="bg-el p-[4%]">
                 <XalianImage colored speciesName={s.name} primaryType={s.element} moreClasses="w-full" />
             </TileArt>

--- a/my-app/src/components/encyclopedia/WorldView.js
+++ b/my-app/src/components/encyclopedia/WorldView.js
@@ -6,7 +6,7 @@ import XalianImage from '../xalianImage';
 import Connections from './Connections';
 import { useVisit, useReadMark, markRead, useResume } from './trail';
 import { SectionHead } from '@/components/system/masthead';
-import { SpecPlate, RecordRow, Tile, TileBar, TileArt, TileMeta, EmptyState } from '@/components/system/record';
+import { SpecPlate, RecordRow, Tile, TileArt, TileMeta, EmptyState } from '@/components/system/record';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
@@ -333,7 +333,6 @@ export default function WorldView() {
                         <div className="grid grid-cols-2 gap-3 gap-y-4 sm:grid-cols-3 sm:gap-4 sm:gap-y-5 md:grid-cols-4 min-[1080px]:grid-cols-5 xl:grid-cols-6">
                             {world.nativeSpecies.map((s) => (
                                 <Tile as={Link} key={s.key} to={lore.routeFor('species', s.key)} className={`el-${s.element}`}>
-                                    <TileBar />
                                     <TileArt className="bg-el p-[4%]">
                                         <XalianImage
                                             colored

--- a/my-app/src/components/encyclopedia/Worlds.js
+++ b/my-app/src/components/encyclopedia/Worlds.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import * as lore from '../../lore';
-import { Tile, TileBar, TileArt, TileMeta } from '@/components/system/record';
+import { Tile, TileArt, TileMeta } from '@/components/system/record';
 
 function sentenceCase(text) {
     if (!text) return text;
@@ -23,7 +23,6 @@ export default function Worlds() {
         <div className="grid grid-cols-2 gap-3 gap-y-4 sm:grid-cols-3 sm:gap-4 sm:gap-y-5 md:grid-cols-4 min-[1080px]:grid-cols-5 xl:grid-cols-6">
             {worlds.map((world) => (
                 <Tile as={Link} key={world.key} to={lore.routeFor('world', world.key)} className={`el-${world.element}`}>
-                    <TileBar />
                     <TileArt>
                         <img
                             src={`/${world.images.planet}`}

--- a/my-app/src/components/system/record.tsx
+++ b/my-app/src/components/system/record.tsx
@@ -155,10 +155,6 @@ function Tile({
   )
 }
 
-function TileBar({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="tile-bar" className={cn("h-[3px] bg-el", className)} {...props} />
-}
-
 function TileArt({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -173,5 +169,5 @@ function TileMeta({ className, ...props }: React.ComponentProps<"div">) {
   return <div data-slot="tile-meta" className={cn("px-4 pb-4 pt-3", className)} {...props} />
 }
 
-export { SpecPlate, RecordRow, Meter, MoveSet, EmptyState, Tile, TileBar, TileArt, TileMeta }
+export { SpecPlate, RecordRow, Meter, MoveSet, EmptyState, Tile, TileArt, TileMeta }
 export type { SpecEntry, Move }

--- a/my-app/src/pages/styleguide/primitiveSections.tsx
+++ b/my-app/src/pages/styleguide/primitiveSections.tsx
@@ -290,7 +290,7 @@ function AspectRatioSection() {
                 <Demo label="16:9, world">
                     <AspectRatio ratio={16 / 9} className="w-full el-water bg-el overflow-hidden">
                         <div className="flex size-full items-center justify-center">
-                            <XalianImage colored speciesName="Hippochamp" primaryType="water" moreClasses="w-full shrink-0" />
+                            <XalianImage colored speciesName="Hippochamp" primaryType="water" moreClasses="h-full w-auto shrink-0" />
                         </div>
                     </AspectRatio>
                 </Demo>


### PR DESCRIPTION
## Summary

Two things Nick flagged on the style guide pass (2026-09-10):

- **Aspect ratio.** The 16:9 demo cropped the creature top and bottom. The silhouette now sits at full height, centered on the element wash.
- **Catalog tiles.** The 3px element strip across the top read as a stray band. `TileBar` is gone from `record.tsx` and from the bestiary, worlds and world-view grids; the art plate already carries the element hue.

A larger pass on tile character is being proposed separately.

## Verification

tsc clean, 1174 tests, build clean. Snapped `/encyclopedia/species`, `/encyclopedia/worlds` and the aspect-ratio section at 1440 and 390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)