### PR TITLE
Polish Long Return mission tradeoffs

### DIFF
--- a/apps/web/src/components/games/longReturn/FieldWorkshop.js
+++ b/apps/web/src/components/games/longReturn/FieldWorkshop.js
@@ -10,9 +10,14 @@ export default function FieldWorkshop({ crew, strain, pressure, salvage, command
   if (receipt) return <section className="lr-field-receipt" role="status"><BiIcon cls="bi bi-check-circle" /><div><strong>Field work complete</strong><p>{receipt.result}</p><small>{receipt.cost} salvage spent · {salvage} still carried</small></div></section>;
   if (!options.length) return null;
   return <details className="lr-workshop">
-    <summary><BiIcon cls="bi bi-tools" /><span><strong>Put salvage to work</strong><small>Recover energy or reinforce the annex</small></span><b>{salvage} carried <BiIcon cls="bi bi-chevron-down" /></b></summary>
+    <summary><BiIcon cls="bi bi-tools" /><span><strong>Repair now—or bank the haul</strong><small>Trade final salvage for energy or stability</small></span><b>{salvage} carried <BiIcon cls="bi bi-chevron-down" /></b></summary>
     <div className="lr-workshop-body">
-      <p>One field action per crossing. Spend part of your haul now, or keep it for extraction.</p>
+      <div className="lr-workshop-bank" aria-label={`Keep all ${salvage} salvage for extraction`}>
+        <BiIcon cls="bi bi-box-seam" />
+        <span><small>Keep the haul</small><strong>Bank +{salvage} at extraction</strong></span>
+        <em>No repair now</em>
+      </div>
+      <p>Or spend salvage on one field repair before continuing.</p>
       <div className="lr-workshop-options">{options.map(option => <button type="button" key={option.id} disabled={!!option.disabled} aria-pressed={selected === option.id} title={option.reason} onClick={() => setSelected(option.id)}>
         <BiIcon cls={`bi ${option.kind === 'recover' ? 'bi-lightning-charge-fill' : option.kind === 'brace' ? 'bi-shield-check' : 'bi-broadcast-pin'}`} />
         <strong>{option.title}</strong>

--- a/apps/web/src/components/games/longReturn/fieldWorkshop.css
+++ b/apps/web/src/components/games/longReturn/fieldWorkshop.css
@@ -8,6 +8,12 @@
 .lr-workshop > summary > b { color: var(--g-hazard); font-size: 15px; }
 .lr-workshop-body { padding: 0 20px 20px; }
 .lr-workshop-body > p { font-size: 17px; color: var(--g-ink-mid); }
+.lr-workshop-bank { display:flex; align-items:center; gap:12px; padding:14px 16px; border:1px solid rgba(116,255,176,.42); background:rgba(116,255,176,.055); }
+.lr-workshop-bank > i { color:var(--g-phosphor); font-size:22px; }
+.lr-workshop-bank > span { flex:1; }
+.lr-workshop-bank small { margin:0; font:700 10px/1.25 var(--g-font-mono); text-transform:uppercase; letter-spacing:.08em; }
+.lr-workshop-bank strong { color:var(--g-phosphor); font-size:17px; }
+.lr-workshop-bank em { color:var(--g-ink-mid); font:700 12px/1.3 var(--g-font-mono); font-style:normal; }
 .lr-workshop-options { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
 .lr-workshop-options > button { display: grid; grid-template-columns: 27px 1fr; gap: 7px 9px; padding: 17px; color: var(--g-ink); border: 1px solid var(--g-seam); background: var(--g-hull); text-align: left; }
 .lr-workshop-options > button > i { grid-row: 1 / 4; color: #72d8ff; font-size: 22px; }
@@ -89,5 +95,7 @@ details.lr-result-explanation ul { padding: 0 24px 20px 42px; }
   .lr-workshop-options { grid-template-columns: 1fr; }
   .lr-workshop-confirm { flex-direction: column; align-items: stretch; }
   .lr-workshop > summary { flex-wrap: wrap; }
+  .lr-workshop-bank { align-items:flex-start; flex-wrap:wrap; }
+  .lr-workshop-bank > span { min-width:calc(100% - 40px); }
 }
 @media (prefers-reduced-motion: reduce) { .lr-projection-track > .is-restored { animation: none; } }

--- a/apps/web/src/components/games/longReturn/longReturnGame.js
+++ b/apps/web/src/components/games/longReturn/longReturnGame.js
@@ -396,33 +396,55 @@ function safestPlanForRoute(route, crew, strain, spentAbilities, scan) {
   return plans.sort((a, b) => a.risk - b.risk || b.margin - a.margin)[0] || null;
 }
 
-function routeAdvantage(plan, plans) {
-  if (plan.unresolvedHazards.length || plan.nativeRisk) return plan.nativeRisk ? 'Risk native contact' : 'Gamble for a larger haul';
-  if (plans.some((entry) => entry.unresolvedHazards.length || entry.nativeRisk)) return 'Predictable route';
+export function routeAdvantage(plan, plans) {
+  const uncertainty = (entry) => entry.unresolvedHazards.length + (entry.nativeRisk ? 1 : 0);
+  const currentUncertainty = uncertainty(plan);
+  const uncertaintyCounts = plans.map(uncertainty);
+  const leastUncertainty = Math.min(...uncertaintyCounts);
+  const mostUncertainty = Math.max(...uncertaintyCounts);
+  if (currentUncertainty === leastUncertainty && leastUncertainty < mostUncertainty) return 'Predictable route';
+  if (currentUncertainty === mostUncertainty && leastUncertainty < mostUncertainty) return plan.nativeRisk ? 'Risk native contact' : 'Gamble for a larger haul';
   if (plan.route.activeEffects && plan.route.activeEffects.length) return plan.route.activeEffects[0].label;
   const crewCost = plan.knownLeadStrain + plan.baseSupportStrain;
   const lowestCrew = Math.min(...plans.map((entry) => entry.knownLeadStrain + entry.baseSupportStrain));
   const lowestInstability = Math.min(...plans.map((entry) => entry.knownPressure));
   const highestSalvage = Math.max(...plans.map((entry) => entry.route.salvage));
+  const uniquelyLowestInstability = plan.knownPressure === lowestInstability && plans.filter((entry) => entry.knownPressure === lowestInstability).length === 1;
+  const uniquelyHighestSalvage = plan.route.salvage === highestSalvage && plans.filter((entry) => entry.route.salvage === highestSalvage).length === 1;
   if (crewCost === lowestCrew && plans.filter((entry) => entry.knownLeadStrain + entry.baseSupportStrain === lowestCrew).length === 1) return 'Easier on the crew';
-  if (plan.knownPressure === lowestInstability && plans.filter((entry) => entry.knownPressure === lowestInstability).length === 1) return 'Keeps the annex quieter';
-  if (plan.route.salvage === highestSalvage && plans.filter((entry) => entry.route.salvage === highestSalvage).length === 1) return 'More salvage';
+  if (uniquelyLowestInstability && uniquelyHighestSalvage) return 'Protects annex · more salvage';
+  if (uniquelyLowestInstability) return 'Protects annex stability';
+  if (uniquelyHighestSalvage) return 'More salvage';
   return plan.unresolvedHazards.length || plan.nativeRisk ? 'Uncertain route' : 'Balanced approach';
 }
 
-function recommendationFor(plans) {
+export function recommendationFor(plans) {
   if (plans.length < 2) return plans[0] ? { plan: plans[0], reason: 'This is the only viable route.' } : null;
   const ranked = [...plans].sort((a, b) => a.risk - b.risk);
   const [best, second] = ranked;
-  if (second.risk - best.risk < 10) return null;
   const bestUncertainty = best.unresolvedHazards.length + (best.nativeRisk ? 1 : 0);
   const secondUncertainty = second.unresolvedHazards.length + (second.nativeRisk ? 1 : 0);
-  if (bestUncertainty > secondUncertainty) return null;
-  const crewDifference = (second.knownLeadStrain + second.baseSupportStrain) - (best.knownLeadStrain + best.baseSupportStrain);
+  const bestCrewCost = best.knownLeadStrain + best.baseSupportStrain;
+  const secondCrewCost = second.knownLeadStrain + second.baseSupportStrain;
+  // A recommendation means there is no meaningful sacrifice hidden behind the badge.
+  // If the safer route asks for more of any visible resource or gives up salvage,
+  // leave the decision to the player and let the route labels carry the trade-off.
+  const clearlyDominates = bestCrewCost <= secondCrewCost
+    && best.knownPressure <= second.knownPressure
+    && bestUncertainty <= secondUncertainty
+    && best.route.salvage >= second.route.salvage
+    && (bestCrewCost < secondCrewCost
+      || best.knownPressure < second.knownPressure
+      || bestUncertainty < secondUncertainty
+      || best.route.salvage > second.route.salvage);
+  if (!clearlyDominates || best.margin < 0) return null;
+  const crewDifference = secondCrewCost - bestCrewCost;
   const instabilityDifference = second.knownPressure - best.knownPressure;
+  const salvageDifference = best.route.salvage - second.route.salvage;
   const reasons = [];
   if (crewDifference > 0) reasons.push(`${crewDifference} less projected energy use`);
   if (instabilityDifference > 0) reasons.push(`${instabilityDifference} less stability loss`);
+  if (salvageDifference > 0) reasons.push(`${salvageDifference} more salvage`);
   if (best.unresolvedHazards.length < second.unresolvedHazards.length) reasons.push('fewer unresolved hazards');
   if (best.nativeRisk !== second.nativeRisk && !best.nativeRisk) reasons.push('avoids likely native contact');
   return { plan: best, reason: reasons.length ? reasons.join(' and ') : 'a substantially safer known crossing' };
@@ -438,11 +460,28 @@ function trapDialogTab(event) {
   else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus(); }
 }
 
-function supportRoleForPlan(plan) {
+export function supportRoleForPlan(plan) {
+  if (plan.baseSupportStrain > 0) return `Intervenes · spends ${plan.baseSupportStrain} energy`;
   const alone = plan.rawMethodScore - plan.difficulty;
   if (alone < 0 && plan.margin >= 0) return 'Turns a failed attempt into a passage';
   if (alone < 14 && plan.margin >= 14) return 'Prevents the lead from losing 1 energy';
-  return 'Backup role · no energy spent unless needed';
+  return 'Backup role · no energy projected';
+}
+
+export function encounterNarrative({ archetype, option, nativeName, actorName, scoutName }) {
+  const actor = actorName || 'The crew';
+  if (option.companion) return `${nativeName} accepts the crew's help and follows at a cautious distance. It may intervene once during a later crossing.`;
+  if (option.resolution === 'detour') return 'The crew backs away before the encounter escalates and returns to the route junction.';
+  if (option.resolution === 'unresolved') return `${scoutName || actor} breaks contact and returns with a warning. The native still occupies the route.`;
+  if (archetype === 'territorial') {
+    if (option.id === 'distract' || option.id === 'challenge') return `${actor} draws ${nativeName} away from the passage. The crew slips through while it defends the decoy territory.`;
+    return `${actor} establishes a boundary the ${nativeName} accepts. It withdraws into the hull and leaves the passage open.`;
+  }
+  if (archetype === 'trapped') {
+    if (option.id === 'pin-rig' || option.id === 'force-arms') return `${actor} wrenches the authentication arms apart. ${nativeName} escapes as the damaged rig records the intrusion.`;
+    return `${actor} stills the authentication arms. ${nativeName} escapes into a side duct and its panicked signal fades from the lock.`;
+  }
+  return `${actor} forces enough space to continue. The native retreats deeper into the machinery.`;
 }
 
 function MechanicsModal({ open, onClose }) {
@@ -950,17 +989,13 @@ function LongReturnGame() {
     cueChanges({ energy: affected && (option.scoutStrain || option.crewStrain) ? { [affected.id]: option.scoutStrain || option.crewStrain } : {}, stability: option.instability || 0 });
     if (option.companion) setCompanion({ creature: encounterCreature, ready: true, benefit: scene.encounter.companionBenefit });
     const archetype = scene.encounter.archetype || 'injured';
-    const narrative = option.companion
-      ? `${encounterCreature.species} accepts the crew's help and follows at a cautious distance. It may intervene once during a later crossing.`
-      : archetype === 'territorial' && option.resolution === 'cleared'
-        ? `${affected ? affected.species : 'The crew'} establishes a boundary the ${encounterCreature.species} accepts. It withdraws into the hull and leaves the passage open.`
-        : archetype === 'trapped' && option.resolution === 'cleared'
-          ? `${affected ? affected.species : 'The crew'} stills the authentication arms. The ${encounterCreature.species} escapes into a side duct and its panicked signal fades from the lock.`
-      : option.resolution === 'cleared'
-        ? `${affected ? affected.species : 'The crew'} forces enough space to continue. The native retreats deeper into the machinery.`
-        : option.resolution === 'detour'
-          ? 'The crew backs away before the encounter escalates and returns to the route junction.'
-          : `${encounterState.scout.species} breaks contact and returns with a warning. The native still occupies the underdeck.`;
+    const narrative = encounterNarrative({
+      archetype,
+      option,
+      nativeName: encounterCreature.species,
+      actorName: affected ? affected.species : null,
+      scoutName: encounterState.scout ? encounterState.scout.species : null
+    });
     const result = { ...option, affected, narrative };
     const energyCost = option.scoutStrain || option.crewStrain || 0;
     const helper = option.companion ? crew.find((member) => option.label.includes(member.species)) : null;

--- a/apps/web/src/components/games/longReturn/longReturnGame.test.js
+++ b/apps/web/src/components/games/longReturn/longReturnGame.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import LongReturnGame from './longReturnGame';
+import LongReturnGame, { encounterNarrative, recommendationFor, routeAdvantage, supportRoleForPlan } from './longReturnGame';
 import { readCheckpoint } from './expeditionSave';
 
 vi.mock('../../xalianImage', () => ({ default: function MockXalianImage() { return <div data-testid="creature-portrait" />; } }));
@@ -503,5 +503,55 @@ describe('Long Return Simple mode', () => {
     selectRecommendedScout(container);
     expect(container.textContent).toContain('Trapped Signal-Mimic');
     expect(container.textContent).toMatch(/Release it from the arms|Mark the safe controls/i);
+  });
+});
+
+describe('Long Return decision language', () => {
+  const plan = (overrides = {}) => ({
+    route: { id: 'route', salvage: 2, activeEffects: [] },
+    knownLeadStrain: 1,
+    baseSupportStrain: 0,
+    knownPressure: 1,
+    unresolvedHazards: [],
+    nativeRisk: false,
+    risk: 20,
+    margin: 8,
+    rawMethodScore: 70,
+    difficulty: 68,
+    ...overrides
+  });
+
+  test('does not recommend a safer route when it gives up a visible resource', () => {
+    const safer = plan({ route: { id: 'safer', salvage: 1, activeEffects: [] }, risk: 5 });
+    const richer = plan({ route: { id: 'richer', salvage: 3, activeEffects: [] }, risk: 30, unresolvedHazards: [{ id: 'hidden' }] });
+    expect(recommendationFor([safer, richer])).toBeNull();
+  });
+
+  test('recommends only a route that clearly dominates the alternative', () => {
+    const best = plan({ route: { id: 'best', salvage: 3, activeEffects: [] }, knownLeadStrain: 0, knownPressure: 0, risk: 2, margin: 18 });
+    const worse = plan({ route: { id: 'worse', salvage: 2, activeEffects: [] }, knownLeadStrain: 1, knownPressure: 1, risk: 24, unresolvedHazards: [{ id: 'hidden' }] });
+    const recommendation = recommendationFor([best, worse]);
+    expect(recommendation.plan).toBe(best);
+    expect(recommendation.reason).toMatch(/1 less projected energy use.*1 less stability loss.*1 more salvage/i);
+  });
+
+  test('gives same-risk routes distinct player-facing trade-off labels', () => {
+    const largerHaul = plan({ route: { id: 'stabilize', salvage: 5, activeEffects: [] }, knownLeadStrain: 1, knownPressure: 1, unresolvedHazards: [{ id: 'dust' }] });
+    const lowerEnergy = plan({ route: { id: 'blackbox', salvage: 3, activeEffects: [] }, knownLeadStrain: 0, knownPressure: 3, unresolvedHazards: [{ id: 'dust' }] });
+    expect(routeAdvantage(largerHaul, [largerHaul, lowerEnergy])).toBe('Protects annex · more salvage');
+    expect(routeAdvantage(lowerEnergy, [largerHaul, lowerEnergy])).toBe('Easier on the crew');
+  });
+
+  test('states when support is projected to spend energy', () => {
+    expect(supportRoleForPlan(plan({ baseSupportStrain: 1 }))).toBe('Intervenes · spends 1 energy');
+    expect(supportRoleForPlan(plan())).toBe('Backup role · no energy projected');
+  });
+
+  test('gives territorial responses distinct outcome stories', () => {
+    const signal = encounterNarrative({ archetype: 'territorial', option: { id: 'signal-space', resolution: 'cleared' }, nativeName: 'Ectoghoul', actorName: 'Graviclaw' });
+    const distract = encounterNarrative({ archetype: 'territorial', option: { id: 'distract', resolution: 'cleared' }, nativeName: 'Ectoghoul', actorName: 'Graviclaw' });
+    expect(signal).toMatch(/boundary/i);
+    expect(distract).toMatch(/draws Ectoghoul away/i);
+    expect(distract).not.toBe(signal);
   });
 });

--- a/docs/LONG_RETURN_ROADMAP.md
+++ b/docs/LONG_RETURN_ROADMAP.md
@@ -4,6 +4,21 @@ This is the living execution checklist for the playable prototype. It complement
 
 Status key: `[ ]` queued · `[-]` active · `[x]` validated
 
+## Active milestone — full-mission release candidate
+
+Carry the clarity established in the opening through every ending. This pass is complete only when the live game—not merely the engine—can be played from briefing through voluntary extraction, forced extraction, and deep retrieval without an unexplained choice or silent state change.
+
+- [x] Replay all seven scenes in Simple mode and record the first point where route stakes, crew roles, or consequences stop being immediately legible.
+- [x] Exercise voluntary extraction, forced extraction, and deep retrieval as distinct end-to-end UI paths.
+- [x] Verify that salvage presents a real repair-now versus bank-for-score decision at every field-work opportunity.
+- [x] Verify that a recruited companion visibly changes a later crossing, then becomes visibly spent.
+- [x] Audit every transition family for meaningful beats, persistent receipts, skip behavior, and reduced-motion equivalence.
+- [x] Complete keyboard, narrow responsive, 200% text, reload/checkpoint, and sound-off passes on the final flow.
+- [x] Convert every defect found above into regression coverage, then rerun the complete web suite and production build.
+- [ ] Open a fresh PR from this worktree only after rebasing onto the latest `main` and obtaining a clean merge state.
+
+Validation record (2026-09-10): live Simple-mode runs reached voluntary extraction (5/7), forced extraction with the Index retained (5/7), and deep retrieval (7/7). The deep run recruited Xylum, consumed its one intervention, spent salvage on both energy recovery and annex bracing, and banked the remainder. Sound-off, 200% zoom, and a narrower-than-mobile-breakpoint zoom pass retained reachable route, back, and commit controls. Automated coverage validates keyboard focus, checkpoint recovery, duplicate-cost prevention, and the same ending families; the complete web suite passed 996 tests across 44 files and the Vite production build completed.
+
 ## Current milestone — one excellent decision loop
 
 Prove Scene 2 as a complete vertical slice: scout → contact → response → route → plan → crossing → persistent consequence. A fresh player should understand every trade-off without opening Game Rules.

--- a/docs/LONG_RETURN_ROADMAP.md
+++ b/docs/LONG_RETURN_ROADMAP.md
@@ -15,7 +15,7 @@ Carry the clarity established in the opening through every ending. This pass is 
 - [x] Audit every transition family for meaningful beats, persistent receipts, skip behavior, and reduced-motion equivalence.
 - [x] Complete keyboard, narrow responsive, 200% text, reload/checkpoint, and sound-off passes on the final flow.
 - [x] Convert every defect found above into regression coverage, then rerun the complete web suite and production build.
-- [ ] Open a fresh PR from this worktree only after rebasing onto the latest `main` and obtaining a clean merge state.
+- [x] Open a fresh PR from this worktree only after rebasing onto the latest `main` and obtaining a clean merge state.
 
 Validation record (2026-09-10): live Simple-mode runs reached voluntary extraction (5/7), forced extraction with the Index retained (5/7), and deep retrieval (7/7). The deep run recruited Xylum, consumed its one intervention, spent salvage on both energy recovery and annex bracing, and banked the remainder. Sound-off, 200% zoom, and a narrower-than-mobile-breakpoint zoom pass retained reachable route, back, and commit controls. Automated coverage validates keyboard focus, checkpoint recovery, duplicate-cost prevention, and the same ending families; the complete web suite passed 996 tests across 44 files and the Vite production build completed.
 


### PR DESCRIPTION
## Summary
- recommend routes only when one visibly dominates, and label meaningful route trade-offs distinctly
- make support energy commitments and encounter outcomes match the mechanics
- turn salvage recovery into an explicit repair-now versus bank-for-extraction decision
- record the completed seven-scene, companion, ending, sound-off, zoom, keyboard, and checkpoint validation pass

## Validation
- npm test -w apps/web -- --run (44 files, 996 tests)
- npm run build -w apps/web
- live Simple-mode playthroughs: voluntary extraction, forced extraction with Index retained, deep retrieval