### PR TITLE
Lore status: five-field batch one ratified

### DIFF
--- a/docs/species-templates/lore-status.json
+++ b/docs/species-templates/lore-status.json
@@ -10,8 +10,8 @@
     "avilily": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was source before the split"
+      "fields": "ratified",
+      "note": "teaser was source before the split; fields ratified 2026-09-10 (batch one)"
     },
     "bioflim": {
       "description": "source",
@@ -22,8 +22,8 @@
     "chromocat": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was source before the split"
+      "fields": "ratified",
+      "note": "teaser was source before the split; fields ratified 2026-09-10 (batch one)"
     },
     "codazzo": {
       "description": "source",
@@ -34,8 +34,8 @@
     "crystorn": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was upgraded before the split"
+      "fields": "ratified",
+      "note": "teaser was upgraded before the split; fields ratified 2026-09-10 (batch one)"
     },
     "drilltail": {
       "description": "source",
@@ -46,8 +46,8 @@
     "dromeus": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was upgraded before the split"
+      "fields": "ratified",
+      "note": "teaser was upgraded before the split; fields ratified 2026-09-10 (batch one)"
     },
     "ectoghoul": {
       "description": "source",
@@ -70,14 +70,14 @@
     "graviclaw": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was source before the split"
+      "fields": "ratified",
+      "note": "teaser was source before the split; fields ratified 2026-09-10 (batch one)"
     },
     "hippochamp": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was upgraded before the split"
+      "fields": "ratified",
+      "note": "teaser was upgraded before the split; fields ratified 2026-09-10 (batch one)"
     },
     "hypnopet": {
       "description": "source",
@@ -88,14 +88,14 @@
     "imprit": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was source before the split"
+      "fields": "ratified",
+      "note": "teaser was source before the split; fields ratified 2026-09-10 (batch one)"
     },
     "kosanos": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was upgraded before the split"
+      "fields": "ratified",
+      "note": "teaser was upgraded before the split; fields ratified 2026-09-10 (batch one)"
     },
     "luceras": {
       "description": "source",
@@ -112,8 +112,8 @@
     "newtapede": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was upgraded before the split"
+      "fields": "ratified",
+      "note": "teaser was upgraded before the split; fields ratified 2026-09-10 (batch one)"
     },
     "scalatto": {
       "description": "source",
@@ -136,8 +136,8 @@
     "tetrahive": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was upgraded before the split"
+      "fields": "ratified",
+      "note": "teaser was upgraded before the split; fields ratified 2026-09-10 (batch one)"
     },
     "thirstaserp": {
       "description": "source",
@@ -166,8 +166,8 @@
     "xylum": {
       "description": "source",
       "appearance": "ratified",
-      "fields": "draft",
-      "note": "teaser was upgraded before the split"
+      "fields": "ratified",
+      "note": "teaser was upgraded before the split; fields ratified 2026-09-10 (batch one)"
     },
     "yetimoth": {
       "description": "source",


### PR DESCRIPTION
Marks the eleven batch-one species' five short fields ratified in lore-status.json (Nick, 2026-09-10). No record content changes.