### PR TITLE
Live walk, round two: navbar strip, record plates, curtain key, CloudFront 404

### DIFF
--- a/apps/web/public/assets/css/legacy/style.css
+++ b/apps/web/public/assets/css/legacy/style.css
@@ -3402,48 +3402,6 @@ input, textarea {
   margin: auto;
 }
 
-/* The pre-round curtain. It covers the board rather than floating on top of a
-   corner of it, so nothing is obscured while it is up and nothing is left
-   overlapping once the round starts. */
-.game-curtain {
-  position: absolute;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--g-3);
-  background: rgba(13, 11, 9, 0.82);
-  border-radius: var(--g-radius-housing);
-}
-
-.game-curtain-kicker {
-  margin: 0;
-}
-
-.game-display-text {
-  font-family: var(--g-font-stencil);
-  font-size: var(--g-size-readout);
-  font-weight: 600;
-  letter-spacing: var(--g-track-label);
-  text-transform: uppercase;
-  color: var(--g-ink);
-  margin: 0;
-}
-
-.game-curtain-note {
-  font-family: var(--g-font-mono);
-  font-size: var(--g-size-small);
-  color: var(--g-ink-mid);
-  margin: 0;
-}
-
-.game-curtain-btn {
-  margin-top: var(--g-3);
-  padding: var(--g-3) var(--g-7);
-}
-
 /* 
 -------------------------------------------
 |   Game Container

--- a/apps/web/src/components/auth/authButtonGroup.tsx
+++ b/apps/web/src/components/auth/authButtonGroup.tsx
@@ -20,10 +20,12 @@ import {
 type AuthState = { username: string; hasVerifiedEmail: boolean } | null;
 
 type AuthButtonGroupProps = {
+	/** Key size; the desktop navbar passes "sm" so a key's mass clears its hairline. */
+	size?: "default" | "sm";
 	authAlertCallback: (user: AuthState) => void;
 };
 
-function AuthButtonGroup({ authAlertCallback }: AuthButtonGroupProps) {
+function AuthButtonGroup({ authAlertCallback, size = "default" }: AuthButtonGroupProps) {
 	const [loggedInUser, setLoggedInUser] = React.useState<AuthState>(null);
 	const [signupModalShow, setSignupModalShow] = React.useState(false);
 	const [verifyEmailModalShow, setVerifyEmailModalShow] = React.useState(false);
@@ -104,7 +106,7 @@ function AuthButtonGroup({ authAlertCallback }: AuthButtonGroupProps) {
 			{loggedInUser ? (
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
-						<Button variant="ghost">{loggedInUser.username}</Button>
+						<Button variant="ghost" size={size}>{loggedInUser.username}</Button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="end">
 						<DropdownMenuItem asChild>
@@ -118,8 +120,8 @@ function AuthButtonGroup({ authAlertCallback }: AuthButtonGroupProps) {
 				</DropdownMenu>
 			) : (
 				<React.Fragment>
-					<Button variant="ghost" onClick={() => setSignInModalShow(true)}>Sign in</Button>
-					<Button variant="secondary" onClick={() => setSignupModalShow(true)}>Create account</Button>
+					<Button variant="ghost" size={size} onClick={() => setSignInModalShow(true)}>Sign in</Button>
+					<Button variant="secondary" size={size} onClick={() => setSignupModalShow(true)}>Create account</Button>
 				</React.Fragment>
 			)}
 

--- a/apps/web/src/components/encyclopedia/SpeciesView.js
+++ b/apps/web/src/components/encyclopedia/SpeciesView.js
@@ -253,11 +253,9 @@ export default function SpeciesView() {
         <article className={`el-${view.element}`}>
             <div className="grid grid-cols-1 gap-6 md:grid-cols-[minmax(240px,360px)_minmax(0,1fr)]">
                 <div className="flex min-w-0 flex-col gap-4 max-sm:contents">
-                    <Card variant="panel" className="p-5 max-sm:order-1 max-sm:max-w-[320px]">
-                        <div className="grid aspect-square w-full place-items-center">
-                            <XalianImage colored speciesName={view.name} primaryType={view.element} moreClasses="w-full" />
-                        </div>
-                    </Card>
+                    <div className="max-sm:order-1 max-sm:max-w-[320px]">
+                        <XalianImage colored speciesName={view.name} primaryType={view.element} moreClasses="w-full" />
+                    </div>
                     {isTemplate && <div className="max-sm:order-3"><Signature signature={view.record.signature} /></div>}
                 </div>
 

--- a/apps/web/src/components/encyclopedia/WorldView.js
+++ b/apps/web/src/components/encyclopedia/WorldView.js
@@ -241,15 +241,13 @@ export default function WorldView() {
         <article className={`el-${world.element}`}>
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(240px,360px)_minmax(0,1fr)]">
                 <div className="flex min-w-0 flex-col gap-4">
-                    <Card variant="panel" className="p-5">
-                        <div className="grid aspect-square w-full place-items-center rounded-full bg-el/25">
-                            <img
-                                src={`/${world.images.planet}`}
-                                alt={`${world.name} globe`}
-                                className="block size-full rounded-full object-cover"
-                            />
-                        </div>
-                    </Card>
+                    <div className="grid aspect-square w-full place-items-center bg-el/24">
+                        <img
+                            src={`/${world.images.planet}`}
+                            alt={`${world.name} globe`}
+                            className="h-[72%] w-[72%] object-contain"
+                        />
+                    </div>
                     <SpecPlate entries={factsEntries} />
                 </div>
 

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -130,7 +130,7 @@ function XalianNavbar({ authAlertCallback }: XalianNavbarProps) {
 					</nav>
 
 					<div className="ml-auto hidden items-center gap-2 md:flex">
-						<AuthButtonGroup authAlertCallback={handleUserAuthAction} />
+						<AuthButtonGroup size="sm" authAlertCallback={handleUserAuthAction} />
 					</div>
 
 					<Sheet open={menuOpen} onOpenChange={setMenuOpen}>

--- a/apps/web/src/pages/games/matchCardGamePage.js
+++ b/apps/web/src/pages/games/matchCardGamePage.js
@@ -9,6 +9,7 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { MotionPathPlugin } from 'gsap/MotionPathPlugin';
 import { TextPlugin } from 'gsap/TextPlugin';
 import { DrawSVGPlugin } from 'gsap/DrawSVGPlugin';
+import { Button } from '@/components/ui/button';
 gsap.registerPlugin(MotionPathPlugin, TextPlugin, ScrollTrigger, DrawSVGPlugin);
 
 class MatchCardGamePage extends React.Component {
@@ -36,7 +37,7 @@ class MatchCardGamePage extends React.Component {
 			tl.to('#match-game-start-button', { autoAlpha: 0 });
 			// the curtain covers the whole board, so it has to clear out of the way
 			// once the round begins - only the countdown legend stays on top
-			tl.to('#match-game-curtain', { backgroundColor: 'rgba(13, 11, 9, 0)', pointerEvents: 'none', duration: 0.4 }, '<');
+			tl.to('#match-game-curtain', { backgroundColor: 'rgba(14, 16, 15, 0)', pointerEvents: 'none', duration: 0.4 }, '<');
 			this.flipAllCardsUp(tl);
 			tl.to('#match-game-display-text', { text: { padSpace: true, preserveSpaces: true, value: '    3...' }, duration: 1 })
 				.to('#match-game-display-text', { text: { padSpace: true, preserveSpaces: true, value: '    2...' }, duration: 1 })
@@ -314,15 +315,15 @@ class MatchCardGamePage extends React.Component {
 					{/* the start control used to sit on top of the middle of the board,
 					    covering two cards; it is a curtain over the whole board until
 					    the round begins, which is what it was always acting as */}
-					<div className="game-curtain" id="match-game-curtain">
-						<p className="g-kicker game-curtain-kicker">Xalian Match</p>
-						<h2 className="game-display-text" id="match-game-display-text">
+					<div className="absolute inset-0 z-[1000] flex flex-col items-center justify-center gap-3 bg-glass/85" id="match-game-curtain">
+						<p className="type-legend m-0">Xalian Match</p>
+						<h2 className="type-title m-0" id="match-game-display-text">
 							Ready...
 						</h2>
-						{this.state.text && <p className="game-curtain-note">{this.state.text}</p>}
-						<button type="button" id="match-game-start-button" className="g-key g-key--primary game-curtain-btn" onClick={this.startGameTapped}>
+						{this.state.text && <p className="type-data m-0 text-small text-ink-2">{this.state.text}</p>}
+						<Button size="lg" id="match-game-start-button" className="mt-3" onClick={this.startGameTapped}>
 							Start
-						</button>
+						</Button>
 					</div>
 				</div>
 			</React.Fragment>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -167,6 +167,11 @@
 	}
 
 	/* The room is not a flat fill: a faint grain and an edge vignette. */
+	/* A page's first margin (the masthead's mt-8) used to collapse through
+	   <main>, so main started 32px below the navbar and the plain body showed
+	   through as a dark strip. flow-root keeps that margin inside main. */
+	main[data-tier="chrome"] { display: flow-root; }
+
 	[data-tier="chrome"] {
 		background-image:
 			linear-gradient(90deg, rgba(0, 0, 0, 0.22), transparent 14%, transparent 86%, rgba(0, 0, 0, 0.22)),

--- a/main.tf
+++ b/main.tf
@@ -565,6 +565,76 @@ resource "aws_s3_bucket_website_configuration" "react_bucket" {
   }
 }
 
+# The site distribution (#203). Created in the console long before Terraform
+# and imported here so the deep-link error mapping lives in code: the S3
+# origin answers every client-side route (/generator, /encyclopedia/...) with
+# a 404 whose body is index.html, and CloudFront must rewrite that status to
+# 200 or every deep link is logged as an error and read by crawlers as a
+# missing page. 403 is mapped the same way for the day the bucket policy
+# stops answering missing keys with 404. Everything else matches the live
+# distribution exactly so the import plans as an update, never a replace.
+import {
+  to = aws_cloudfront_distribution.site
+  id = var.cloudfront_id
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  http_version        = "http2"
+  price_class         = "PriceClass_100"
+  default_root_object = "index.html"
+  aliases             = ["www.xalians.com", "xalians.com"]
+
+  origin {
+    origin_id   = var.frontend_bucket_name
+    domain_name = "${var.frontend_bucket_name}.s3.us-east-1.amazonaws.com"
+    # No s3_origin_config: the live origin has an empty access identity (the
+    # bucket is public-read) and the provider treats the omitted block as that.
+  }
+
+  default_cache_behavior {
+    target_origin_id           = var.frontend_bucket_name
+    viewer_protocol_policy     = "allow-all"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6" # Managed-CachingOptimized
+    origin_request_policy_id   = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf" # Managed-CORS-S3Origin
+    response_headers_policy_id = "5cc3b908-e619-4b99-88e5-2cf7f45965bd" # Managed-CORS-With-Preflight
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.cert_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_s3_bucket_cors_configuration" "react_bucket" {
   bucket = aws_s3_bucket.react_bucket.id
 


### PR DESCRIPTION
Fixes everything left from the live walk after #204, plus the navbar strip that was still visible on production.

**Navbar strip.** The masthead's top margin collapsed through `<main>`, so the textured chrome surface started 32px below the navbar and the plain body color showed through as a dark band. Chrome mains are now `display: flow-root`; main starts exactly at the navbar's bottom edge (verified at 1440: nav bottom 57, main top 57).

**Record plates.** The species record plate is the element wash itself, no card frame around it. The world record plate is square, same tint as its index tile, globe at 72%.

**Training curtain.** The pre-round curtain uses the v4 primary key (`Button size="lg"`) and the v4 type classes; the legacy `.game-curtain*` CSS block is deleted. GSAP still targets the same ids.

**Navbar keys.** Desktop auth keys are the small size so Create account's mass clears the navbar hairline (11px clearance).

**CloudFront deep links (#203).** The site distribution is imported into Terraform with an `import` block and the custom error responses map 404 and 403 to 200 with `/index.html`. Local `terraform plan` against live state: update in place, only the error mapping changes. Needed #206 (role permissions) first, which is merged and applied.

Not changed: the distribution's viewer protocol policy is still `allow-all`. Switching it to redirect-to-https is a one-line follow-up if you want it.

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)