### PR TITLE
Site DNS and HTTPS, and typecheck the web app in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        run: npm run typecheck -w apps/web
+
       - name: Test
         run: npm test -w apps/web -- --run --passWithNoTests
 
@@ -43,6 +46,9 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck -w packages/content
+
+      - name: Typecheck rules
+        run: npm run typecheck -w packages/rules
 
       - name: Test
         run: npm test -w packages/content

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,7 +57,8 @@
     "preview": "vite preview",
     "build-deploy": "npm run build && aws s3 sync build s3://xalians.com --delete",
     "deploy": "aws s3 sync build s3://xalians.com --delete",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "browserslist": {
     "production": [

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,6 +13,11 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    // packages/rules and packages/content are consumed as TypeScript source with
+    // no build step, and their own imports carry the .ts extension. noEmit is
+    // on here, so allowing it costs nothing and keeps this app's typecheck
+    // agreeing with the packages it imports.
+    "allowImportingTsExtensions": true,
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src", "vite.config.js", "../packages/rules/src"]

--- a/main.tf
+++ b/main.tf
@@ -595,7 +595,7 @@ resource "aws_cloudfront_distribution" "site" {
 
   default_cache_behavior {
     target_origin_id           = var.frontend_bucket_name
-    viewer_protocol_policy     = "allow-all"
+    viewer_protocol_policy     = "redirect-to-https"
     allowed_methods            = ["GET", "HEAD", "OPTIONS"]
     cached_methods             = ["GET", "HEAD"]
     compress                   = true
@@ -632,6 +632,40 @@ resource "aws_cloudfront_distribution" "site" {
 
   lifecycle {
     prevent_destroy = true
+  }
+}
+
+# The site's own DNS. The www record was created in the console alongside the
+# distribution and is imported here; the apex record is new -- xalians.com was
+# listed as a distribution alias and covered by the certificate, but had no
+# record, so only www resolved. Both are alias records to the distribution;
+# Z2FDTNDATAQYW2 is CloudFront's fixed hosted zone id.
+import {
+  to = aws_route53_record.site_www
+  id = "${var.hosted_zone_id}_www.${var.frontend_bucket_name}_A"
+}
+
+resource "aws_route53_record" "site_www" {
+  zone_id = data.aws_route53_zone.xalian_zone.zone_id
+  name    = "www.${var.frontend_bucket_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "site_apex" {
+  zone_id = data.aws_route53_zone.xalian_zone.zone_id
+  name    = var.frontend_bucket_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = true
   }
 }
 


### PR DESCRIPTION
Closes the loose ends from the live walk.

**HTTPS.** The distribution's viewer protocol policy moves from `allow-all` to `redirect-to-https`.

**Apex domain.** `xalians.com` was listed as a distribution alias and is covered by the certificate (`xalians.com` + `*.xalians.com`), but the hosted zone had no record for it, so only www resolved. Both records now live in Terraform: the www record is imported from the console, the apex record is created. Both are alias records to the distribution.

**Typecheck.** `apps/web` could not typecheck at all: it consumes `packages/rules` and `packages/content` as TypeScript source, and their imports carry the `.ts` extension, which the app's tsconfig did not allow. With `allowImportingTsExtensions` on (the app is `noEmit`, so nothing changes at build time) the run is clean. Added a `typecheck` script to `apps/web` and wired both it and `packages/rules` into CI, so this cannot silently rot again.

Local `terraform plan` against live state:

```
aws_cloudfront_distribution.site  ~ viewer_protocol_policy = "allow-all" -> "redirect-to-https"
aws_route53_record.site_www       will be imported (no diff)
aws_route53_record.site_apex      will be created
```

996 tests pass, build passes, all three typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)