### PR TITLE
Infra: stages depend on the showroom route they throttle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -155,6 +155,11 @@ resource "aws_apigatewayv2_api" "lambda" {
 }
 
 resource "aws_apigatewayv2_stage" "prod" {
+  # route_settings names "GET /xalians/showroom"; API Gateway rejects the stage update
+  # when that route does not exist yet, so the stage must wait for the module that
+  # creates it (seen on the 2026-09-10 apply that introduced the route).
+  depends_on = [module.showroom_xalian_lambda_module]
+
   api_id = aws_apigatewayv2_api.lambda.id
 
   name        = "prod"
@@ -196,6 +201,11 @@ resource "aws_apigatewayv2_stage" "prod" {
 }
 
 resource "aws_apigatewayv2_stage" "test" {
+  # route_settings names "GET /xalians/showroom"; API Gateway rejects the stage update
+  # when that route does not exist yet, so the stage must wait for the module that
+  # creates it (seen on the 2026-09-10 apply that introduced the route).
+  depends_on = [module.showroom_xalian_lambda_module]
+
   api_id = aws_apigatewayv2_api.lambda.id
 
   name        = "test"


### PR DESCRIPTION
## Summary
The apply for #195 failed on both `aws_apigatewayv2_stage` updates with `Unable to find Route by key GET /xalians/showroom within the provided RouteSettings`: the stage carries a per-route throttle for the new showroom route, and Terraform ordered the stage update before the module that creates the route. Everything else in that apply landed (the legacy functions and routes are gone, the showroom and release routes exist); a re-dispatched apply of `main` succeeds now that the route exists. This adds an explicit `depends_on` on both stages so a future new throttled route cannot hit the same ordering.

Verified: `terraform fmt`, `terraform init -backend=false`, `terraform validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)