### PR TITLE
Backend: server-generated Xalian registry, signed showroom keeps (D1)

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -44,3 +44,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@xalians/content": "1.0.0",
+    "@xalians/rules": "1.0.0",
     "zod": "^4.6.0"
   },
   "devDependencies": {

--- a/apps/api/src/handlers/createXalian.ts
+++ b/apps/api/src/handlers/createXalian.ts
@@ -1,16 +1,46 @@
-// POST /db/xalian. Requires an authenticated caller. The body is still trusted as-is; a
-// later PR (Wave D, D1 in docs/design/backend-modernization-plan.md) moves generation
-// server-side so a client can no longer post arbitrary stats.
-import { withApi } from '../lib/api.ts';
-import { CreateXalianBodySchema } from '../lib/schemas.ts';
+// POST /db/xalian. The keep flow (audit F2 / D1): the body is the exact { xalian,
+// signature } envelope GET /xalian returned. This verifies the signature (so the stats
+// are provably the ones the server generated, not ones the client edited), requires the
+// record to be fresh (so a signature cannot be replayed indefinitely), persists it, then
+// appends the id to the caller's user record -- all in one call. The old two-call flow
+// (POST /db/xalian trusting the body, then a separate PATCH /db/user ADD_XALIAN_ID) is
+// gone; ADD_XALIAN_ID is now rejected everywhere else (see updateUser.ts).
+import { ApiError, withApi } from '../lib/api.ts';
+import { KeepXalianBodySchema } from '../lib/schemas.ts';
+import { verifyRecord } from '../lib/signing.ts';
 import * as xaliansRepo from '../repositories/xalians.ts';
+import * as usersRepo from '../repositories/users.ts';
 import * as log from '../lib/log.ts';
 
+const SIGNATURE_TTL_MS = 24 * 60 * 60 * 1000;
+
 export const handler = withApi(
-  async ({ body, requestId }) => {
-    await xaliansRepo.createXalian(body);
-    log.info('createXalian success', { requestId, xalianId: body.xalianId });
-    return { status: 200, body: { message: 'ok' } };
+  async ({ subject, body, requestId }) => {
+    const userId = subject as string;
+    const { xalian, signature } = body;
+
+    if (!verifyRecord(xalian, signature)) {
+      throw new ApiError(400, 'INVALID_SIGNATURE', 'Xalian signature does not verify');
+    }
+
+    const age = Date.now() - xalian.createTimestamp;
+    if (age > SIGNATURE_TTL_MS || age < 0) {
+      throw new ApiError(400, 'SIGNATURE_EXPIRED', 'Xalian signature is more than 24 hours old');
+    }
+
+    try {
+      await xaliansRepo.createXalian(xalian);
+    } catch (err) {
+      if (err instanceof xaliansRepo.XalianAlreadyExistsError) {
+        throw new ApiError(409, 'ALREADY_KEPT', err.message);
+      }
+      throw err;
+    }
+
+    await usersRepo.addXalianId(userId, xalian.xalianId);
+
+    log.info('createXalian success', { requestId, userId, xalianId: xalian.xalianId });
+    return { status: 200, body: { message: 'ok', xalianId: xalian.xalianId } };
   },
-  { auth: 'jwt', body: CreateXalianBodySchema }
+  { auth: 'jwt', body: KeepXalianBodySchema }
 );

--- a/apps/api/src/handlers/generateRegistryXalian.ts
+++ b/apps/api/src/handlers/generateRegistryXalian.ts
@@ -1,0 +1,54 @@
+// POST /xalians (D1, the registry). Generates a ratified XalianRecord server-side from
+// @xalians/rules with a server-drawn seed, persists it under the caller, and returns it.
+// This is the "generate" verb the vision doc ratified (the word "mint" is banned
+// platform-wide): the server owns the creature from the moment it exists, unlike the
+// legacy showroom flow (GET /xalian, POST /db/xalian) where the client shows a record and
+// then asks to keep it.
+import { randomBytes } from 'node:crypto';
+import { ApiError, withApi } from '../lib/api.ts';
+import { GenerateRegistryXalianBodySchema } from '../lib/schemas.ts';
+import { generateXalian, getSpeciesTemplate, getSpeciesTemplates } from '@xalians/rules/generator';
+import { XalianRecordSchema } from '@xalians/content/schema';
+import * as registryRepo from '../repositories/registry.ts';
+import * as log from '../lib/log.ts';
+
+function pickRandom<T>(items: T[]): T {
+  return items[Math.floor(Math.random() * items.length)];
+}
+
+export const handler = withApi(
+  async ({ subject, body, requestId }) => {
+    const ownerId = subject as string;
+
+    const template = body.species ? getSpeciesTemplate(body.species) : pickRandom(getSpeciesTemplates());
+    if (!template) {
+      throw new ApiError(400, 'UNKNOWN_SPECIES', `"${body.species}" is not a ratified species`);
+    }
+
+    const seed = randomBytes(16).toString('hex');
+    const generated = generateXalian(template, seed, {
+      origin: template.homePlanet,
+      generatedAt: new Date().toISOString(),
+    });
+
+    // The generator and the schema are already integration-tested together (see
+    // packages/rules); this parse is a guard against drift between the two packages, not
+    // a substitute for that coverage. A failure here is a server bug, not a client error,
+    // so it is logged with the zod issue path and surfaces as a 500.
+    const parsed = XalianRecordSchema.safeParse(generated);
+    if (!parsed.success) {
+      log.error('generateRegistryXalian: generated record failed schema validation', {
+        requestId,
+        issues: parsed.error.issues.map((issue) => issue.path.join('.')),
+      });
+      throw new Error('Generated record did not match XalianRecordSchema');
+    }
+    const record = parsed.data;
+
+    await registryRepo.putRecord(ownerId, record);
+
+    log.info('generateRegistryXalian success', { requestId, ownerId, xalianId: record.id, species: record.species });
+    return { status: 201, body: record };
+  },
+  { auth: 'jwt', body: GenerateRegistryXalianBodySchema }
+);

--- a/apps/api/src/handlers/generateXalian.ts
+++ b/apps/api/src/handlers/generateXalian.ts
@@ -1,6 +1,9 @@
 // GET /xalian. Unauthenticated free showroom generator. Runs the legacy (pre-record)
-// engine and returns its translated shape unchanged; CORS is API Gateway's, not this
-// handler's (the old hand-rolled CORS headers here were invalid and are gone).
+// engine and returns its translated shape unchanged, plus a server-side HMAC over it
+// (audit F2 / signing.ts): POST /db/xalian verifies that signature before persisting, so
+// keeping a Xalian can no longer write stats the server never generated. CORS is API
+// Gateway's, not this handler's (the old hand-rolled CORS headers here were invalid and
+// are gone).
 //
 // The legacy engine (src/legacy) is CommonJS. Importing it with plain ESM `import`
 // syntax, rather than a hand-rolled `require`, is what lets esbuild see the reference
@@ -11,6 +14,7 @@
 import xalianBuilder from '../legacy/xalianBuilder.js';
 import translator from '../legacy/translator.js';
 import { withApi } from '../lib/api.ts';
+import { signRecord } from '../lib/signing.ts';
 
 type LegacyXalianBuilder = { buildXalian: (selectedSpecies?: unknown) => unknown };
 type LegacyTranslator = { translateCharacterToPresentableType: (xalian: unknown) => unknown };
@@ -22,7 +26,8 @@ export const handler = withApi(
   async () => {
     const xalian = builder.buildXalian();
     const translated = translate.translateCharacterToPresentableType(xalian);
-    return { status: 200, body: translated };
+    const signature = signRecord(translated);
+    return { status: 200, body: { xalian: translated, signature } };
   },
   { auth: 'none' }
 );

--- a/apps/api/src/handlers/listRegistryXalians.ts
+++ b/apps/api/src/handlers/listRegistryXalians.ts
@@ -1,0 +1,25 @@
+// GET /xalians (D1, the registry). Without ownerId, lists the caller's own generated
+// records; with ownerId, lists that owner's -- registry records are public, like the
+// legacy collection view (retrieveUser.ts's populateXalians path).
+import { withApi } from '../lib/api.ts';
+import { ListRegistryXaliansQuerySchema } from '../lib/schemas.ts';
+import * as registryRepo from '../repositories/registry.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ subject, query, requestId }) => {
+    const ownerId = query.ownerId ?? (subject as string);
+
+    const result = await registryRepo.listByOwner(ownerId, {
+      limit: query.limit,
+      cursor: query.cursor,
+    });
+
+    log.info('listRegistryXalians success', { requestId, ownerId, count: result.items.length });
+    return {
+      status: 200,
+      body: result.nextCursor ? { items: result.items, nextCursor: result.nextCursor } : { items: result.items },
+    };
+  },
+  { auth: 'jwt', query: ListRegistryXaliansQuerySchema }
+);

--- a/apps/api/src/handlers/retrieveRegistryXalian.ts
+++ b/apps/api/src/handlers/retrieveRegistryXalian.ts
@@ -1,0 +1,20 @@
+// GET /xalians/{xalianId} (D1, the registry). Any authenticated caller may read any
+// registry record (they are public, like the legacy collection view); ownership only
+// gates generation and future spends. 404 XALIAN_NOT_FOUND here, unlike the legacy
+// /db/xalian route which keeps its historical 400 XALIAN_NOT_FOUND for compatibility.
+import { ApiError, withApi } from '../lib/api.ts';
+import { RetrieveRegistryXalianParamsSchema } from '../lib/schemas.ts';
+import * as registryRepo from '../repositories/registry.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ params, requestId }) => {
+    const record = await registryRepo.getRecord(params.xalianId);
+    if (!record) {
+      throw new ApiError(404, 'XALIAN_NOT_FOUND', `Did not find xalian with xalianId=${params.xalianId}`);
+    }
+    log.info('retrieveRegistryXalian success', { requestId, xalianId: params.xalianId });
+    return { status: 200, body: record };
+  },
+  { auth: 'jwt', params: RetrieveRegistryXalianParamsSchema }
+);

--- a/apps/api/src/handlers/updateUser.ts
+++ b/apps/api/src/handlers/updateUser.ts
@@ -3,16 +3,19 @@
 	keyword. The subject always comes from the JWT; any userId in the body is ignored.
 
 	ACTIONS:
-		ADD_XALIAN_ID
 		REMOVE_XALIAN_ID
-		REMOVE_TOKENS
 
-	ADD_TOKENS is rejected: token issuance is server-only.
+	ADD_XALIAN_ID is rejected: keeping a xalian is now the server-side effect of
+	POST /db/xalian (createXalian.ts), which verifies the server's own signature before
+	persisting and appending the id in one call. ADD_TOKENS and REMOVE_TOKENS are rejected:
+	token accounting is server-only (nothing spends tokens yet; issuance never went through
+	the client). usersRepo.removeTokens and addXalianId are not deleted -- the registry
+	(D1) and future token spending still use them -- only their client entry points are
+	closed here.
 
-	The three real actions are atomic (audit F9): ADD_XALIAN_ID and REMOVE_XALIAN_ID use a
-	condition expression as a race guard around a read that makes the common case a
-	no-op/lookup, REMOVE_TOKENS is a single conditional SET. See repositories/users.ts for
-	the expressions.
+	REMOVE_XALIAN_ID is atomic (audit F9): it uses a condition expression as a race guard
+	around a read that makes the common case a no-op/lookup. See repositories/users.ts for
+	the expression.
 */
 import { ApiError, withApi } from '../lib/api.ts';
 import { UpdateUserBodySchema } from '../lib/schemas.ts';
@@ -23,37 +26,26 @@ export const handler = withApi(
   async ({ subject, body, requestId }) => {
     const userId = subject as string;
 
-    if (body.action === 'ADD_TOKENS') {
-      throw new ApiError(403, 'FORBIDDEN_ACTION', 'Token issuance is server-only');
+    if (body.action === 'ADD_TOKENS' || body.action === 'REMOVE_TOKENS') {
+      throw new ApiError(403, 'FORBIDDEN_ACTION', 'Token accounting is server-side');
     }
 
     if (body.action === 'ADD_XALIAN_ID') {
-      await usersRepo.addXalianId(userId, body.value);
-      log.info('updateXalianUser success', { requestId, userId, action: body.action });
-      return { status: 200, body: { message: 'ok' } };
+      throw new ApiError(403, 'FORBIDDEN_ACTION', 'Keeping is server-side');
     }
 
-    if (body.action === 'REMOVE_XALIAN_ID') {
-      let result: usersRepo.RemoveXalianIdResult;
-      try {
-        result = await usersRepo.removeXalianId(userId, body.value);
-      } catch (err) {
-        if (err instanceof usersRepo.ConditionFailedError) {
-          throw new ApiError(409, 'CONFLICT', err.message);
-        }
-        throw err;
+    // body.action === 'REMOVE_XALIAN_ID'
+    let result: usersRepo.RemoveXalianIdResult;
+    try {
+      result = await usersRepo.removeXalianId(userId, body.value);
+    } catch (err) {
+      if (err instanceof usersRepo.ConditionFailedError) {
+        throw new ApiError(409, 'CONFLICT', err.message);
       }
-      if (result === 'not-found') {
-        throw new ApiError(400, 'XALIAN_NOT_FOUND_IN_USER', 'Did not find xalian with xalianId=' + body.value);
-      }
-      log.info('updateXalianUser success', { requestId, userId, action: body.action });
-      return { status: 200, body: { message: 'ok' } };
+      throw err;
     }
-
-    // body.action === 'REMOVE_TOKENS'
-    const result = await usersRepo.removeTokens(userId, body.value);
-    if (result === 'insufficient') {
-      throw new ApiError(400, 'INSUFFICIENT_TOKENS', `User tokens were not enough to remove requested [${body.value}]`);
+    if (result === 'not-found') {
+      throw new ApiError(400, 'XALIAN_NOT_FOUND_IN_USER', 'Did not find xalian with xalianId=' + body.value);
     }
     log.info('updateXalianUser success', { requestId, userId, action: body.action });
     return { status: 200, body: { message: 'ok' } };

--- a/apps/api/src/lib/api.ts
+++ b/apps/api/src/lib/api.ts
@@ -29,6 +29,7 @@ export type ApiResult = {
 export type ApiEvent = {
   body?: string | null;
   queryStringParameters?: Record<string, string | undefined> | null;
+  pathParameters?: Record<string, string | undefined> | null;
   routeKey?: string;
   rawPath?: string;
   requestContext?: {
@@ -40,20 +41,22 @@ export type ApiEvent = {
   };
 };
 
-export type HandlerArgs<TBody, TQuery> = {
+export type HandlerArgs<TBody, TQuery, TParams> = {
   subject: string | null;
   body: TBody;
   query: TQuery;
+  params: TParams;
   event: ApiEvent;
   requestId: string;
 };
 
 export type HandlerResult = { status: number; body: unknown };
 
-export type WithApiOptions<TBody, TQuery> = {
+export type WithApiOptions<TBody, TQuery, TParams> = {
   auth: 'jwt' | 'none';
   body?: ZodType<TBody>;
   query?: ZodType<TQuery>;
+  params?: ZodType<TParams>;
 };
 
 function zodIssueMessage(issue: { path: PropertyKey[]; message: string }): string {
@@ -61,9 +64,9 @@ function zodIssueMessage(issue: { path: PropertyKey[]; message: string }): strin
   return `${path}: ${issue.message}`;
 }
 
-export function withApi<TBody = undefined, TQuery = undefined>(
-  fn: (args: HandlerArgs<TBody, TQuery>) => Promise<HandlerResult>,
-  opts: WithApiOptions<TBody, TQuery>
+export function withApi<TBody = undefined, TQuery = undefined, TParams = undefined>(
+  fn: (args: HandlerArgs<TBody, TQuery, TParams>) => Promise<HandlerResult>,
+  opts: WithApiOptions<TBody, TQuery, TParams>
 ) {
   return async (event: ApiEvent, context: ApiContext): Promise<ApiResult> => {
     const requestId = context?.awsRequestId ?? 'unknown';
@@ -102,7 +105,16 @@ export function withApi<TBody = undefined, TQuery = undefined>(
         query = parsed.data;
       }
 
-      const result = await fn({ subject, body, query, event, requestId });
+      let params = undefined as TParams;
+      if (opts.params) {
+        const parsed = opts.params.safeParse(event.pathParameters ?? {});
+        if (!parsed.success) {
+          throw new ApiError(400, 'BAD_REQUEST', zodIssueMessage(parsed.error.issues[0]));
+        }
+        params = parsed.data;
+      }
+
+      const result = await fn({ subject, body, query, params, event, requestId });
       status = result.status;
       return {
         statusCode: result.status,

--- a/apps/api/src/lib/schemas.ts
+++ b/apps/api/src/lib/schemas.ts
@@ -16,33 +16,70 @@ export const RetrieveUserQuerySchema = z.object({
 });
 export type RetrieveUserQuery = z.infer<typeof RetrieveUserQuerySchema>;
 
-// PATCH /db/user
+// PATCH /db/user. Reduced to REMOVE_XALIAN_ID (D1 / decision 6 in
+// docs/design/backend-modernization-plan.md): keeping is now the server-side effect of
+// POST /db/xalian (see createXalian.ts), so ADD_XALIAN_ID is no longer a client action,
+// and token accounting (ADD_TOKENS, REMOVE_TOKENS) is server-only. All three still parse
+// here (so the handler can return a consistent 403 FORBIDDEN_ACTION rather than a 400
+// BAD_REQUEST for a client still sending the old shape) but only REMOVE_XALIAN_ID is
+// permitted past the handler's guard.
 export const UpdateUserBodySchema = z.discriminatedUnion('action', [
-  z.object({ action: z.literal('ADD_XALIAN_ID'), value: z.string().min(1) }),
   z.object({ action: z.literal('REMOVE_XALIAN_ID'), value: z.string().min(1) }),
+  z.object({ action: z.literal('ADD_XALIAN_ID'), value: z.string().min(1) }),
   // z.coerce accepts the numeric-string values the client has always sent
   // (JSON.stringify({ value: '1000000' }) in the existing test suite) as well as a real
   // number, and rejects anything that is not a non-negative integer once coerced.
   z.object({ action: z.literal('REMOVE_TOKENS'), value: z.coerce.number().int().nonnegative() }),
-  // ADD_TOKENS is rejected unconditionally in the handler before the delegate is ever
-  // reached (token issuance is server-only); its value is intentionally unvalidated here.
   z.object({ action: z.literal('ADD_TOKENS'), value: z.unknown().optional() }),
 ]);
 export type UpdateUserBody = z.infer<typeof UpdateUserBodySchema>;
 
-// POST /db/xalian. Server-side generation lands in Wave D (D1, api/registry); until then
-// the client still posts a full generated record, and this only pins down the two fields
-// the repository's key design depends on. Everything else passes through untouched.
-export const CreateXalianBodySchema = z
-  .object({
-    xalianId: z.string().min(1),
-    speciesId: z.string().min(1),
-  })
-  .passthrough();
-export type CreateXalianBody = z.infer<typeof CreateXalianBodySchema>;
+// POST /db/xalian (the "keep" flow, D1 / audit F2). The body is the exact envelope
+// GET /xalian returned: the legacy translated shape plus the HMAC signature over it. The
+// handler verifies the signature and the createTimestamp freshness before persisting, so
+// a client can no longer keep a record it fabricated or tampered with. `xalian` is only
+// pinned down on the two fields the repository's key design depends on (xalianId,
+// speciesId) plus createTimestamp (needed for the freshness check); everything else
+// passes through untouched, same as the legacy body did.
+export const KeepXalianBodySchema = z.object({
+  xalian: z
+    .object({
+      xalianId: z.string().min(1),
+      speciesId: z.string().min(1),
+      createTimestamp: z.number(),
+    })
+    .passthrough(),
+  signature: z.string().min(1),
+});
+export type KeepXalianBody = z.infer<typeof KeepXalianBodySchema>;
 
 // GET /db/xalian and GET /db/xalians both take a comma-separated xalianId query param.
 export const RetrieveXalianQuerySchema = z.object({
   xalianId: z.string().min(1),
 });
 export type RetrieveXalianQuery = z.infer<typeof RetrieveXalianQuerySchema>;
+
+// POST /xalians (D1, the registry). species is optional; when given it must be a
+// ratified species key (checked against @xalians/rules's getSpeciesTemplates() in the
+// handler, not here, since that is a runtime lookup against the bundled templates, not a
+// static shape check). Omitted, the handler draws one uniformly.
+export const GenerateRegistryXalianBodySchema = z.object({
+  species: z.string().min(1).optional(),
+});
+export type GenerateRegistryXalianBody = z.infer<typeof GenerateRegistryXalianBodySchema>;
+
+// GET /xalians. Without ownerId, lists the caller's own records; with ownerId, lists that
+// owner's (registry records are public, like the legacy collection view). limit is
+// coerced from the query string and capped the same way the repository caps it.
+export const ListRegistryXaliansQuerySchema = z.object({
+  ownerId: z.string().min(1).optional(),
+  limit: z.coerce.number().int().positive().max(200).optional(),
+  cursor: z.string().min(1).optional(),
+});
+export type ListRegistryXaliansQuery = z.infer<typeof ListRegistryXaliansQuerySchema>;
+
+// GET /xalians/{xalianId}
+export const RetrieveRegistryXalianParamsSchema = z.object({
+  xalianId: z.string().min(1),
+});
+export type RetrieveRegistryXalianParams = z.infer<typeof RetrieveRegistryXalianParamsSchema>;

--- a/apps/api/src/lib/signing.ts
+++ b/apps/api/src/lib/signing.ts
@@ -25,8 +25,14 @@ export function canonicalize(value: unknown): string {
     return `[${value.map((item) => canonicalize(item)).join(',')}]`;
   }
   if (value !== null && typeof value === 'object') {
-    const keys = Object.keys(value as Record<string, unknown>).sort();
-    const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalize((value as Record<string, unknown>)[key])}`);
+    // Keys whose value is undefined are dropped, exactly as JSON.stringify drops them on
+    // the wire: the server signs the in-memory object and the client sends it back through
+    // JSON, so the two views must canonicalize identically.
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj)
+      .filter((key) => obj[key] !== undefined)
+      .sort();
+    const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalize(obj[key])}`);
     return `{${entries.join(',')}}`;
   }
   return JSON.stringify(value);

--- a/apps/api/src/lib/signing.ts
+++ b/apps/api/src/lib/signing.ts
@@ -1,0 +1,49 @@
+// Signs and verifies legacy showroom Xalians (audit F2). GET /xalian returns a record
+// generated server-side plus an HMAC over it; POST /db/xalian verifies that HMAC before
+// persisting, so a client can no longer keep a record it fabricated or tampered with.
+//
+// The secret comes from XALIAN_SIGNING_SECRET (a random_password resource in main.tf,
+// injected only into the GenerateXalian and TableCreateXalian functions). It is read
+// lazily on first use rather than at module load, so importing this file in a test or a
+// handler that never signs anything does not require the env var to be set.
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function secret(): string {
+  const value = process.env.XALIAN_SIGNING_SECRET;
+  if (!value) {
+    throw new Error('XALIAN_SIGNING_SECRET is not set; cannot sign or verify a Xalian record');
+  }
+  return value;
+}
+
+// Canonical JSON: object keys sorted recursively, no whitespace. Two calls with the same
+// logical record (regardless of key insertion order) produce byte-identical input to the
+// HMAC, which is what makes verification independent of how the record was constructed
+// or re-serialized on its way over the wire.
+export function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item)).join(',')}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalize((value as Record<string, unknown>)[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function signRecord(record: unknown): string {
+  return createHmac('sha256', secret()).update(canonicalize(record)).digest('hex');
+}
+
+export function verifyRecord(record: unknown, signature: string): boolean {
+  const expected = signRecord(record);
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const actualBuf = Buffer.from(signature ?? '', 'hex');
+  // timingSafeEqual throws if the buffers differ in length, which a forged or
+  // truncated signature will; treat that as "not verified" rather than an error.
+  if (expectedBuf.length !== actualBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBuf, actualBuf);
+}

--- a/apps/api/src/repositories/registry.ts
+++ b/apps/api/src/repositories/registry.ts
@@ -1,0 +1,116 @@
+// Promise-returning repository for XalianRegistry (hash key xalianId, GSI byOwner on
+// ownerId + generatedAt). This is the new table for server-generated, ratified records
+// (D1); it does not touch the legacy XalianTable/XalianUsersTable, which keep serving the
+// showroom keep flow (see repositories/xalians.ts, repositories/users.ts).
+import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import type { XalianRecord } from '@xalians/content/schema';
+import { ddb } from '../lib/db.ts';
+import * as log from '../lib/log.ts';
+
+const TABLE_NAME = 'XalianRegistry';
+const GSI_NAME = 'byOwner';
+const DEFAULT_LIMIT = 50;
+
+export type RegistryItem = {
+  xalianId: string;
+  ownerId: string;
+  generatedAt: string;
+  species: string;
+  record: XalianRecord;
+};
+
+export class XalianAlreadyExistsError extends Error {
+  constructor(xalianId: string) {
+    super(`xalian ${xalianId} already exists in the registry`);
+    this.name = 'XalianAlreadyExistsError';
+  }
+}
+
+export async function putRecord(ownerId: string, record: XalianRecord): Promise<void> {
+  const item: RegistryItem = {
+    xalianId: record.id,
+    ownerId,
+    generatedAt: record.provenance.generatedAt,
+    species: record.species,
+    record,
+  };
+
+  try {
+    await ddb.send(
+      new PutCommand({
+        TableName: TABLE_NAME,
+        Item: item,
+        ConditionExpression: 'attribute_not_exists(xalianId)',
+      })
+    );
+  } catch (err) {
+    if (err instanceof Error && err.name === 'ConditionalCheckFailedException') {
+      throw new XalianAlreadyExistsError(record.id);
+    }
+    log.error('putRecord failed', { xalianId: record.id, errorName: err instanceof Error ? err.name : typeof err });
+    throw err;
+  }
+}
+
+export async function getRecord(xalianId: string): Promise<XalianRecord | null> {
+  try {
+    const result = await ddb.send(new GetCommand({ TableName: TABLE_NAME, Key: { xalianId } }));
+    const item = result.Item as RegistryItem | undefined;
+    return item ? item.record : null;
+  } catch (err) {
+    log.error('getRecord failed', { xalianId, errorName: err instanceof Error ? err.name : typeof err });
+    throw err;
+  }
+}
+
+export type ListByOwnerOptions = {
+  limit?: number;
+  cursor?: string;
+};
+
+export type ListByOwnerResult = {
+  items: XalianRecord[];
+  nextCursor?: string;
+};
+
+// Cursor is base64url of the raw LastEvaluatedKey, opaque to the caller. Encoding it
+// rather than exposing generatedAt/xalianId directly keeps the wire contract stable if
+// the GSI's key schema ever changes.
+function encodeCursor(key: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(key), 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor: string): Record<string, unknown> {
+  try {
+    return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+  } catch {
+    throw new Error('Invalid cursor');
+  }
+}
+
+export async function listByOwner(ownerId: string, options: ListByOwnerOptions = {}): Promise<ListByOwnerResult> {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+
+  try {
+    const result = await ddb.send(
+      new QueryCommand({
+        TableName: TABLE_NAME,
+        IndexName: GSI_NAME,
+        KeyConditionExpression: 'ownerId = :ownerId',
+        ExpressionAttributeValues: { ':ownerId': ownerId },
+        ScanIndexForward: false,
+        Limit: limit,
+        ExclusiveStartKey: options.cursor ? decodeCursor(options.cursor) : undefined,
+      })
+    );
+
+    const items = (result.Items ?? []) as RegistryItem[];
+    return {
+      items: items.map((item) => item.record),
+      nextCursor: result.LastEvaluatedKey ? encodeCursor(result.LastEvaluatedKey) : undefined,
+    };
+  } catch (err) {
+    log.error('listByOwner failed', { ownerId, errorName: err instanceof Error ? err.name : typeof err });
+    throw err;
+  }
+}

--- a/apps/api/src/repositories/xalians.ts
+++ b/apps/api/src/repositories/xalians.ts
@@ -93,15 +93,33 @@ export async function getXalianBatch(xalianIds: string[]): Promise<unknown[]> {
   }
 }
 
+export class XalianAlreadyExistsError extends Error {
+  constructor(xalianId: string) {
+    super(`xalian ${xalianId} already exists`);
+    this.name = 'XalianAlreadyExistsError';
+  }
+}
+
+// ConditionExpression guards the keep flow (audit F2 / D1): a xalian can only be kept
+// once, so a retried or duplicated keep request fails loudly instead of silently
+// overwriting whatever was persisted first.
 export async function createXalian(xalian: { xalianId: string; speciesId: string; [key: string]: unknown }): Promise<void> {
-  await ddb.send(
-    new PutCommand({
-      TableName: TABLE_NAME,
-      Item: {
-        speciesId: xalian.speciesId,
-        xalianId: xalian.xalianId,
-        attributes: xalian,
-      },
-    })
-  );
+  try {
+    await ddb.send(
+      new PutCommand({
+        TableName: TABLE_NAME,
+        Item: {
+          speciesId: xalian.speciesId,
+          xalianId: xalian.xalianId,
+          attributes: xalian,
+        },
+        ConditionExpression: 'attribute_not_exists(xalianId)',
+      })
+    );
+  } catch (err) {
+    if (err instanceof Error && err.name === 'ConditionalCheckFailedException') {
+      throw new XalianAlreadyExistsError(xalian.xalianId);
+    }
+    throw err;
+  }
 }

--- a/apps/api/test/handlers/createXalian.test.ts
+++ b/apps/api/test/handlers/createXalian.test.ts
@@ -1,45 +1,129 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { handler } from '../../src/handlers/createXalian.ts';
+import { signRecord } from '../../src/lib/signing.ts';
 import { authedEvent, fakeContext } from '../testEvent.ts';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
+const ORIGINAL_SECRET = process.env.XALIAN_SIGNING_SECRET;
 
 beforeEach(() => {
   ddbMock.reset();
+  process.env.XALIAN_SIGNING_SECRET = 'test-secret';
 });
 
-describe('createXalian handler', () => {
+afterEach(() => {
+  process.env.XALIAN_SIGNING_SECRET = ORIGINAL_SECRET;
+});
+
+function makeXalian(overrides: Record<string, unknown> = {}) {
+  return {
+    xalianId: 'fire-1',
+    speciesId: 'fire',
+    name: 'Ember',
+    createTimestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('createXalian handler (keep flow, D1 / audit F2)', () => {
   it('requires a subject', async () => {
+    const xalian = makeXalian();
     const result = await handler(
-      { body: JSON.stringify({ xalianId: 'fire-1', speciesId: 'fire' }), requestContext: {} },
+      { body: JSON.stringify({ xalian, signature: signRecord(xalian) }), requestContext: {} },
       fakeContext()
     );
     expect(result.statusCode).toBe(401);
   });
 
-  it('rejects a body missing xalianId/speciesId with 400', async () => {
+  it('rejects a body missing xalian/signature with 400', async () => {
     const result = await handler(authedEvent('nick', { body: JSON.stringify({}) }), fakeContext());
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body as string).errorCode).toBe('BAD_REQUEST');
   });
 
-  it('persists the item keyed by speciesId + xalianId with the whole body as attributes', async () => {
-    ddbMock.on(PutCommand).resolves({});
+  it('rejects a bad signature with 400 INVALID_SIGNATURE', async () => {
+    const xalian = makeXalian();
+    const result = await handler(
+      authedEvent('nick', { body: JSON.stringify({ xalian, signature: 'a'.repeat(64) }) }),
+      fakeContext()
+    );
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body as string).errorCode).toBe('INVALID_SIGNATURE');
+    expect(ddbMock.calls()).toHaveLength(0);
+  });
+
+  it('rejects a tampered record whose signature no longer matches', async () => {
+    const xalian = makeXalian();
+    const signature = signRecord(xalian);
+    const tampered = { ...xalian, name: 'Somethingelse' };
 
     const result = await handler(
-      authedEvent('nick', { body: JSON.stringify({ xalianId: 'fire-1', speciesId: 'fire', name: 'Ember' }) }),
+      authedEvent('nick', { body: JSON.stringify({ xalian: tampered, signature }) }),
+      fakeContext()
+    );
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body as string).errorCode).toBe('INVALID_SIGNATURE');
+  });
+
+  it('rejects a signature older than 24 hours with 400 SIGNATURE_EXPIRED', async () => {
+    const xalian = makeXalian({ createTimestamp: Date.now() - 25 * 60 * 60 * 1000 });
+    const signature = signRecord(xalian);
+
+    const result = await handler(
+      authedEvent('nick', { body: JSON.stringify({ xalian, signature }) }),
+      fakeContext()
+    );
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body as string).errorCode).toBe('SIGNATURE_EXPIRED');
+    expect(ddbMock.calls()).toHaveLength(0);
+  });
+
+  it('409s when the xalian has already been kept', async () => {
+    const xalian = makeXalian();
+    const signature = signRecord(xalian);
+    const err = Object.assign(new Error('conditional check failed'), { name: 'ConditionalCheckFailedException' });
+    ddbMock.on(PutCommand).rejects(err);
+
+    const result = await handler(
+      authedEvent('nick', { body: JSON.stringify({ xalian, signature }) }),
+      fakeContext()
+    );
+
+    expect(result.statusCode).toBe(409);
+    expect(JSON.parse(result.body as string).errorCode).toBe('ALREADY_KEPT');
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  it('persists the item then appends the id to the caller, in one call', async () => {
+    const xalian = makeXalian();
+    const signature = signRecord(xalian);
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(GetCommand).resolves({ Item: { userId: 'nick', xalianIds: [], attributes: {} } });
+    ddbMock.on(UpdateCommand).resolves({});
+
+    const result = await handler(
+      authedEvent('nick', { body: JSON.stringify({ xalian, signature }) }),
       fakeContext()
     );
 
     expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body as string);
+    expect(body).toEqual({ message: 'ok', xalianId: 'fire-1' });
+
     const putCalls = ddbMock.commandCalls(PutCommand);
     expect(putCalls).toHaveLength(1);
     expect(putCalls[0].args[0].input.Item).toEqual({
       speciesId: 'fire',
       xalianId: 'fire-1',
-      attributes: { xalianId: 'fire-1', speciesId: 'fire', name: 'Ember' },
+      attributes: xalian,
     });
+    expect(putCalls[0].args[0].input.ConditionExpression).toBe('attribute_not_exists(xalianId)');
+
+    const updateCalls = ddbMock.commandCalls(UpdateCommand);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].args[0].input.Key).toEqual({ userId: 'nick' });
+    expect(updateCalls[0].args[0].input.ExpressionAttributeValues).toMatchObject({ ':id': 'fire-1' });
   });
 });

--- a/apps/api/test/handlers/generateRegistryXalian.test.ts
+++ b/apps/api/test/handlers/generateRegistryXalian.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { handler } from '../../src/handlers/generateRegistryXalian.ts';
+import { XalianRecordSchema } from '@xalians/content/schema';
+import { getSpeciesTemplates } from '@xalians/rules/generator';
+import { authedEvent, fakeContext } from '../testEvent.ts';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe('generateRegistryXalian handler', () => {
+  it('requires a subject', async () => {
+    const result = await handler({ body: '{}', requestContext: {} }, fakeContext());
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('rejects an unknown species with 400 UNKNOWN_SPECIES', async () => {
+    const result = await handler(
+      authedEvent('nick', { body: JSON.stringify({ species: 'not-a-real-species' }) }),
+      fakeContext()
+    );
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body as string).errorCode).toBe('UNKNOWN_SPECIES');
+    expect(ddbMock.calls()).toHaveLength(0);
+  });
+
+  it('generates from a given ratified species, persists under the subject, and returns 201 with a record that passes XalianRecordSchema', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const species = getSpeciesTemplates()[0].key;
+
+    const result = await handler(
+      authedEvent('nick', { body: JSON.stringify({ species }) }),
+      fakeContext()
+    );
+
+    expect(result.statusCode).toBe(201);
+    const body = JSON.parse(result.body as string);
+    expect(() => XalianRecordSchema.parse(body)).not.toThrow();
+    expect(body.species).toBe(species);
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].args[0].input.Item).toMatchObject({ ownerId: 'nick', xalianId: body.id, species });
+  });
+
+  it('draws a species uniformly when none is given', async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await handler(authedEvent('nick', { body: '{}' }), fakeContext());
+
+    expect(result.statusCode).toBe(201);
+    const body = JSON.parse(result.body as string);
+    const keys = getSpeciesTemplates().map((t) => t.key);
+    expect(keys).toContain(body.species);
+  });
+});

--- a/apps/api/test/handlers/generateXalian.test.ts
+++ b/apps/api/test/handlers/generateXalian.test.ts
@@ -1,15 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { handler } from '../../src/handlers/generateXalian.ts';
+import { verifyRecord } from '../../src/lib/signing.ts';
 import { fakeContext } from '../testEvent.ts';
 
+const ORIGINAL_SECRET = process.env.XALIAN_SIGNING_SECRET;
+
+beforeEach(() => {
+  process.env.XALIAN_SIGNING_SECRET = 'test-secret';
+});
+
+afterEach(() => {
+  process.env.XALIAN_SIGNING_SECRET = ORIGINAL_SECRET;
+});
+
 describe('generateXalian handler', () => {
-  it('returns 200 with the legacy translated shape, unauthenticated', async () => {
+  it('returns 200 with a signed envelope over the legacy translated shape, unauthenticated', async () => {
     const result = await handler({ requestContext: { http: { method: 'GET' } } }, fakeContext());
 
     expect(result.statusCode).toBe(200);
     const body = JSON.parse(result.body as string);
-    expect(typeof body.species.name).toBe('string');
-    expect(body.moves).toHaveLength(4);
-    expect(body.xalianId).toEqual(expect.any(String));
+    expect(typeof body.xalian.species.name).toBe('string');
+    expect(body.xalian.moves).toHaveLength(4);
+    expect(body.xalian.xalianId).toEqual(expect.any(String));
+    expect(body.signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(verifyRecord(body.xalian, body.signature)).toBe(true);
   });
 });

--- a/apps/api/test/handlers/listRegistryXalians.test.ts
+++ b/apps/api/test/handlers/listRegistryXalians.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { handler } from '../../src/handlers/listRegistryXalians.ts';
+import { authedEvent, fakeContext } from '../testEvent.ts';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe('listRegistryXalians handler', () => {
+  it('requires a subject', async () => {
+    const result = await handler({ queryStringParameters: null, requestContext: {} }, fakeContext());
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('without ownerId, lists the caller\'s own records', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const result = await handler(authedEvent('nick', { queryStringParameters: null }), fakeContext());
+
+    expect(result.statusCode).toBe(200);
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.ExpressionAttributeValues).toEqual({ ':ownerId': 'nick' });
+  });
+
+  it('with ownerId, lists that owner\'s records (public, like the legacy collection view)', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const result = await handler(
+      authedEvent('nick', { queryStringParameters: { ownerId: 'someoneelse' } }),
+      fakeContext()
+    );
+
+    expect(result.statusCode).toBe(200);
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.ExpressionAttributeValues).toEqual({ ':ownerId': 'someoneelse' });
+  });
+
+  it('encodes and decodes the cursor and returns nextCursor when there is another page', async () => {
+    const lastKey = { xalianId: 'xal_1', ownerId: 'nick', generatedAt: '2026-09-10T00:00:00.000Z' };
+    ddbMock.on(QueryCommand).resolves({ Items: [], LastEvaluatedKey: lastKey });
+
+    const result = await handler(authedEvent('nick', { queryStringParameters: null }), fakeContext());
+    const body = JSON.parse(result.body as string);
+    expect(typeof body.nextCursor).toBe('string');
+
+    ddbMock.resetHistory();
+    await handler(
+      authedEvent('nick', { queryStringParameters: { cursor: body.nextCursor } }),
+      fakeContext()
+    );
+    const secondInput = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(secondInput.ExclusiveStartKey).toEqual(lastKey);
+  });
+
+  it('omits nextCursor when there is no further page', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const result = await handler(authedEvent('nick', { queryStringParameters: null }), fakeContext());
+    const body = JSON.parse(result.body as string);
+    expect('nextCursor' in body).toBe(false);
+  });
+});

--- a/apps/api/test/handlers/retrieveRegistryXalian.test.ts
+++ b/apps/api/test/handlers/retrieveRegistryXalian.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { handler } from '../../src/handlers/retrieveRegistryXalian.ts';
+import { authedEvent, fakeContext } from '../testEvent.ts';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe('retrieveRegistryXalian handler', () => {
+  it('requires a subject', async () => {
+    const result = await handler({ pathParameters: { xalianId: 'xal_1' }, requestContext: {} }, fakeContext());
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('404s with XALIAN_NOT_FOUND when the record does not exist', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const result = await handler(
+      authedEvent('nick', { pathParameters: { xalianId: 'xal_ghost' } }),
+      fakeContext()
+    );
+
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body as string).errorCode).toBe('XALIAN_NOT_FOUND');
+  });
+
+  it('returns the record for any authenticated caller, not just its owner', async () => {
+    const record = { id: 'xal_1', species: 'graviclaw' };
+    ddbMock.on(GetCommand).resolves({
+      Item: { xalianId: 'xal_1', ownerId: 'someoneelse', generatedAt: '2026-09-10T00:00:00.000Z', species: 'graviclaw', record },
+    });
+
+    const result = await handler(
+      authedEvent('nick', { pathParameters: { xalianId: 'xal_1' } }),
+      fakeContext()
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body as string)).toEqual(record);
+  });
+});

--- a/apps/api/test/handlers/updateUser.test.ts
+++ b/apps/api/test/handlers/updateUser.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 
 describe('updateUser handler', () => {
-  it('rejects ADD_TOKENS with a single 403 and never touches the delegate (ports userTableCRUDLambdas test)', async () => {
+  it('rejects ADD_TOKENS with a 403 and never touches the delegate', async () => {
     const result = await handler(
       authedEvent('nick', { body: JSON.stringify({ action: 'ADD_TOKENS', value: '1000000' }) }),
       fakeContext('req-5')
@@ -22,35 +22,26 @@ describe('updateUser handler', () => {
     expect(ddbMock.calls()).toHaveLength(0);
   });
 
-  it('ADD_XALIAN_ID ignores userId in the body and sends the list_append/contains update (ports userTableCRUDLambdas test)', async () => {
-    ddbMock.on(GetCommand).resolves({ Item: { userId: 'nick', xalianIds: [], attributes: {} } });
-    ddbMock.on(UpdateCommand).resolves({});
-
+  it('rejects REMOVE_TOKENS with a 403 and never touches the delegate (token accounting is server-side, D1)', async () => {
     const result = await handler(
-      authedEvent('nick', { body: JSON.stringify({ userId: 'someone-else', action: 'ADD_XALIAN_ID', value: 'xal_1' }) }),
+      authedEvent('nick', { body: JSON.stringify({ action: 'REMOVE_TOKENS', value: '3' }) }),
+      fakeContext('req-9')
+    );
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body as string).errorCode).toBe('FORBIDDEN_ACTION');
+    expect(ddbMock.calls()).toHaveLength(0);
+  });
+
+  it('rejects ADD_XALIAN_ID with a 403 and never touches the delegate (keeping is server-side, D1)', async () => {
+    const result = await handler(
+      authedEvent('nick', { body: JSON.stringify({ action: 'ADD_XALIAN_ID', value: 'xal_1' }) }),
       fakeContext('req-6')
     );
 
-    expect(result.statusCode).toBe(200);
-    const updateCalls = ddbMock.commandCalls(UpdateCommand);
-    expect(updateCalls).toHaveLength(1);
-    const input = updateCalls[0].args[0].input;
-    expect(input.Key).toEqual({ userId: 'nick' });
-    expect(input.UpdateExpression).toContain('list_append');
-    expect(input.ConditionExpression).toBe('NOT contains(xalianIds, :id)');
-    expect(input.ExpressionAttributeValues).toMatchObject({ ':id': 'xal_1' });
-  });
-
-  it('ADD_XALIAN_ID is a no-op success when the id is already present (idempotent)', async () => {
-    ddbMock.on(GetCommand).resolves({ Item: { userId: 'nick', xalianIds: ['xal_1'], attributes: {} } });
-
-    const result = await handler(
-      authedEvent('nick', { body: JSON.stringify({ action: 'ADD_XALIAN_ID', value: 'xal_1' }) }),
-      fakeContext('req-6b')
-    );
-
-    expect(result.statusCode).toBe(200);
-    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body as string).errorCode).toBe('FORBIDDEN_ACTION');
+    expect(ddbMock.calls()).toHaveLength(0);
   });
 
   it('REMOVE_XALIAN_ID sends REMOVE with the index condition', async () => {
@@ -81,45 +72,17 @@ describe('updateUser handler', () => {
     expect(JSON.parse(result.body as string).errorCode).toBe('XALIAN_NOT_FOUND_IN_USER');
   });
 
-  it('REMOVE_TOKENS sends the subtract with the >= condition', async () => {
+  it('ignores userId in the body; the subject always comes from the JWT', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { userId: 'nick', xalianIds: ['xal_1'], attributes: {} } });
     ddbMock.on(UpdateCommand).resolves({});
 
     const result = await handler(
-      authedEvent('nick', { body: JSON.stringify({ action: 'REMOVE_TOKENS', value: '3' }) }),
-      fakeContext('req-9')
+      authedEvent('nick', { body: JSON.stringify({ userId: 'someone-else', action: 'REMOVE_XALIAN_ID', value: 'xal_1' }) }),
+      fakeContext('req-12')
     );
 
     expect(result.statusCode).toBe(200);
     const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    // Exact expression: DynamoDB rejects SET clauses whose document paths overlap
-    // (#attrs alongside #attrs.tokens), so any if_not_exists initializer on #attrs here
-    // would fail every spend at runtime.
-    expect(input.UpdateExpression).toBe('SET #attrs.tokens = #attrs.tokens - :n');
-    expect(input.ConditionExpression).toBe('#attrs.tokens >= :n');
-    expect(input.ExpressionAttributeValues).toMatchObject({ ':n': 3 });
-  });
-
-  it('REMOVE_TOKENS maps a ConditionalCheckFailedException to 400 INSUFFICIENT_TOKENS', async () => {
-    const err = Object.assign(new Error('conditional check failed'), { name: 'ConditionalCheckFailedException' });
-    ddbMock.on(UpdateCommand).rejects(err);
-
-    const result = await handler(
-      authedEvent('nick', { body: JSON.stringify({ action: 'REMOVE_TOKENS', value: '1000000' }) }),
-      fakeContext('req-10')
-    );
-
-    expect(result.statusCode).toBe(400);
-    expect(JSON.parse(result.body as string).errorCode).toBe('INSUFFICIENT_TOKENS');
-  });
-
-  it('rejects a negative REMOVE_TOKENS value with 400 BAD_REQUEST before touching the delegate', async () => {
-    const result = await handler(
-      authedEvent('nick', { body: JSON.stringify({ action: 'REMOVE_TOKENS', value: '-1' }) }),
-      fakeContext('req-11')
-    );
-
-    expect(result.statusCode).toBe(400);
-    expect(JSON.parse(result.body as string).errorCode).toBe('BAD_REQUEST');
-    expect(ddbMock.calls()).toHaveLength(0);
+    expect(input.Key).toEqual({ userId: 'nick' });
   });
 });

--- a/apps/api/test/repositories/registry.test.ts
+++ b/apps/api/test/repositories/registry.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, PutCommand, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import * as registryRepo from '../../src/repositories/registry.ts';
+import type { XalianRecord } from '@xalians/content/schema';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+function makeRecord(overrides: Partial<XalianRecord> = {}): XalianRecord {
+  return {
+    id: 'xal_deadbeef',
+    species: 'graviclaw',
+    provenance: {
+      seed: 'abc',
+      generatorVersion: '1',
+      schemaVersion: '1',
+      generatedAt: '2026-09-10T00:00:00.000Z',
+      origin: 'stonera',
+      serial: 1,
+    },
+    ...overrides,
+  } as XalianRecord;
+}
+
+describe('registry repository', () => {
+  it('putRecord persists under the owner with attribute_not_exists(xalianId)', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const record = makeRecord();
+
+    await registryRepo.putRecord('nick', record);
+
+    const calls = ddbMock.commandCalls(PutCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+    expect(input.ConditionExpression).toBe('attribute_not_exists(xalianId)');
+    expect(input.Item).toEqual({
+      xalianId: 'xal_deadbeef',
+      ownerId: 'nick',
+      generatedAt: '2026-09-10T00:00:00.000Z',
+      species: 'graviclaw',
+      record,
+    });
+  });
+
+  it('putRecord throws XalianAlreadyExistsError on a condition failure', async () => {
+    const err = Object.assign(new Error('conditional check failed'), { name: 'ConditionalCheckFailedException' });
+    ddbMock.on(PutCommand).rejects(err);
+
+    await expect(registryRepo.putRecord('nick', makeRecord())).rejects.toBeInstanceOf(
+      registryRepo.XalianAlreadyExistsError
+    );
+  });
+
+  it('getRecord returns the record, not the wrapper item', async () => {
+    const record = makeRecord();
+    ddbMock.on(GetCommand).resolves({
+      Item: { xalianId: record.id, ownerId: 'nick', generatedAt: record.provenance.generatedAt, species: record.species, record },
+    });
+
+    const result = await registryRepo.getRecord('xal_deadbeef');
+    expect(result).toEqual(record);
+  });
+
+  it('getRecord returns null on a miss', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const result = await registryRepo.getRecord('xal_ghost');
+    expect(result).toBeNull();
+  });
+
+  it('listByOwner queries the byOwner GSI newest first', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    await registryRepo.listByOwner('nick', { limit: 10 });
+
+    const calls = ddbMock.commandCalls(QueryCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+    expect(input.IndexName).toBe('byOwner');
+    expect(input.ScanIndexForward).toBe(false);
+    expect(input.Limit).toBe(10);
+    expect(input.KeyConditionExpression).toBe('ownerId = :ownerId');
+    expect(input.ExpressionAttributeValues).toEqual({ ':ownerId': 'nick' });
+  });
+
+  it('encodes and decodes the cursor round trip through LastEvaluatedKey/ExclusiveStartKey', async () => {
+    const record = makeRecord();
+    const lastKey = { xalianId: 'xal_deadbeef', ownerId: 'nick', generatedAt: record.provenance.generatedAt };
+
+    ddbMock
+      .on(QueryCommand)
+      .resolvesOnce({
+        Items: [{ xalianId: record.id, ownerId: 'nick', generatedAt: record.provenance.generatedAt, species: record.species, record }],
+        LastEvaluatedKey: lastKey,
+      })
+      .resolvesOnce({ Items: [] });
+
+    const first = await registryRepo.listByOwner('nick');
+    expect(first.nextCursor).toBeTypeOf('string');
+    expect(first.items).toEqual([record]);
+
+    await registryRepo.listByOwner('nick', { cursor: first.nextCursor });
+
+    const calls = ddbMock.commandCalls(QueryCommand);
+    expect(calls[1].args[0].input.ExclusiveStartKey).toEqual(lastKey);
+  });
+});

--- a/apps/api/test/signing.test.ts
+++ b/apps/api/test/signing.test.ts
@@ -26,6 +26,12 @@ describe('signing', () => {
     expect(signRecord(a)).toBe(signRecord(b));
   });
 
+  it('survives a JSON round trip: undefined-valued keys do not affect the signature', () => {
+    const inMemory = { a: 1, b: undefined, nested: { c: 'x', d: undefined } };
+    const overTheWire = JSON.parse(JSON.stringify(inMemory));
+    expect(verifyRecord(overTheWire, signRecord(inMemory))).toBe(true);
+  });
+
   it('fails verification when a stat is tampered with', () => {
     const record = { xalianId: 'fire-1', stats: { speedPoints: { points: 5 } } };
     const signature = signRecord(record);

--- a/apps/api/test/signing.test.ts
+++ b/apps/api/test/signing.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { canonicalize, signRecord, verifyRecord } from '../src/lib/signing.ts';
+
+const ORIGINAL_SECRET = process.env.XALIAN_SIGNING_SECRET;
+
+describe('signing', () => {
+  beforeEach(() => {
+    process.env.XALIAN_SIGNING_SECRET = 'test-secret';
+  });
+
+  afterEach(() => {
+    process.env.XALIAN_SIGNING_SECRET = ORIGINAL_SECRET;
+  });
+
+  it('round trips: a record signed with signRecord verifies with verifyRecord', () => {
+    const record = { xalianId: 'fire-1', species: { name: 'Ember' }, stats: { speedPoints: { points: 5 } } };
+    const signature = signRecord(record);
+    expect(signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(verifyRecord(record, signature)).toBe(true);
+  });
+
+  it('is independent of key order (canonical JSON)', () => {
+    const a = { xalianId: 'fire-1', species: { name: 'Ember', id: 'fire' } };
+    const b = { species: { id: 'fire', name: 'Ember' }, xalianId: 'fire-1' };
+    expect(canonicalize(a)).toBe(canonicalize(b));
+    expect(signRecord(a)).toBe(signRecord(b));
+  });
+
+  it('fails verification when a stat is tampered with', () => {
+    const record = { xalianId: 'fire-1', stats: { speedPoints: { points: 5 } } };
+    const signature = signRecord(record);
+    const tampered = { xalianId: 'fire-1', stats: { speedPoints: { points: 9999 } } };
+    expect(verifyRecord(tampered, signature)).toBe(false);
+  });
+
+  it('fails verification for a garbage signature without throwing', () => {
+    const record = { xalianId: 'fire-1' };
+    expect(verifyRecord(record, 'not-hex-and-wrong-length')).toBe(false);
+  });
+
+  it('throws when the secret is missing', () => {
+    delete process.env.XALIAN_SIGNING_SECRET;
+    expect(() => signRecord({ a: 1 })).toThrow(/XALIAN_SIGNING_SECRET/);
+  });
+});

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,10 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.2"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 
   required_version = ">= 1.10"
@@ -79,11 +83,29 @@ resource "aws_iam_role_policy" "dynamodb_policy" {
         Resource = [
           "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/XalianTable",
           "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/XalianUsersTable",
+          # XalianRegistry (D1): the two entries above are exact table names, not a
+          # table-level wildcard, so the new registry table needs its own ARN here. The
+          # index wildcard below already covers its byOwner GSI.
+          "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/XalianRegistry",
           "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/Xalian*/index/*",
         ]
       },
     ]
   })
+}
+#####                                               #####
+#########################################################
+
+#########################################################
+#####          XALIAN SIGNING SECRET (F2)           #####
+#########################################################
+# HMAC secret for the legacy showroom keep flow (audit F2 / D1, apps/api/src/lib/signing.ts):
+# GET /xalian (GenerateXalian) signs the record it returns; POST /db/xalian
+# (TableCreateXalian) verifies that signature before persisting, so a client can no longer
+# keep a record it fabricated or tampered with. Only those two functions receive it.
+resource "random_password" "xalian_signing_secret" {
+  length  = 48
+  special = false
 }
 #####                                               #####
 #########################################################
@@ -267,6 +289,9 @@ module "generate_xalian_lambda_module" {
   apigw_lambda_route_key          = "GET /xalian"
   base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
   authorization_type              = "NONE"
+  environment_variables = {
+    XALIAN_SIGNING_SECRET = random_password.xalian_signing_secret.result
+  }
 }
 #####                                               #####
 #########################################################
@@ -290,6 +315,9 @@ module "table_create_xalian_lambda_module" {
   base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
   authorization_type              = "JWT"
   authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+  environment_variables = {
+    XALIAN_SIGNING_SECRET = random_password.xalian_signing_secret.result
+  }
 }
 #####                                               #####
 #########################################################
@@ -399,6 +427,72 @@ module "table_update_xalian_user_lambda_module" {
   lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
   iam_role_arn                    = aws_iam_role.lambda_exec.arn
   apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "JWT"
+  authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+}
+#####                                               #####
+#########################################################
+
+#########################################################
+#####               LAMBDA INSTANCE                 #####
+##          Generate Registry Xalian Lambda (D1)       ##
+#########################################################
+module "generate_registry_xalian_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "GenerateRegistryXalian"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "generateRegistryXalian/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "POST /xalians"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "JWT"
+  authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+}
+#####                                               #####
+#########################################################
+
+#########################################################
+#####               LAMBDA INSTANCE                 #####
+##           List Registry Xalians Lambda (D1)         ##
+#########################################################
+module "list_registry_xalians_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "ListRegistryXalians"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "listRegistryXalians/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "GET /xalians"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "JWT"
+  authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+}
+#####                                               #####
+#########################################################
+
+#########################################################
+#####               LAMBDA INSTANCE                 #####
+##          Retrieve Registry Xalian Lambda (D1)       ##
+#########################################################
+module "retrieve_registry_xalian_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "RetrieveRegistryXalian"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "retrieveRegistryXalian/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "GET /xalians/{xalianId}"
   base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
   authorization_type              = "JWT"
   authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
@@ -933,6 +1027,47 @@ import {
 import {
   to = aws_dynamodb_table.xalian_users_table
   id = "XalianUsersTable"
+}
+
+# XalianRegistry (D1): the table for server-generated, ratified records (@xalians/rules
+# XalianRecord). New, not imported -- Terraform creates it on apply. hash key xalianId
+# (the record's own id) with a byOwner GSI (ownerId + generatedAt, newest first) for
+# listing a caller's own generated Xalians. prevent_destroy for the same reason as the two
+# legacy tables: this holds real user data the moment the first record is generated.
+resource "aws_dynamodb_table" "xalian_registry" {
+  name         = "XalianRegistry"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "xalianId"
+
+  attribute {
+    name = "xalianId"
+    type = "S"
+  }
+
+  attribute {
+    name = "ownerId"
+    type = "S"
+  }
+
+  attribute {
+    name = "generatedAt"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "byOwner"
+    hash_key        = "ownerId"
+    range_key       = "generatedAt"
+    projection_type = "ALL"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 #####                                               #####
 #########################################################

--- a/my-app/src/pages/generatorPage.tsx
+++ b/my-app/src/pages/generatorPage.tsx
@@ -30,18 +30,24 @@ const STAT_ROWS: [string, string, string][] = [
 ];
 
 function GeneratorPage() {
-	const [xalian, setXalian] = React.useState<any>(null);
+	// Holds the whole { xalian, signature } envelope generateXalian returns. `xalian` is
+	// the legacy shape every render below already expects; `signature` only matters to
+	// saveXalian, which sends the envelope back unchanged so the server can verify the
+	// stats were never edited client-side.
+	const [envelope, setEnvelope] = React.useState<any>(null);
 	const [isLoading, setIsLoading] = React.useState(true);
 	const [isGenerating, setIsGenerating] = React.useState(false);
 	const [loggedInUser, setLoggedInUser] = React.useState<any>(null);
 	const [jsonOpen, setJsonOpen] = React.useState(false);
 
+	const xalian = envelope ? envelope.xalian : null;
+
 	const getXalian = React.useCallback(() => {
 		setIsGenerating(true);
 		xalianApi
 			.callGenerateXalian()
-			.then((x: any) => {
-				setXalian(x);
+			.then((e: any) => {
+				setEnvelope(e);
 				setIsLoading(false);
 				setIsGenerating(false);
 			})
@@ -58,10 +64,10 @@ function GeneratorPage() {
 
 	const saveXalian = () => {
 		setIsLoading(true);
-		// create the xalian record first so the user record never references a xalian that doesn't exist
+		// Keeping is one call: the server verifies the signature, persists, and appends
+		// the id to the caller's user record itself.
 		dbApi
-			.callCreateXalian(xalian)
-			.then(() => dbApi.callUpdateUserAddXalian(loggedInUser.username, xalian.xalianId))
+			.callKeepXalian(envelope)
 			.then(() => {
 				setIsLoading(false);
 				toast.success(`${xalian.species.name} kept.`);

--- a/my-app/src/utils/dbApi.js
+++ b/my-app/src/utils/dbApi.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import qs from "qs";
 import Amplify, { API, Auth } from "aws-amplify";
+import { UserRecordSchema, PublicProfileSchema, XalianRecordSchema } from "@xalians/content/schema";
 
 async function authHeaders() {
   const session = await Auth.currentSession();
@@ -11,12 +12,35 @@ export const callGetXalian = (id = "00009-4c1d8607-d3de-4313-91b1-84eecd5ce921")
   return callGet("https://api.xalians.com/prod/db/xalian?xalianId=" + id);
 };
 
-export const callGetUser = (id, populateXalians = false) => {
-  if (populateXalians) {
-    return callGet("https://api.xalians.com/prod/db/user?userId=" + id + "&populateXalians=true");
-  } else {
-    return callGet("https://api.xalians.com/prod/db/user?userId=" + id);
+// The legacy user record's shape is still drifting (D1's docs call this out as the
+// "drift alarm", not a hard contract): safeParse rather than parse, warn with the zod
+// issue path on a mismatch, and always return the raw data so the legacy pages that
+// tolerate extra/missing fields keep working either way.
+function warnOnSchemaMismatch(schema, data, label) {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    console.warn(
+      `dbApi: ${label} response did not match its schema: ${result.error.issues
+        .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("; ")}`
+    );
   }
+  return data;
+}
+
+export const callGetUser = (id, populateXalians = false) => {
+  const url = populateXalians
+    ? "https://api.xalians.com/prod/db/user?userId=" + id + "&populateXalians=true"
+    : "https://api.xalians.com/prod/db/user?userId=" + id;
+
+  return callGet(url).then((data) => {
+    // A caller's own full record has "tokens"/"attributes"; anyone else's is the public
+    // profile (userId + xalianIds, optionally xalians). Pick the schema that matches the
+    // shape actually returned rather than guessing from the request.
+    const schema = "tokens" in data || "attributes" in data ? UserRecordSchema : PublicProfileSchema;
+    const label = schema === UserRecordSchema ? "GET /db/user (own profile)" : "GET /db/user (public profile)";
+    return warnOnSchemaMismatch(schema, data, label);
+  });
 };
 
 export const callGet = (url) => {
@@ -48,8 +72,12 @@ export const callGetXalianBatch = (ids) => {
   );
 };
 
-export const callCreateXalian = (xalian) => {
-  return callCreate("https://api.xalians.com/prod/db/xalian", xalian);
+// Keeps a Xalian in one call: posts the { xalian, signature } envelope
+// callGenerateXalian() returned, unchanged. The server verifies the signature, persists,
+// and appends the id to the caller's user record itself (apps/api/src/handlers/createXalian.ts);
+// there is no longer a separate "add to user" step (see the deleted callUpdateUserAddXalian).
+export const callKeepXalian = (envelope) => {
+  return callCreate("https://api.xalians.com/prod/db/xalian", envelope);
 };
 
 export const callCreateUser = (user) => {
@@ -65,10 +93,6 @@ export const callCreate = (url, data) => {
       data,
     }).then((response) => response.data);
   });
-};
-
-export const callUpdateUserAddXalian = (userId, xalianId) => {
-  return callUpdateUserXalian('ADD_XALIAN_ID', userId, xalianId);
 };
 
 export const callUpdateUserRemoveXalian = (userId, xalianId) => {
@@ -93,4 +117,35 @@ export const callUpdateUserXalian = (action, userId, xalianId) => {
       data,
     }).then((response) => response.data);
   });
+};
+
+// -----------------------------------------------------------------------------------
+// Registry (D1): server-generated, ratified XalianRecords. No page uses these yet (the
+// generator and account pages stay on the legacy shape until the separate record-view
+// design brief); these are new and typed end to end, so responses are parsed strictly
+// (schema.parse, not safeParse) rather than warned-and-passed-through.
+// -----------------------------------------------------------------------------------
+
+export const callGenerateRegistryXalian = (species) => {
+  return callCreate("https://api.xalians.com/prod/xalians", species ? { species } : {}).then((data) =>
+    XalianRecordSchema.parse(data)
+  );
+};
+
+export const callListRegistryXalians = (ownerId, cursor) => {
+  const params = new URLSearchParams();
+  if (ownerId) params.set("ownerId", ownerId);
+  if (cursor) params.set("cursor", cursor);
+  const qsSuffix = params.toString() ? "?" + params.toString() : "";
+
+  return callGet("https://api.xalians.com/prod/xalians" + qsSuffix).then((data) => ({
+    items: data.items.map((item) => XalianRecordSchema.parse(item)),
+    nextCursor: data.nextCursor,
+  }));
+};
+
+export const callGetRegistryXalian = (id) => {
+  return callGet("https://api.xalians.com/prod/xalians/" + encodeURIComponent(id)).then((data) =>
+    XalianRecordSchema.parse(data)
+  );
 };

--- a/my-app/src/utils/xalianApi.js
+++ b/my-app/src/utils/xalianApi.js
@@ -1,5 +1,9 @@
 import axios from 'axios';
 
+// Returns the whole { xalian, signature } envelope (apps/api/src/handlers/generateXalian.ts).
+// `xalian` is the exact legacy shape this endpoint always returned; `signature` is a
+// server HMAC over it that dbApi.callKeepXalian sends back unchanged when the user keeps
+// this Xalian, so the server can verify the stats were never edited client-side.
 export const callGenerateXalian = () => {
 
     const url = "https://api.xalians.com/xalian";

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@xalians/content": "1.0.0",
+        "@xalians/rules": "1.0.0",
         "zod": "^4.6.0"
       },
       "devDependencies": {

--- a/terraform/modules/lambda/lambda_instance.tf
+++ b/terraform/modules/lambda/lambda_instance.tf
@@ -32,6 +32,12 @@ variable "iam_role_arn" {
   type        = string
 }
 
+variable "environment_variables" {
+  description = "environment variables to set on the function; left unset (no environment block at all) when empty, e.g. for functions that need no secrets"
+  type        = map(string)
+  default     = {}
+}
+
 
 
 
@@ -48,6 +54,16 @@ resource "aws_lambda_function" "lambda_function" {
   handler          = var.lambda_handler_path
   source_code_hash = var.lambda_archive_file_output_hash
   role             = var.iam_role_arn
+
+  # Only set when the map is non-empty: an environment block with an empty `variables`
+  # map is valid but shows as a diff against a function with no block at all, so most
+  # functions (which need no secrets) get no block rather than an empty one.
+  dynamic "environment" {
+    for_each = length(var.environment_variables) > 0 ? [var.environment_variables] : []
+    content {
+      variables = environment.value
+    }
+  }
 }
 
 # lambda function cloudwatch log group


### PR DESCRIPTION
## Summary

Wave D, PR D1 of the backend modernization: the server now generates and owns Xalians. Two independent pieces:

### 1. The registry (new)

- `POST /xalians` (JWT) — generates a ratified `XalianRecord` from `@xalians/rules` with a server-drawn seed, persists it under the caller, returns 201 with the record.
  - Body: `{ species?: string }`. Omitted, the handler draws uniformly from `getSpeciesTemplates()`. Given, it must be a ratified species key or the response is 400 `UNKNOWN_SPECIES`.
  - `serial` is omitted from the `generateXalian(...)` call (defaults to `1` in the generator) rather than derived from a per-owner/per-species count — there is no existing counter and deriving one from `listByOwner` would require a scan-and-filter across an owner's whole history for every generate. `origin` is passed explicitly as `template.homePlanet` per the brief (the generator defaults to the same value when omitted, so this is belt-and-suspenders).
  - The generated record is validated with `XalianRecordSchema.parse` before persisting; a failure is a 500 that logs the zod issue paths (guard only — the generator and schema are already integration-tested together in `packages/rules`).
- `GET /xalians` (JWT) — without `ownerId`, lists the caller's own records; with `ownerId`, lists that owner's (registry records are public, like the legacy collection view). Returns `{ items: XalianRecord[], nextCursor?: string }`, cursor is base64url of `LastEvaluatedKey`.
- `GET /xalians/{xalianId}` (JWT) — any authenticated caller may read any record. 404 `XALIAN_NOT_FOUND` on a miss (the legacy `/db/xalian` route keeps its historical 400 for compatibility).
- New table `XalianRegistry`: hash key `xalianId`, GSI `byOwner` (hash `ownerId`, range `generatedAt`, `ALL` projection), on-demand billing, point-in-time recovery, `prevent_destroy`. The Lambda role's inline DynamoDB policy previously listed `XalianTable`/`XalianUsersTable` as exact ARNs (not a table-level wildcard — only the index suffix is wildcarded), so `table/XalianRegistry` was added explicitly alongside them.

### 2. Signed showroom keeps (audit F2)

Today `GET /xalian` returns a legacy-shape creature with no proof of origin, and `POST /db/xalian` stores whatever body it receives — a client could keep any stats it liked. Fixed without changing what the user sees:

- `GET /xalian` now returns `{ xalian, signature }` — `xalian` is the exact legacy shape this route always returned; `signature` is an HMAC-SHA256 (hex) over a canonical (sorted-key, no-whitespace) serialization of it. **This is the one public contract change in this PR**, and the frontend is updated in the same PR.
- `POST /db/xalian` (the "keep" flow) now takes `{ xalian, signature }`: verifies the signature (400 `INVALID_SIGNATURE`), requires `xalian.createTimestamp` within the last 24 hours (400 `SIGNATURE_EXPIRED`), persists with `attribute_not_exists(xalianId)` (409 `ALREADY_KEPT` on a repeat), then appends the id to the caller's user record — all in one call. The old two-call flow (`POST /db/xalian` + `PATCH /db/user ADD_XALIAN_ID`) is gone.
- `PATCH /db/user` reduces to `REMOVE_XALIAN_ID`. `ADD_XALIAN_ID` is now 403 `FORBIDDEN_ACTION` ("keeping is server-side"); `ADD_TOKENS`/`REMOVE_TOKENS` are 403 `FORBIDDEN_ACTION` ("token accounting is server-side"). `usersRepo.removeTokens`/`addXalianId` are untouched in the repository — the registry and future token spending still use them.
- Terraform: `random_password.xalian_signing_secret` (48 chars, the `random` provider is newly added to `required_providers`), injected via a new `environment_variables` map variable + `dynamic "environment"` block on the reusable Lambda module, wired only into `GenerateXalian` and `TableCreateXalian`.

### Frontend

- `dbApi.js`: `callKeepXalian(envelope)` posts the envelope to `/db/xalian` unchanged; `callUpdateUserAddXalian` deleted (its only caller was the old two-call keep flow); `callUpdateUserRemoveXalian` kept. `GET /db/user` responses are `safeParse`d against `UserRecordSchema`/`PublicProfileSchema` and `console.warn` (not thrown) on drift. New `callGenerateRegistryXalian`, `callListRegistryXalians`, `callGetRegistryXalian`, parsed strictly with `XalianRecordSchema` — no page uses them yet, per the brief.
- `generatorPage.tsx`: state holds the `{ xalian, signature }` envelope; every render path derives `xalian` from it; `saveXalian` is now the single `callKeepXalian(envelope)` call.

## Refs

Refs #20 — this is a first real implementation of the registry idea, not the close condition in the issue text (which defers the full design to a second consumer app / M5 multiplayer). Leaving it open.

**Terraform apply on merge** will create the `XalianRegistry` table and the `random_password` secret; both are new resources, nothing existing is modified destructively.

## Verification

- `npm run typecheck -w apps/api` — clean
- `npm test -w apps/api` — 14 files, 63 tests passing (new: signing round-trip/tamper/missing-secret, registry repository put/get/list/cursor, all three registry handlers, keep-flow signature/expiry/duplicate/success, updateUser's three forbidden actions never touching DynamoDB)
- `npm run build -w apps/api` — 9 handler bundles (up from 6)
- Standalone bundle smoke tests: `generateXalian/index.mjs` run directly with `XALIAN_SIGNING_SECRET=test` (and `node_modules/@xalians` renamed away) returns 200 with a 64-hex-char signature that verifies; `generateRegistryXalian/index.mjs` run the same way with a fake JWT event loads, runs the real generator, and returns 500 `INTERNAL_ERROR` (not a crash on import) when it reaches DynamoDB with no table/credentials, exactly as expected standalone
- `npm test -w my-app -- --run` — 37 files, 1191 tests passing
- `npm run build -w my-app` — succeeds (pre-existing chunk-size warnings unrelated to this change; one pre-existing Vite warning about inconsistent JSON import attributes on `registries.json`, not introduced here — surfaced because `dbApi.js` now imports `@xalians/content/schema`, which transitively imports it)
- `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)