### PR TITLE
Rules: derive generator types from @xalians/content/schema

### DIFF
--- a/packages/content/src/schema/abilityCatalog.ts
+++ b/packages/content/src/schema/abilityCatalog.ts
@@ -37,3 +37,6 @@ export const AbilityCatalogSchema = z.object({
 });
 
 export type AbilityCatalog = z.infer<typeof AbilityCatalogSchema>;
+// Exported so consumers (packages/rules's generator) that walk individual cell entries
+// have a name for one, instead of reaching into AbilityCatalog['neutral'][action][number].
+export type CatalogEntry = z.infer<typeof CatalogNameEntrySchema>;

--- a/packages/rules/src/generator/__tests__/generate.test.ts
+++ b/packages/rules/src/generator/__tests__/generate.test.ts
@@ -8,7 +8,7 @@ import registriesJson from '@xalians/content/registries.json';
 import catalogJson from '@xalians/content/abilityCatalog.json';
 import { ELEMENT_ADJACENCY, CONDUIT_ACTIONS_BY_MEDIUM, TRAIT_EXCLUSIONS, HEFT_BANDS } from '../constants.ts';
 import { makeRng } from '../prng.ts';
-import type { AttributeKey } from '../types.ts';
+import type { AttributeKey, ElementKey } from '../types.ts';
 
 const registries = registriesJson as any;
 const catalog = catalogJson as any;
@@ -105,7 +105,7 @@ describe('generator: every ratified species honors the record contract', () => {
 				if (el === t.element) {
 					return;
 				}
-				expect(ELEMENT_ADJACENCY[t.element]).toContain(el);
+				expect(ELEMENT_ADJACENCY[t.element as ElementKey]).toContain(el);
 				expect(grade).toBeGreaterThanOrEqual(1);
 				expect(grade).toBeLessThanOrEqual(99);
 			});
@@ -121,7 +121,7 @@ describe('generator: every ratified species honors the record contract', () => {
 				expect(Object.keys(t.traits.pool).concat(['phasing'])).toContain(k);
 			});
 			Object.entries(t.traits.pool).forEach(([k, pct]) => {
-				if (pct >= 100) {
+				if ((pct ?? 0) >= 100) {
 					expect(r.traits).toContain(k);
 				}
 			});

--- a/packages/rules/src/generator/__tests__/schema.test.ts
+++ b/packages/rules/src/generator/__tests__/schema.test.ts
@@ -1,0 +1,39 @@
+/*
+	Integration test: every record the generator can produce must satisfy the ratified
+	record schema in @xalians/content/schema (docs/design/xalian-creature-data-structure.md).
+	This is the check that packages/rules/src/generator/types.ts's hand-written record
+	shape (deleted in favor of re-exporting the schema type) and generate.ts's actual
+	output never drift apart -- if generate.ts writes something the schema rejects, this
+	is where it shows up, with the zod issue path and the species key that produced it.
+*/
+import { describe, test, expect } from 'vitest';
+import { generateBatch, getSpeciesTemplates } from '../index.ts';
+import { XalianRecordSchema } from '@xalians/content/schema';
+
+const SEED = 'schema-integration-fixed-seed';
+const COUNT = 200;
+
+describe('generator output against XalianRecordSchema', () => {
+	test('generateBatch(200, fixed seed) across every ratified species all parse', () => {
+		const templates = getSpeciesTemplates();
+		expect(templates.length).toBeGreaterThan(0);
+
+		const records = generateBatch(COUNT, SEED, { templates });
+		expect(records.length).toBe(COUNT);
+
+		const failures: string[] = [];
+		records.forEach((record) => {
+			const result = XalianRecordSchema.safeParse(record);
+			if (!result.success) {
+				const paths = result.error.issues
+					.map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+					.join('; ');
+				failures.push(`species "${record.species}" (id ${record.id}): ${paths}`);
+			}
+		});
+
+		if (failures.length > 0) {
+			throw new Error(`${failures.length} of ${records.length} generated records failed XalianRecordSchema:\n${failures.join('\n')}`);
+		}
+	});
+});

--- a/packages/rules/src/generator/devtools/simulateGenerator.ts
+++ b/packages/rules/src/generator/devtools/simulateGenerator.ts
@@ -188,12 +188,12 @@ function speciesStats(template: SpeciesTemplate, records: XalianRecord[]): Speci
 
 	// build (archetype) shares vs authored weights
 	const weights = template.archetypeWeights || { balanced: 100 };
-	const weightSum = Object.values(weights).reduce((a, b) => a + b, 0) || 1;
+	const weightSum = Object.values(weights).reduce<number>((a, b) => a + (b ?? 0), 0) || 1;
 	const buildCounts = new Map<string, number>();
 	records.forEach((r) => buildCounts.set(r.archetype.key, (buildCounts.get(r.archetype.key) || 0) + 1));
 	const buildRows: BuildRow[] = Object.keys(weights).map((key) => ({
 		key,
-		authoredShare: pct(weights[key], weightSum),
+		authoredShare: pct(weights[key] ?? 0, weightSum),
 		observedShare: pct(buildCounts.get(key) || 0, n),
 	}));
 
@@ -201,9 +201,9 @@ function speciesStats(template: SpeciesTemplate, records: XalianRecord[]): Speci
 	const pool = (template.traits && template.traits.pool) || {};
 	const traitRows: TraitRow[] = Object.keys(pool).map((key) => {
 		const landed = records.filter((r) => r.traits.includes(key)).length;
-		return { key, authoredPercent: pool[key], observedRate: pct(landed, n) };
+		return { key, authoredPercent: pool[key] ?? 0, observedRate: pct(landed, n) };
 	});
-	const expectedTraitCount = Object.values(pool).reduce((a, b) => a + b, 0) / 100;
+	const expectedTraitCount = Object.values(pool).reduce<number>((a, b) => a + (b ?? 0), 0) / 100;
 	const traitCounts = records.map((r) => r.traits.length);
 	const traitCountDist: Record<string, number> = {};
 	traitCounts.forEach((c) => {
@@ -292,9 +292,9 @@ function rosterStats(templates: SpeciesTemplate[], perSpecies: Map<string, Xalia
 	templates.forEach((t) => {
 		const records = perSpecies.get(t.key) || [];
 		const weights = t.archetypeWeights || { balanced: 100 };
-		const weightSum = Object.values(weights).reduce((a, b) => a + b, 0) || 1;
+		const weightSum = Object.values(weights).reduce<number>((a, b) => a + (b ?? 0), 0) || 1;
 		Object.keys(weights).forEach((key) => {
-			const expected = (records.length * weights[key]) / weightSum;
+			const expected = (records.length * (weights[key] ?? 0)) / weightSum;
 			expectedBuildCounts.set(key, (expectedBuildCounts.get(key) || 0) + expected);
 		});
 	});

--- a/packages/rules/src/generator/generate.ts
+++ b/packages/rules/src/generator/generate.ts
@@ -52,13 +52,16 @@ import type {
 	GenerateBatchArgs,
 	GenerateXalianArgs,
 	Registries,
-	RecordAbility,
-	RecordArchetype,
-	RecordElement,
-	RecordPhysiology,
 	SpeciesTemplate,
 	XalianRecord,
 } from './types.ts';
+
+// record.ts's nested shapes have no standalone exported name (they're inline in
+// XalianRecord), so this package names them locally for its own intermediate results.
+type RecordArchetype = XalianRecord['archetype'];
+type RecordElement = XalianRecord['element'];
+type RecordPhysiology = XalianRecord['physiology'];
+type RecordAbility = XalianRecord['abilities'][number];
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -160,8 +163,8 @@ function rollPhysiology(rng: Rng, template: SpeciesTemplate): PhysiologyResult {
 		senseBands[key] = b;
 		senses[key] = rollInBand(rng, b);
 	});
-	if (Array.isArray(src.senses && src.senses.special) && (src.senses as { special?: string[] }).special!.length > 0) {
-		senses.special = (src.senses as { special: string[] }).special.slice();
+	if (src.senses && Array.isArray(src.senses.special) && src.senses.special.length > 0) {
+		senses.special = src.senses.special.slice();
 	}
 
 	const chiralityRule = src.genome && src.genome.chirality;
@@ -204,7 +207,12 @@ interface AffinitiesResult {
 }
 
 function rollAffinities(rng: Rng, template: SpeciesTemplate): AffinitiesResult {
-	const primary = template.element;
+	// template.element is validated against the closed element enum by
+	// SpeciesTemplateSchema (packages/content/src/schema/speciesTemplate.ts) at bundle
+	// parse time in index.ts, but registries.json-derived key enums infer as a bare
+	// `string` (see the note in ./types.ts), so this package's own ElementKey union is
+	// narrower than the schema's; the cast asserts what parsing already guaranteed.
+	const primary = template.element as ElementKey;
 	const affinities: RecordElement['affinities'] = { [primary]: 100 };
 	const graph = ELEMENT_ADJACENCY[primary] || [];
 	let secondary: ElementKey | null = null;
@@ -269,8 +277,8 @@ function tiltedPercent(key: string, percent: number, ctx: TiltContext): number {
 function rollTraits(rng: Rng, template: SpeciesTemplate, ctx: TiltContext): string[] {
 	const pool = (template.traits && template.traits.pool) || {};
 	const tilted = Object.keys(pool)
-		.filter((key) => pool[key] > 0)
-		.map((key) => ({ key, percent: tiltedPercent(key, pool[key], ctx) }));
+		.filter((key) => (pool[key] ?? 0) > 0)
+		.map((key) => ({ key, percent: tiltedPercent(key, pool[key] ?? 0, ctx) }));
 
 	// a non-corporeal body phases whether or not the template listed it
 	if (ctx.physiology.corporeality === 'non-corporeal' && !tilted.some((t) => t.key === 'phasing')) {

--- a/packages/rules/src/generator/grade.ts
+++ b/packages/rules/src/generator/grade.ts
@@ -119,7 +119,9 @@ function traitsScore(record: XalianRecord, template: SpeciesTemplate): number {
 	const traits = record.traits || [];
 	let score = 0;
 	Object.keys(pool).forEach((key) => {
-		const percent = pool[key];
+		// traits.pool is a partial record (an unlisted trait key is an implicit 0), but
+		// key came from Object.keys(pool) so the value is always present here.
+		const percent = pool[key] ?? 0;
 		if (percent >= 100) {
 			return;
 		}

--- a/packages/rules/src/generator/index.ts
+++ b/packages/rules/src/generator/index.ts
@@ -5,19 +5,24 @@
 	tested with fixtures and later moved to the Lambda.
 */
 
-// the bundled JSON is validated data, not a typed structure this package owns; cast at
-// the boundary (a zod schema for it lives in packages/content/src/schema, branch
-// content/schemas, landing separately)
 import speciesRecordsJson from '@xalians/content/speciesRecords.json';
 import registriesJson from '@xalians/content/registries.json';
 import catalogJson from '@xalians/content/abilityCatalog.json';
+import { SpeciesRecordsBundleSchema } from '@xalians/content/schema';
 import { generateXalian as generateWithTables, generateBatch as generateBatchWithTables } from './generate.ts';
-import type { AbilityCatalog, GenerateBatchOptions, GenerateOptions, Registries, SpeciesRecordsBundle, SpeciesTemplate, XalianRecord } from './types.ts';
+import type { AbilityCatalog, GenerateBatchOptions, GenerateOptions, Registries, SpeciesTemplate, XalianRecord } from './types.ts';
 
 export { GENERATOR_VERSION, SCHEMA_VERSION } from './constants.ts';
 export type * from './types.ts';
 
-const speciesRecords = speciesRecordsJson as unknown as SpeciesRecordsBundle;
+// speciesRecords.json is parsed through the schema (not cast) so a bundle that violates
+// the ratified record shape fails loudly at import time rather than producing garbage
+// records; measured at ~8ms for the 30-species bundle, well under the cost of skipping
+// it. registries.json and abilityCatalog.json stay a cast at the boundary: the ability
+// catalog is validated structurally by packages/content's own test suite rather than
+// per-entry (see abilityCatalog.ts), and registries.json is internal plumbing the
+// generator only reads a few fields of.
+const speciesRecords = SpeciesRecordsBundleSchema.parse(speciesRecordsJson);
 const registries = registriesJson as unknown as Registries;
 const catalog = catalogJson as unknown as AbilityCatalog;
 

--- a/packages/rules/src/generator/types.ts
+++ b/packages/rules/src/generator/types.ts
@@ -1,20 +1,39 @@
 /*
-	Shared types for the generator: the species template shape (speciesRecords.json), the
-	registries shape (registries.json), the ability catalog shape (abilityCatalog.json),
-	and the generated creature record shape, per docs/design/xalian-creature-data-structure.md
-	and docs/design/sample-record-graviclaw.json.
-
-	These are derived from what generate.js/index.js/grade.js actually read and write, not
-	hand-invented. A zod-validated version of the record and template shapes is being built
-	independently in packages/content/src/schema (branch content/schemas); these types are
-	the structural contract this package needs until that lands, and are deliberately loose
-	where the JSON data is looser than the ratified doc (see the `Band` / optional-field
-	notes below).
+	Generator types. The species template, registries, ability catalog and generated
+	record shapes are no longer hand-written here: `@xalians/content/schema` derives them
+	from zod schemas (docs/design/xalian-creature-data-structure.md), and this file
+	re-exports those so every existing `from './types.ts'` import keeps working. What
+	remains here is generator-internal: types with no schema counterpart, because they
+	describe something the schema doesn't (a roll band, the generator's own option bags,
+	the lever tables in constants.ts) or narrow a schema field the schema itself leaves as
+	a bare `string` (the closed key unions below -- see "Schema changes" in the PR that
+	introduced this file for why those stay local instead of widening call sites).
 */
 
-// a [min, max] roll band; JSON stores these as two-element arrays
+export type {
+	AbilityCatalog,
+	CatalogEntry,
+	Registries,
+	SpeciesRecordsBundle,
+	SpeciesTemplate,
+	XalianRecord,
+} from '@xalians/content/schema';
+
+// a [min, max] roll band; JSON stores these as two-element arrays. The schema expresses
+// the same shape as a validated tuple inline (speciesTemplate.ts's `range()`) but does
+// not export a standalone name for it.
 export type Band = [number, number];
 
+/*
+	registries.json's closed vocabularies are zod enums built from the JSON at runtime
+	(packages/content/src/schema/registries.ts), which keeps the *values* honest but,
+	because `resolveJsonModule` types every JSON string as plain `string`, their z.infer
+	type is `string`, not a literal union -- so the schema has no narrow-key counterpart
+	to re-export here. The generator leans on these unions for real safety (exhaustive
+	switches in generate.ts, `Record<AttributeKey, ...>` maps that must stay total), so
+	they stay hand-written and local rather than being loosened to `string` at every call
+	site. See "Schema changes" in this PR's description for the follow-up option.
+*/
 export type AttributeKey =
 	| 'strength' | 'vitality' | 'endurance' | 'agility' | 'reflex'
 	| 'intelligence' | 'willpower' | 'instinct' | 'charisma' | 'resilience';
@@ -32,169 +51,10 @@ export type Corporeality = 'corporeal' | 'non-corporeal';
 export type Finish = 'standard' | 'gleam' | 'prismatic' | 'eclipse';
 
 // -----------------------------------------------------------------------------------
-// species template (one entry of @xalians/content/speciesRecords.json's `records` array)
+// generateXalian / generateBatch options -- generator-internal, no schema counterpart
 // -----------------------------------------------------------------------------------
 
-export interface SpeciesTemplateSize {
-	heightCm: Band;
-	weightKg: Band;
-}
-
-export interface SpeciesTemplatePhysiology {
-	corporeality?: Corporeality;
-	composition?: { primary?: string; secondary?: string };
-	bodyPlan?: string;
-	anatomy?: string[];
-	covering?: string;
-	size: SpeciesTemplateSize;
-	lifespan?: string;
-	genome?: { chirality?: 'rolled' | Chirality };
-	diet?: string;
-	communication?: string[];
-	breathes?: string[];
-	environmentalTolerance?: {
-		ambientMedia?: string[];
-		temperatureC?: { min: number; max: number };
-	};
-	capabilities?: Partial<Record<CapabilityKey, Band>>;
-	senses?: Partial<Record<GradedSenseKey, Band>> & { special?: string[] };
-}
-
-export interface SpeciesTemplateSignatureAbility {
-	name: string;
-	instrument: string;
-	action: string;
-	medium: string;
-	intensity: Band;
-	description?: string;
-}
-
-export interface SpeciesTemplate {
-	key: string;
-	name: string;
-	element: ElementKey;
-	homePlanet: string;
-	generatorPlanets?: string[];
-	lore?: Record<string, unknown>;
-	physiology: SpeciesTemplatePhysiology;
-	archetypeWeights: Record<string, number>;
-	attributes: Record<AttributeKey, Band>;
-	traits: { pool: Record<string, number> };
-	instruments: string[];
-	conduits?: Record<string, string>;
-	signatureAbility: SpeciesTemplateSignatureAbility;
-}
-
-export interface SpeciesRecordsBundle {
-	records: SpeciesTemplate[];
-}
-
-// -----------------------------------------------------------------------------------
-// registries.json
-// -----------------------------------------------------------------------------------
-
-export interface ArchetypeRow {
-	key: string;
-	name: string;
-	nature: string;
-	favors: string[];
-}
-
-export interface Registries {
-	version?: string;
-	note?: string;
-	archetypes: ArchetypeRow[];
-	instrumentActions: Record<string, string[]>;
-	[key: string]: unknown;
-}
-
-// -----------------------------------------------------------------------------------
-// abilityCatalog.json
-// -----------------------------------------------------------------------------------
-
-// a bare name (untagged, ordinary heft), [name, tags] (ordinary heft), or
-// [name, tags, heft] (heft 1 or 3) — scripts/bundleAbilityCatalog.js's entry shape
-export type CatalogEntry = string | [string, string[]] | [string, string[], number];
-
-export interface AbilityCatalog {
-	elements: Record<string, Record<string, CatalogEntry[]>>;
-	neutral: Record<string, CatalogEntry[]>;
-	counts?: { heft?: Record<string, number>; [key: string]: unknown };
-	[key: string]: unknown;
-}
-
-// -----------------------------------------------------------------------------------
-// generated record (generate.js's generateXalian output; docs/design/
-// xalian-creature-data-structure.md section 2)
-// -----------------------------------------------------------------------------------
-
-export interface RecordProvenance {
-	seed: string;
-	generatorVersion: string;
-	schemaVersion: string;
-	generatedAt: string;
-	origin: string;
-	serial: number;
-}
-
-export interface RecordPhysiology {
-	corporeality: Corporeality;
-	composition: { primary: string; secondary?: string };
-	bodyPlan: string;
-	anatomy: string[];
-	covering: string;
-	heightCm: number;
-	weightKg: number;
-	lifespan: string;
-	genome: { chirality: Chirality };
-	diet: string;
-	communication: string[];
-	breathes: string[];
-	environmentalTolerance: {
-		ambientMedia: string[];
-		temperatureC: { min: number; max: number };
-	};
-	capabilities: Record<CapabilityKey, number>;
-	senses: Record<GradedSenseKey, number> & { special?: string[] };
-}
-
-export interface RecordArchetype {
-	key: string;
-	favors: string[];
-}
-
-export interface RecordElement {
-	primary: ElementKey;
-	affinities: Partial<Record<ElementKey, number>>;
-}
-
-export interface RecordAbility {
-	name: string;
-	signature: boolean;
-	instrument: string;
-	action: string;
-	medium: string;
-	intensity: number;
-	description?: string;
-}
-
-export interface XalianRecord {
-	id: string;
-	species: string;
-	provenance: RecordProvenance;
-	physiology: RecordPhysiology;
-	archetype: RecordArchetype;
-	attributes: Record<AttributeKey, number>;
-	element: RecordElement;
-	traits: string[];
-	temperament: Record<TemperamentKey, number>;
-	appearance: { finish: Finish };
-	abilities: RecordAbility[];
-}
-
-// -----------------------------------------------------------------------------------
-// generateXalian / generateBatch options
-// -----------------------------------------------------------------------------------
+import type { AbilityCatalog, Registries, SpeciesTemplate } from '@xalians/content/schema';
 
 export interface GenerateOptions {
 	origin?: string;
@@ -217,7 +77,7 @@ export interface GenerateXalianArgs {
 }
 
 // -----------------------------------------------------------------------------------
-// constants.js lever tables
+// constants.ts lever tables -- generator-internal, no schema counterpart
 // -----------------------------------------------------------------------------------
 
 export interface TraitTiltSpec {


### PR DESCRIPTION
## Summary

Follow-up to C1 (zod schemas, PR #173) and B2 (`@xalians/rules` generator, PR #175): `packages/rules/src/generator/types.ts` hand-wrote 31 exports that duplicated shapes `packages/content/src/schema` already derives from zod (`SpeciesTemplate`, `SpeciesRecordsBundle`, `Registries`, `AbilityCatalog`, `XalianRecord`). Two definitions of one shape violates "one source per data kind" and will drift, so this deletes the duplicates and re-exports the schema types.

## What changed

**Deleted from `types.ts`** (now re-exported from `@xalians/content/schema`): `SpeciesTemplateSize`, `SpeciesTemplatePhysiology`, `SpeciesTemplateSignatureAbility`, `SpeciesTemplate`, `SpeciesRecordsBundle`, `ArchetypeRow`, `Registries`, `CatalogEntry`, `AbilityCatalog`, `RecordProvenance`, `RecordPhysiology`, `RecordArchetype`, `RecordElement`, `RecordAbility`, `XalianRecord`.

**Kept as generator-internal** (no schema counterpart): `Band`; the closed key unions `AttributeKey`, `CapabilityKey`, `GradedSenseKey`, `TemperamentKey`, `ElementKey`, `Chirality`, `Corporeality`, `Finish`; `GenerateOptions`/`GenerateBatchOptions`/`GenerateXalianArgs`/`GenerateBatchArgs`; the `constants.ts` lever types `TraitTiltSpec`/`TemperamentTiltSpec`/`FinishOdds`.

The key unions stay hand-written on purpose, not as an oversight: `registries.json`'s zod enums (`packages/content/src/schema/registries.ts`) are built from the parsed JSON at runtime so their *values* can't drift, but TypeScript's `resolveJsonModule` widens every JSON string to plain `string`, so `z.infer` on those enums gives `string`, not a literal union. Verified this directly (`z.infer<typeof AttributeKeySchema>` accepts an arbitrary string with no type error). The generator leans on the narrow local unions for real safety — exhaustive lookups like `ELEMENT_ADJACENCY[element]` and total `Record<AttributeKey, ...>` maps — so keeping them local was the smaller, lower-risk fix versus reworking `registries.ts`'s JSON-to-enum derivation (which would touch every consumer of `packages/content/src/schema`, including the in-flight `api/typescript` branch). Flagging as a real gap for a future follow-up rather than silently widening call sites to `string`.

## Schema changes

- **Added `CatalogEntry`** as an exported type in `packages/content/src/schema/abilityCatalog.ts` (`z.infer` of the existing, previously-unexported `CatalogNameEntrySchema`). Purely additive — `packages/rules`'s generator needed a name for one ability-name-cell entry instead of reaching into `AbilityCatalog['neutral'][action][number]`.

No other schema changes. The rest of the friction found (partial-record trait/archetype-weight pools, `element` typed as bare `string`) was a case of the schema being *correctly* stricter/looser than the old hand-written types assumed, so it was fixed on the generator side (see below), not by loosening the schema.

## Generator-side fixes

- `index.ts` now parses the bundled `speciesRecords.json` through `SpeciesRecordsBundleSchema` at startup instead of casting — measured at ~8ms for the 30-species bundle, well under a 50ms budget, so it runs unconditionally rather than only in a test. `registries.json` and `abilityCatalog.json` stay a boundary cast, matching how `packages/content`'s own test suite validates the catalog structurally rather than per-entry (it's ~400KB / ~22,700 names).
- `template.element` is cast to the local `ElementKey` where used as a lookup key (`ELEMENT_ADJACENCY[...]`) — safe because the startup parse above already validates every template's `element` against the schema's closed enum; the cast just restores the literal type TypeScript can't infer from the JSON import.
- `traits.pool` and `archetypeWeights` are zod partial records (an absent key means "not rolled" / weight 0), stricter than the old always-present `Record<string, number>` type. Added `?? 0` guards at each read site (`generate.ts`, `grade.ts`, `simulateGenerator.ts`, `generate.test.ts`) rather than assuming presence.
- `senses.special` is already correctly typed by the schema as the literal special-sense union; removed a now-unneeded manual `string[]` cast in `rollPhysiology`.

## Integration test

Added `packages/rules/src/generator/__tests__/schema.test.ts`: `generateBatch(200, <fixed seed>)` across every ratified species (30 species, so every species appears 6-7 times), each record parsed with `XalianRecordSchema.safeParse` — on failure it reports every distinct zod issue path plus the species key and record id, not just the first failure.

**First-run result: 0 of 200 failed.** The generator's output already matched the schema once the type-level fixes above landed (no surprise — `npm test -w packages/rules`'s existing 39 tests already exercise the same pipeline, and the startup schema-parse of the input templates would have caught template-shape problems earlier in the pipeline).

To confirm the test actually catches violations (not just passing vacuously), I temporarily forced `rollFinish` to return an invalid `appearance.finish` value, reran the test, watched it fail with the expected zod path (`appearance.finish: Invalid option...`) for every one of the 200 records, then reverted. Full suite is green with the revert in place.

## Verification

- `npm run typecheck -w packages/rules` — clean
- `npm run typecheck -w packages/content` — clean
- `npm test -w packages/rules` — 40/40 passing (39 existing + the new schema test)
- `npm test -w packages/content` — 34/34 passing
- `npm test -w my-app -- --run` — 1191/1191 passing
- `npm run build -w my-app` — succeeds (one pre-existing, unrelated Vite warning about `@xalians/content/registries.json` being imported with and without `with { type: 'json' }` attributes in different files across the monorepo — now also reachable through this package's new `@xalians/content/schema` import; non-fatal, worth a follow-up issue if Nick wants it cleaned up)
- `node scripts/checkCatalogCoverage.js` — 0 species under the coverage floor (reverted the incidental `docs/ability-catalog/COVERAGE.md` timestamp/count diff the run produces, since the underlying data was already stale in this branch before my changes and re-syncing it is out of scope here)

Did not touch `apps/api` (in flight on `api/typescript`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)