### PR TITLE
CI role: read and update the site CloudFront distribution

### DIFF
--- a/github-oidc.tf
+++ b/github-oidc.tf
@@ -184,6 +184,22 @@ resource "aws_iam_role_policy" "github_terraform" {
         Action   = ["acm:DescribeCertificate", "acm:ListCertificates", "acm:ListTagsForCertificate"]
         Resource = "*"
       },
+      # The site distribution (#203): read and update only, scoped to the one
+      # distribution, so CI can import it and manage its error mapping but a
+      # bad plan can never create or delete a distribution.
+      {
+        Sid    = "CloudFrontSite"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:GetDistribution",
+          "cloudfront:GetDistributionConfig",
+          "cloudfront:UpdateDistribution",
+          "cloudfront:ListTagsForResource",
+          "cloudfront:TagResource",
+          "cloudfront:UntagResource",
+        ]
+        Resource = var.cloudfront_arn
+      },
       # Without these the role cannot refresh the two resources above, and
       # every `terraform plan` in CI fails with AccessDenied on itself.
       # Deliberately excludes Delete*/CreateRole so a bad plan cannot


### PR DESCRIPTION
Adds a CloudFrontSite statement to the GitHub terraform role, scoped to the site distribution, with read and update only (no create or delete).

This is step one of fixing #203. The follow-up imports the distribution into Terraform and changes the 404 error mapping to return 200, which the CI plan cannot even read until this role change is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)