### PR TITLE
Infra: key the Lambda environment block off a known boolean

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -289,6 +289,7 @@ module "generate_xalian_lambda_module" {
   apigw_lambda_route_key          = "GET /xalian"
   base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
   authorization_type              = "NONE"
+  has_environment                 = true
   environment_variables = {
     XALIAN_SIGNING_SECRET = random_password.xalian_signing_secret.result
   }
@@ -315,6 +316,7 @@ module "table_create_xalian_lambda_module" {
   base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
   authorization_type              = "JWT"
   authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+  has_environment                 = true
   environment_variables = {
     XALIAN_SIGNING_SECRET = random_password.xalian_signing_secret.result
   }

--- a/terraform/modules/lambda/lambda_instance.tf
+++ b/terraform/modules/lambda/lambda_instance.tf
@@ -38,6 +38,12 @@ variable "environment_variables" {
   default     = {}
 }
 
+variable "has_environment" {
+  description = "set true alongside environment_variables; keeps the environment block count known at plan time even when a variable value is not (see the environment block below)"
+  type        = bool
+  default     = false
+}
+
 
 
 
@@ -55,13 +61,17 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = var.lambda_archive_file_output_hash
   role             = var.iam_role_arn
 
-  # Only set when the map is non-empty: an environment block with an empty `variables`
+  # Only set when has_environment is true: an environment block with an empty `variables`
   # map is valid but shows as a diff against a function with no block at all, so most
-  # functions (which need no secrets) get no block rather than an empty one.
+  # functions (which need no secrets) get no block rather than an empty one. The block
+  # count is keyed off a plain boolean rather than length(var.environment_variables):
+  # when a value in the map is unknown at plan time (a random_password created in the
+  # same apply), the length is unknown too, Terraform plans zero blocks, applies one, and
+  # fails with "Provider produced inconsistent final plan" (seen 2026-09-10).
   dynamic "environment" {
-    for_each = length(var.environment_variables) > 0 ? [var.environment_variables] : []
+    for_each = var.has_environment ? [1] : []
     content {
-      variables = environment.value
+      variables = var.environment_variables
     }
   }
 }


### PR DESCRIPTION
## Summary
The backend apply for #186 failed on `GenerateXalian` and `TableCreateXalian` with `Provider produced inconsistent final plan: .environment: block count changed from 0 to 1`. The module's dynamic `environment` block used `length(var.environment_variables) > 0`, and the map's value (`random_password.xalian_signing_secret.result`) was unknown at plan time because the secret is created in the same apply, so the plan said zero blocks and the apply produced one.

The block count now keys off a plain `has_environment` boolean (default false), set `true` on the two modules that pass the secret. Everything else from the #186 apply (the registry table, the three new routes, the secret itself) landed; this PR's apply finishes the two function updates and the site's signed keep flow starts working end to end.

Verified: `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)