### PR TITLE
Live walk fixes: home tile mass, reading room key, grid, index placeholder

### DIFF
--- a/apps/web/src/components/encyclopedia/Index.js
+++ b/apps/web/src/components/encyclopedia/Index.js
@@ -96,7 +96,7 @@ export default function Index() {
                     <Input
                         className="min-w-48 flex-[1_1_16rem]"
                         type="search"
-                        placeholder="SEARCH ENTRIES"
+                        placeholder="Search entries"
                         aria-label="Search entries"
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}

--- a/apps/web/src/components/encyclopedia/ReadingRoom.js
+++ b/apps/web/src/components/encyclopedia/ReadingRoom.js
@@ -45,7 +45,7 @@ function BeginOrResumeCard({ story }) {
 					</p>
 				</div>
 				{/* The one forward action on this screen: the primary key. */}
-				<Button asChild className="shrink-0">
+				<Button asChild className="shrink-0 max-sm:w-full">
 					<Link to={lore.routeFor('era', resumedPart.era.key)}>
 						Resume Part {resumedPart.order}, {resumedPart.era.name}
 					</Link>
@@ -62,7 +62,7 @@ function BeginOrResumeCard({ story }) {
 				<h2 className="type-heading m-0 mb-1">{story.title}</h2>
 				<p className="m-0 font-body text-body text-ink-2">{story.parts.length} parts, one per era.</p>
 			</div>
-			<Button asChild className="shrink-0">
+			<Button asChild className="shrink-0 max-sm:w-full">
 				<Link to={lore.routeFor('era', firstPart.era.key)}>
 					Begin Part 1, {firstPart.era.name}
 				</Link>

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -87,7 +87,7 @@ function Home() {
 								<Link
 									key={world.key}
 									to={routeFor('world', world.key)}
-									className={`el-${world.element} group flex flex-col items-start gap-1 overflow-hidden border border-edge bg-s1 pb-2 transition-colors duration-1 ease-out hover:border-edge-strong hover:bg-s2 focus-visible:outline-2 focus-visible:outline-ring`}
+									className={`el-${world.element} mass-el group flex flex-col items-start gap-1 overflow-hidden border border-edge bg-s1 pb-2 hover:border-edge-strong hover:bg-s2 focus-visible:outline-2 focus-visible:outline-ring`}
 								>
 									<div className="flex aspect-square w-full items-center justify-center bg-el/24">
 										<img
@@ -114,7 +114,7 @@ function Home() {
 							<Link
 								key={s.id || s.name}
 								to={routeFor('species', s.name.toLowerCase())}
-								className={`el-${s.type.toLowerCase()} flex w-[140px] shrink-0 snap-start flex-col items-center gap-2 overflow-hidden border border-edge bg-s1 pb-3 transition-colors duration-1 ease-out hover:border-edge-strong hover:bg-s2 focus-visible:outline-2 focus-visible:outline-ring sm:w-auto sm:shrink`}
+								className={`el-${s.type.toLowerCase()} mass-el flex w-[140px] shrink-0 snap-start flex-col items-center gap-2 overflow-hidden border border-edge bg-s1 pb-3 hover:border-edge-strong hover:bg-s2 focus-visible:outline-2 focus-visible:outline-ring sm:w-auto sm:shrink`}
 							>
 								<div className="aspect-square w-full bg-el">
 									<XalianImage colored speciesName={s.name} primaryType={s.type} moreClasses="w-full" />

--- a/apps/web/src/pages/styleguide/primitiveSections.tsx
+++ b/apps/web/src/pages/styleguide/primitiveSections.tsx
@@ -100,7 +100,7 @@ function AvatarSection() {
             <p className="text-body text-ink-2">Account identity: a square level-2 plate with a hairline edge and initials in the legend face.</p>
             <div className="mt-6 flex flex-wrap items-end gap-8">
                 <Demo label="sm, image">
-                    <Avatar size="sm"><AvatarImage src="/xalians_dna_logo.svg" alt="" /><AvatarFallback>NJ</AvatarFallback></Avatar>
+                    <Avatar size="sm"><AvatarFallback>NJ</AvatarFallback></Avatar>
                 </Demo>
                 <Demo label="md, fallback">
                     <Avatar size="md"><AvatarFallback>NJ</AvatarFallback></Avatar>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -160,8 +160,8 @@
 	/* Level-0 surfaces carry a faint 32px layout grid; nothing else does. */
 	.surface-0 {
 		background-image:
-			linear-gradient(color-mix(in srgb, var(--color-ink) 4.5%, transparent) 1px, transparent 1px),
-			linear-gradient(90deg, color-mix(in srgb, var(--color-ink) 4.5%, transparent) 1px, transparent 1px);
+			linear-gradient(color-mix(in srgb, var(--color-ink) 3%, transparent) 1px, transparent 1px),
+			linear-gradient(90deg, color-mix(in srgb, var(--color-ink) 3%, transparent) 1px, transparent 1px);
 		background-size: 32px 32px;
 		background-position: -1px -1px;
 	}


### PR DESCRIPTION
Findings from walking www.xalians.com after PR #165 deployed, fixed here:

- Home planet tiles and the species strip are links but had no mass; they now stand on their element like every other tile.
- The reading room's "Begin Part 1" primary overflowed its card at 390; full width on the phone.
- The level-0 layout grid drops from 4.5 to 3 percent; the account empty state read as graph paper at 1440.
- The index search placeholder was uppercase; now sentence case like every other field.
- The style guide avatar demo requested a logo path that is not served (a 404 on the style guide only).

Not fixed here, filed as #203: every deep link is served with an HTTP 404 status by CloudFront.

apps/web: tests 940 passing, build clean. The pre-existing tsc errors under packages/content (`.ts` import extensions) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)