### PR TITLE
Ratify depth as thickness

### DIFF
--- a/.claude/skills/build-ui/SKILL.md
+++ b/.claude/skills/build-ui/SKILL.md
@@ -8,6 +8,10 @@ allowed-tools: Read, Grep, Glob, Bash, Edit, Write
 
 Read `docs/DESIGN_SYSTEM.md` in full first; it is the contract for what things look like. `docs/design/frontend-stack-migration.md` is the contract for how they are built: Tailwind 4 tokens, shadcn components restyled to the system, Lucide icons, no Bootstrap. This skill is the order of operations.
 
+## Step 0: the five descriptors
+
+Instrument, warm, printed, physical, quiet. Before anything else, check the thing you are about to build against them: it is operated rather than read at, its neutrals carry a hue, its surfaces have grain rather than flat fill, it has thickness if and only if it can be pressed, and it does not compete with the content. See the top of `docs/DESIGN_SYSTEM.md`.
+
 ## Step 1: which tier
 
 Answer before writing markup: **does this screen read, browse, configure or manage, or is it play in progress?**

--- a/apps/web/src/pages/styleguide/depthSections.tsx
+++ b/apps/web/src/pages/styleguide/depthSections.tsx
@@ -1,55 +1,43 @@
 import * as React from 'react';
-import { Search, ZoomIn, ZoomOut } from 'lucide-react';
 
 import XalianImage from '../../components/xalianImage';
 import { SectionHead } from '@/components/system/masthead';
 import { Tile, TileArt, TileMeta } from '@/components/system/record';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
-import { Switch } from '@/components/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
 /**
- * Depth, round two (docs/design/v4-pressed-plate.html, 2026-09-10): the
- * pieces that shipped and, beside them, the pieces that were built for the
- * proposal and not carried into the system, rendered live on the room so
- * they can be judged on the real ground rather than a mockup. The "not
- * adopted" pieces are styled inline here on purpose: nothing in globals.css
- * or the components carries them, so deleting this section deletes them.
+ * Depth (docs/DESIGN_SYSTEM.md section 5.1, ratified 2026-09-11).
+ *
+ * Thickness means pressable. Every demo below is a real component reading the
+ * real rule, so nothing here can flatter the system: if a mass reads badly on
+ * this page it reads badly on a real one. The flat half matters as much as the
+ * thick half, because the rule only carries meaning while most things stay
+ * flat.
+ *
+ * The alternatives that were built for the proposal and judged live (mass
+ * straight down, mass on chips, mass under the switch knob, sinking slots, a
+ * record number on the plate) were set aside on 2026-09-11 and deleted with
+ * this pass. They are in the history of this file if one is ever reopened.
  */
 
-// A darker step under a level-2 key: the mass a secondary key would carry.
-const MASS_S2 = 'shadow-[0_3px_0_0_var(--color-glass)] hover:-translate-y-px hover:shadow-[0_4px_0_0_var(--color-glass)] active:translate-y-[3px] active:shadow-none';
-const MASS_PLAGUE = 'shadow-[0_3px_0_0_color-mix(in_srgb,var(--color-plague)_55%,black)] hover:-translate-y-px active:translate-y-[3px] active:shadow-none';
-const MASS_EL_XS = 'shadow-[0_2px_0_0_color-mix(in_srgb,var(--color-el)_50%,black)] hover:-translate-y-px active:translate-y-[2px] active:shadow-none';
-const MASS_EL_DIAG = 'shadow-[4px_4px_0_0_color-mix(in_srgb,var(--color-el)_45%,black)] hover:-translate-x-px hover:-translate-y-px hover:shadow-[5px_5px_0_0_color-mix(in_srgb,var(--color-el)_45%,black)] active:translate-x-1 active:translate-y-1 active:shadow-none';
-
-function Demo({ label, children, className = '' }: { label: string; children: React.ReactNode; className?: string }) {
+function Demo({ label, children }: { label: string; children: React.ReactNode }) {
     return (
-        <div className={`flex flex-col items-start gap-3 ${className}`}>
+        <div className="flex flex-col items-start gap-3">
             {children}
             <span className="type-legend text-ink-3">{label}</span>
         </div>
     );
 }
 
-function Verdict({ kept, children }: { kept: boolean; children: React.ReactNode }) {
+function SpeciesTile({ name, world, element }: { name: string; world: string; element: string }) {
     return (
-        <div className="mb-4 flex items-center gap-3">
-            <Badge variant={kept ? 'ok' : 'default'}>{kept ? 'Adopted' : 'Not adopted'}</Badge>
-            <span className="text-body text-ink-2">{children}</span>
-        </div>
-    );
-}
-
-function SpeciesTile({ name, world, element, className = '', num }: { name: string; world: string; element: string; className?: string; num?: string }) {
-    return (
-        <Tile href="#" onClick={(e) => e.preventDefault()} className={`el-${element} w-[168px] ${className}`}>
-            <TileArt className="relative">
+        <Tile href="#" onClick={(e) => e.preventDefault()} className={`el-${element} w-[168px]`}>
+            <TileArt>
                 <XalianImage colored speciesName={name} primaryType={element} moreClasses="w-full" />
-                {num ? <span className="type-data absolute right-2 top-1.5 text-[10.5px] text-black/60">{num}</span> : null}
             </TileArt>
             <TileMeta>
                 <span className="type-subhead block text-base">{name}</span>
@@ -59,128 +47,99 @@ function SpeciesTile({ name, world, element, className = '', num }: { name: stri
     );
 }
 
-function AdoptedBlock() {
+function Pressable() {
     return (
         <Card variant="panel" className="mt-6">
-            <Verdict kept>Thickness means pressable, on every key, toggle and tile: mass offset down and right in the ink (level-2 keys), the darker viable (primary) or the element dimmed (tiles). Textures instead of flat fills.</Verdict>
-            <div className="flex flex-wrap items-start gap-8 pb-2">
-                <Demo label="Primary key, 4px on viable-lo"><Button>Generate</Button></Demo>
-                <Demo label="Secondary and destructive, 3px in the ink"><div className="flex gap-4"><Button variant="secondary">Keep</Button><Button variant="destructive">Release</Button></div></Demo>
-                <Demo label="Segmented: selected is pressed"><ToggleGroup type="single" defaultValue="all" variant="outline">{['all', 'fire', 'water'].map((v) => <ToggleGroupItem key={v} value={v}>{v}</ToggleGroupItem>)}</ToggleGroup></Demo>
-                <Demo label="Element tile, its hue dimmed"><SpeciesTile name="Hypnopet" world="Telypso" element="psychic" /></Demo>
-                <Demo label="Wash: grain and vignette">
-                    <div className="el-fire w-[168px]"><XalianImage colored speciesName="Dromeus" primaryType="fire" moreClasses="w-full" /></div>
+            <p className="type-legend m-0 text-ink-2">Thick, because it can be pressed</p>
+            <p className="m-0 mt-2 max-w-[68ch] text-body text-ink-2">
+                The mass is solid, never blurred, cast down and to the right. Its color belongs to the
+                object: the ink under an ordinary key, the darker viable under the primary, a darkened
+                plague under destructive, the element dimmed under a tile. Hover lifts by one pixel and the
+                mass grows. Press moves the object into its own mass and the mass disappears.
+            </p>
+            <div className="mt-6 flex flex-wrap items-start gap-8 pb-2">
+                <Demo label="Primary key, on viable-lo"><Button>Generate</Button></Demo>
+                <Demo label="Secondary and destructive, in the ink">
+                    <div className="flex gap-4">
+                        <Button variant="secondary">Keep</Button>
+                        <Button variant="destructive">Release</Button>
+                    </div>
                 </Demo>
-                <Demo label="Level-0 grid (recessed card)">
-                    <Card variant="recessed" className="w-[260px]"><p className="type-legend m-0">Recessed</p><p className="m-0 mt-2 text-body text-ink-2">The 32px layout grid on level 0.</p></Card>
-                </Demo>
-                <Demo label="Room grain and edge vignette">
-                    <p className="m-0 max-w-[26ch] text-body text-ink-2">Under every chrome page; look at the left and right edges of this page at full width.</p>
-                </Demo>
-            </div>
-        </Card>
-    );
-}
-
-function NotAdoptedBlock() {
-    return (
-        <Card variant="panel" className="mt-6">
-            <Verdict kept={false}>Built for the proposal, left out of the system. Judge them on the real ground: a darker step under a dark key mostly vanishes.</Verdict>
-            <div className="flex flex-wrap items-start gap-8 pb-2">
-                <Demo label="Secondary key with mass, 3px"><Button variant="secondary" className={MASS_S2}>Keep</Button></Demo>
-                <Demo label="Destructive key with mass"><Button variant="destructive" className={MASS_PLAGUE}>Release</Button></Demo>
-                <Demo label="Icon key with mass"><Button variant="secondary" size="icon" aria-label="Search" className={MASS_S2}><Search /></Button></Demo>
-                <Demo label="Selected means pressed">
-                    <ToggleGroup type="single" defaultValue="all" variant="outline" className="pb-[3px]">
-                        {['all', 'fire', 'water', 'dark'].map((v) => (
-                            <ToggleGroupItem key={v} value={v} className={`${MASS_S2} data-[state=on]:translate-y-[3px] data-[state=on]:shadow-none data-[state=on]:hover:translate-y-[3px]`}>{v}</ToggleGroupItem>
+                <Demo label="Segmented: selected is already pressed">
+                    <ToggleGroup type="single" defaultValue="all" variant="outline">
+                        {['all', 'fire', 'water'].map((v) => (
+                            <ToggleGroupItem key={v} value={v}>{v}</ToggleGroupItem>
                         ))}
                     </ToggleGroup>
                 </Demo>
-                <Demo label="Filter chips with mass, 2px">
-                    <div className="flex gap-2">
-                        {[['fire', 'Fire'], ['water', 'Water'], ['psychic', 'Psychic']].map(([el, label]) => (
-                            <button key={el} type="button" className={`el-${el} ${MASS_EL_XS}`}><Badge variant="chip">{label}</Badge></button>
-                        ))}
-                    </div>
-                </Demo>
-                <Demo label="Switch knob with mass">
-                    <Switch defaultChecked className="[&>span]:shadow-[0_2px_0_0_rgba(0,0,0,0.45)]" />
-                </Demo>
-                <Demo label="Slot sinks (inset lip)">
-                    <Input placeholder="Worlds, species, terms" className="w-[280px] bg-room shadow-[inset_0_3px_0_0_rgba(0,0,0,0.45)]" />
-                </Demo>
-                <Demo label="Record number on the plate"><SpeciesTile name="Yetimoth" world="Krystos" element="ice" num="SP-029" /></Demo>
-                <Demo label="Diagonal mass"><SpeciesTile name="Hippochamp" world="Poseidas" element="water" className={`shadow-none ${MASS_EL_DIAG}`} /></Demo>
-                <Demo label="Icon group with mass">
-                    <div className="flex">
-                        <Button variant="secondary" size="icon" aria-label="Zoom in" className={`${MASS_S2} -mr-px`}><ZoomIn /></Button>
-                        <Button variant="secondary" size="icon" aria-label="Zoom out" className={MASS_S2}><ZoomOut /></Button>
-                    </div>
+                <Demo label="Tile, its own hue dimmed">
+                    <SpeciesTile name="Hypnopet" world="Telypso" element="psychic" />
                 </Demo>
             </div>
         </Card>
     );
 }
 
-// The mass matrix: the same secondary key and the same tile under every
-// combination Nick asked to compare (2026-09-10): mass color (a darker step,
-// the strong edge, the ink) by direction (straight down, diagonal).
-// Literal class strings on purpose: Tailwind only generates classes it can
-// read in the source, so a template string would silently produce nothing.
-const DOWN = 'hover:-translate-y-px active:translate-y-[3px] active:shadow-none';
-const DIAG = 'hover:-translate-x-px hover:-translate-y-px active:translate-x-[3px] active:translate-y-[3px] active:shadow-none';
-const MATRIX: { dir: string; cells: [string, string][] }[] = [
-    { dir: 'Down 3px', cells: [
-        ['Darker step', `shadow-[0_3px_0_0_var(--color-glass)] hover:shadow-[0_4px_0_0_var(--color-glass)] ${DOWN}`],
-        ['Edge', `shadow-[0_3px_0_0_var(--color-edge-strong)] hover:shadow-[0_4px_0_0_var(--color-edge-strong)] ${DOWN}`],
-        ['Ink-3', `shadow-[0_3px_0_0_var(--color-ink-3)] hover:shadow-[0_4px_0_0_var(--color-ink-3)] ${DOWN}`],
-        ['Ink-2', `shadow-[0_3px_0_0_var(--color-ink-2)] hover:shadow-[0_4px_0_0_var(--color-ink-2)] ${DOWN}`],
-        ['Outlined, ink-2', `border-ink-2 shadow-[0_3px_0_0_var(--color-ink-2)] hover:shadow-[0_4px_0_0_var(--color-ink-2)] ${DOWN}`],
-    ] },
-    { dir: 'Diagonal 3px', cells: [
-        ['Darker step', `shadow-[3px_3px_0_0_var(--color-glass)] hover:shadow-[4px_4px_0_0_var(--color-glass)] ${DIAG}`],
-        ['Edge', `shadow-[3px_3px_0_0_var(--color-edge-strong)] hover:shadow-[4px_4px_0_0_var(--color-edge-strong)] ${DIAG}`],
-        ['Ink-3', `shadow-[3px_3px_0_0_var(--color-ink-3)] hover:shadow-[4px_4px_0_0_var(--color-ink-3)] ${DIAG}`],
-        ['Ink-2', `shadow-[3px_3px_0_0_var(--color-ink-2)] hover:shadow-[4px_4px_0_0_var(--color-ink-2)] ${DIAG}`],
-        ['Outlined, ink-2', `border-ink-2 shadow-[3px_3px_0_0_var(--color-ink-2)] hover:shadow-[4px_4px_0_0_var(--color-ink-2)] ${DIAG}`],
-    ] },
-];
-
-function MassMatrix() {
+function Flat() {
     return (
         <Card variant="panel" className="mt-6">
-            <Verdict kept={false}>The secondary key under every mass color and direction. The last column outlines the key in the mass color, the way the reference button does.</Verdict>
-            <div className="overflow-x-auto">
-                <table className="w-auto border-separate border-spacing-x-8 border-spacing-y-4">
-                    <thead>
-                        <tr>
-                            <th className="type-legend text-left text-ink-3">Direction</th>
-                            {MATRIX[0].cells.map(([label]) => <th key={label} className="type-legend text-left text-ink-3">{label}</th>)}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {MATRIX.map(({ dir, cells }) => (
-                            <tr key={dir}>
-                                <td className="type-legend align-middle text-ink-3">{dir}</td>
-                                {cells.map(([label, cls]) => (
-                                    <td key={label} className="pb-[4px] align-middle"><Button variant="secondary" className={cls}>Keep</Button></td>
-                                ))}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-            <div className="mt-6 flex flex-wrap items-start gap-8">
-                <Demo label="Primary, down"><Button>Generate</Button></Demo>
-                <Demo label="Primary, diagonal (mass drawn by the holder)">
-                    <span className="relative inline-block isolate">
-                        <Button className="[&::after]:!translate-x-1 [&::after]:!translate-y-1 hover:[&::after]:!translate-x-[5px] hover:[&::after]:!translate-y-[5px] hover:!-translate-x-px hover:!-translate-y-px active:!translate-x-1 active:!translate-y-1 active:[&::after]:!translate-x-0 active:[&::after]:!translate-y-0">Generate</Button>
-                    </span>
+            <p className="type-legend m-0 text-ink-2">Flat, because it cannot</p>
+            <p className="m-0 mt-2 max-w-[68ch] text-body text-ink-2">
+                Cards, panels, badges, chips, inputs, slots and meters are read, not operated, so none of
+                them has thickness. This is the half that makes the other half mean something: give a card
+                a mass and a key stops announcing anything.
+            </p>
+            <div className="mt-6 flex flex-wrap items-start gap-8 pb-2">
+                <Demo label="Card">
+                    <Card variant="panel" className="w-[220px]">
+                        <p className="type-legend m-0">Panel</p>
+                        <p className="m-0 mt-2 text-body text-ink-2">Read, not pressed.</p>
+                    </Card>
                 </Demo>
-                <Demo label="Tile, down (adopted)"><SpeciesTile name="Akinza" world="Krystos" element="ice" /></Demo>
-                <Demo label="Tile, diagonal"><SpeciesTile name="Akinza" world="Krystos" element="ice" className={`shadow-none ${MASS_EL_DIAG}`} /></Demo>
-                <Demo label="Tile, diagonal, mass in edge"><SpeciesTile name="Akinza" world="Krystos" element="ice" className="shadow-none shadow-[4px_4px_0_0_var(--color-ink-3)] hover:-translate-x-px hover:-translate-y-px active:translate-x-1 active:translate-y-1 active:shadow-none" /></Demo>
+                <Demo label="Badges and chips">
+                    <div className="flex gap-2">
+                        <Badge variant="ok">Viable</Badge>
+                        <Badge variant="info">Pending</Badge>
+                        <span className="el-fire"><Badge variant="chip">Fire</Badge></span>
+                    </div>
+                </Demo>
+                <Demo label="Input"><Input placeholder="Worlds, species, terms" className="w-[260px]" /></Demo>
+                <Demo label="Recessed card, on the level-0 grid">
+                    <Card variant="recessed" className="w-[240px]">
+                        <p className="type-legend m-0">Recessed</p>
+                        <p className="m-0 mt-2 text-body text-ink-2">The 32px layout grid.</p>
+                    </Card>
+                </Demo>
+            </div>
+        </Card>
+    );
+}
+
+function Printed() {
+    return (
+        <Card variant="panel" className="mt-6">
+            <p className="type-legend m-0 text-ink-2">Printed, not filled</p>
+            <p className="m-0 mt-2 max-w-[68ch] text-body text-ink-2">
+                Nothing on the site is a flat fill. A wash carries fine grain over a vignette that deepens
+                its hue toward the edges, and the room itself wears the same grain with a vignette at the
+                left and right edges of the page.
+            </p>
+            <div className="mt-6 flex flex-wrap items-start gap-8 pb-2">
+                <Demo label="Element wash: grain and vignette">
+                    <div className="el-fire w-[168px]">
+                        <XalianImage colored speciesName="Dromeus" primaryType="fire" moreClasses="w-full" />
+                    </div>
+                </Demo>
+                <Demo label="Two types: the blend keeps the grain">
+                    <div className="el-ice w-[168px]">
+                        <XalianImage colored speciesName="Akinza" primaryType="ice" secondaryType="water" moreClasses="w-full" />
+                    </div>
+                </Demo>
+                <Demo label="Room grain and edge vignette">
+                    <p className="m-0 max-w-[26ch] text-body text-ink-2">
+                        Under every chrome page. Look at the left and right edges of this page at full width.
+                    </p>
+                </Demo>
             </div>
         </Card>
     );
@@ -188,15 +147,18 @@ function MassMatrix() {
 
 export const SECTIONS: { id: string; label: string; node: React.ReactNode }[] = [
     {
-        id: 'depth-2',
-        label: 'Depth, round two',
+        id: 'thickness',
+        label: 'Thickness',
         node: (
-            <section id="depth-2" className="mt-12">
-                <SectionHead title="Depth, round two" />
-                <p className="text-body text-ink-2">The pressed plate, 2026-09-10: what shipped, and what was built for the proposal and set aside. Hover and press everything.</p>
-                <AdoptedBlock />
-                <NotAdoptedBlock />
-                <MassMatrix />
+            <section id="thickness" className="mt-12">
+                <SectionHead title="Thickness" />
+                <p className="text-body text-ink-2">
+                    Thickness means pressable (section 5.1, ratified 2026-09-11). Hover and press everything
+                    here; the rule is only legible in motion.
+                </p>
+                <Pressable />
+                <Flat />
+                <Printed />
             </section>
         ),
     },

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -106,7 +106,7 @@
 	   tile. Flat things (cards, badges, content chips, slots) carry none. */
 	.mass-key {
 		--mass: var(--color-ink-3);
-		--thick: 3px;
+		--thick: var(--thickness-key);
 		box-shadow: inset 0 1px 0 var(--color-edge-hi), var(--thick) var(--thick) 0 0 var(--mass);
 		transition: transform 120ms ease-out, box-shadow 120ms ease-out, background-color 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
 	}
@@ -124,7 +124,7 @@
 	.key-primary {
 		--key-face: var(--color-viable);
 		--key-mass: var(--color-viable-lo);
-		--thick: 4px;
+		--thick: var(--thickness-primary);
 		position: relative;
 		isolation: isolate;
 		background: transparent;
@@ -149,7 +149,7 @@
 
 	/* An element tile is a plate you can lift: its mass is its own hue, dimmed. */
 	.mass-el {
-		--thick: 4px;
+		--thick: var(--thickness-tile);
 		--mass: color-mix(in srgb, var(--color-el) 45%, black);
 		box-shadow: var(--thick) var(--thick) 0 0 var(--mass);
 		transition: transform 120ms ease-out, box-shadow 120ms ease-out, background-color 120ms ease-out, border-color 120ms ease-out;

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -114,6 +114,14 @@
 	--radius-full: 9999px;
 	--shadow-float: 0 12px 28px rgba(0, 0, 0, 0.45);
 
+	/* Thickness: how far a pressable object stands off the surface behind it,
+	   cast down and to the right. The primary key is the thickest thing on any
+	   screen; ordinary keys and tiles are one step under it. Ratified
+	   2026-09-11. */
+	--thickness-key: 3px;
+	--thickness-primary: 4px;
+	--thickness-tile: 4px;
+
 	/* --- motion (section 7) --- */
 	--ease-out: cubic-bezier(0.2, 0.7, 0.2, 1);
 	--ease-in: cubic-bezier(0.6, 0, 0.8, 0.4);

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -8,6 +8,8 @@ Version 4 was ruled by Nick on 2026-09-08 and 2026-09-09 after the version 3 "on
 
 **Scope, ruled by Nick 2026-09-11: the games are out of scope for design work until they are built.** Reclamation, the duel board and reference, Long Return and the training games are all still being designed as games, so restyling them now would be spent twice. They are also the immersive tier, which is allowed to look like itself rather than like the chrome, so the cost of leaving them on version 3 is low. What is in scope is everything a visitor reads and operates: the home page, the encyclopedia, the generator, the account pages and the chrome around all of it. A game page is worth touching only when it is genuinely broken, when a change is cheap and self-contained, or when its own build work reaches the point of needing a look.
 
+**The five descriptors (ratified 2026-09-11).** New work is checked against these before it is checked against any rule below. The interface is an **instrument**: it is operated, and its controls look like they can be. It is **warm**: the neutrals carry a hue, and nothing is a pure gray or a pure black. It is **printed**: surfaces have grain and washes have vignettes, because nothing here is a flat fill. It is **physical**: a thing that can be pressed has thickness, and a thing that cannot does not. It is **quiet**: the accent is rare, the world lives in the content, and the interface does not compete with it.
+
 For interaction vocabulary, game-feel standards, quality scoring, playtest questions, and the living decision registry, also read [`GAME_EXPERIENCE_QUALITY_GUIDE.md`](./GAME_EXPERIENCE_QUALITY_GUIDE.md). This document defines how the interface looks; that guide defines how a game experience should communicate and behave.
 
 ## 1. The three tiers
@@ -138,12 +140,26 @@ The version 3 faces (Barlow Condensed, Barlow, IBM Plex Mono, Special Elite and 
 - **Space** is a 4 point scale: 4, 8, 12, 16, 24, 32, 48, 64 (`--g-1` to `--g-8`).
 - **Corners are square.** No radius anywhere except dots and toggles. Ruled 2026-09-09.
 - **The chamfer is the signature shape**, reserved for emphasis: a twelve pixel cut at top left and bottom right on the **glass tier** (live data), and an eight pixel cut on the **one primary key** per screen. Nothing else is cut. The cut echoes the logo's corners, and because it is rare it marks what is live and what is next. It is drawn as two clipped layers (an edge-colored layer and a one pixel inset surface layer) so the hairline follows the contour; `.g-glass` and `.g-key--primary` carry this and nothing else needs to.
-- **Depth is low.** Surfaces are told apart by tone and a hairline edge with one inset top highlight. Levels: page (`--g-room`), 0, 1, 2, glass, floating. Drop shadows exist only on things that float over the page: modal, drawer, popover, toast, menu, search results. The one shadow they cast is `--g-shadow-float`; no page CSS writes a literal shadow.
+- **Surfaces are told apart by tone,** a hairline edge and one inset top highlight, not by light. Levels: page (`--color-room`), 0, 1, 2, glass, floating. Nothing is lit, nothing glows, nothing is beveled.
 - The room keeps a very faint grain and edge vignette. It is not a flat fill.
 
-**Under review, not ratified (opened 2026-09-10).** The site currently carries more depth than the three bullets above describe: keys, toggles and tiles cast a solid diagonal mass down and to the right, in ink-3 under level-2 keys, viable-lo under the primary, and the element at 45 percent black under tiles. A pressed segment loses its mass without moving; flat things such as cards, badges and chips have none. The proposal is `docs/design/v4-pressed-plate.html`, the live comparison is the "Depth, round two" section of `/styleguide`, and the working phrase is that depth is thickness rather than light, so thickness means pressable. **Nick has not ruled on it.** Until he does, this section and section 13 describe the older, flatter rule while the site runs ahead of them. Do not remove the mass as a contract violation, and do not extend it to anything new.
+### 5.1 Depth is thickness (ratified 2026-09-11)
+
+**Thickness means pressable.** An object that can be pressed stands off the surface behind it and casts a solid, unblurred mass. An object that cannot has none. That is the whole rule, and it only carries meaning because most things stay flat.
+
+- **Direction is diagonal**, down and to the right, echoing the chamfer corner. Never straight down, never up, never to the left.
+- **The mass is colored by what it belongs to**, never by a generic shadow color: the ink under ordinary keys, `--color-viable-lo` under the primary key, a darkened plague under destructive, and the element's own hue at 45 percent black under a tile.
+- **Thickness comes from a token**, never a literal: `--thickness-key`, `--thickness-primary`, `--thickness-tile`. The primary key is the thickest thing on a screen.
+- **Pressing moves the object into its own mass.** Hover lifts it by one pixel and the mass grows by one. Active translates by the full thickness and the mass disappears. Disabled has neither.
+- **A selected segment is already pressed:** it loses its mass without moving, so a row of filters stays aligned and its unselected neighbors standing proud carry the message.
+- **What stays flat:** cards, panels, badges, chips, inputs, slots, meters, the masthead, anything purely being read. Adding mass to one of these is what would destroy the rule.
+- **Floating is a separate thing.** Modals, drawers, popovers, toasts, menus and search results cast `--shadow-float`, a real blurred drop shadow, because they float over the page rather than standing on it. No page CSS writes a literal shadow of either kind.
+
+**Set aside, 2026-09-11, after being built and judged live:** mass straight down rather than diagonal, mass on filter chips, mass under the switch knob, slots that sink into an inset lip, and a record number printed on the plate. Do not reintroduce one without a ruling.
 
 ## 6. Controls and states
+
+Every control in this section is pressable, so every one of them carries thickness (section 5.1): the mass in its own color, cast diagonally, taken back on press.
 
 Four ranks of button, five states each. Focus is always a two pixel ring in `--g-viable-hi`, offset two.
 
@@ -289,7 +305,8 @@ Each step is one PR, verified by paint with `scripts/design/snap.js`, auto-merge
 - Stat tile rows and equal-card feature grids on the home page. They are dashboard and marketing shapes.
 - Skeleton screens.
 - Rounded corners and pills, except dots and toggles.
-- Drop shadows on things that do not float. **Under review since 2026-09-10:** the solid diagonal mass now on keys and tiles is not a drop shadow in the blurred sense, but it is a shadow on something that does not float, and it is live. See the note at the end of section 5; Nick has not ruled.
+- Blurred drop shadows on anything that does not float. The solid diagonal mass under a pressable object (section 5.1) is not one of these and is the only shadow a resting object may cast.
+- Mass on anything that cannot be pressed. A card or a badge with thickness breaks what thickness means.
 - Whole-page scanlines, noise overlays, glow on surfaces, pulsing anything.
 - Fallout signals: Pip-Boy green as a screen wash, hazard yellow, atomic iconography. The mint is an accent on a full-color site, never a monochrome screen.
 - Orange as the accent. Withdrawn 2026-09-08.


### PR DESCRIPTION
Nick ruled on 2026-09-11: depth as thickness becomes the contract, and the set-aside alternatives stay out.

**The rule, now section 5.1.** Thickness means pressable. An object that can be pressed casts a solid, unblurred mass down and to the right; an object that cannot has none. The mass is colored by what it belongs to, never by a generic shadow color. Pressing moves the object into its own mass. A selected segment is already pressed, so it loses its mass without moving and a row of filters stays aligned. The section names what stays flat, because that half is what keeps the rule meaningful.

**Section 13** no longer contradicts the site. The ban is now on blurred drop shadows for anything that does not float, plus a new ban on mass for anything that cannot be pressed.

**The five descriptors** (instrument, warm, printed, physical, quiet) go in at the top of the contract, where a reader meets the design's character, and into the `build-ui` skill as step 0.

**Thickness is a token now.** `--thickness-key`, `--thickness-primary` and `--thickness-tile` replace three literals in `globals.css`.

**The set-aside pile is ruled out and deleted:** mass straight down rather than diagonal, mass on filter chips, mass under the switch knob, slots that sink into an inset lip, and a record number printed on the plate. The style guide's adopted-versus-not-adopted blocks and the mass matrix existed to let Nick judge those live, so they go too. In their place is a Thickness section documenting the ratified rule in three parts: what is thick, what is flat, and what is printed, all drawn with real components rather than mockups. It sits under its own nav entry, next to the existing Depth and corners section.

**Verified by paint** at 1440, reading computed styles rather than source: ink-3 at 3px diagonal under secondary, a darkened plague under destructive, the element's hue under tiles, the primary key drawing its own clipped mass, and nothing at all under cards, badges or inputs.

1006 tests pass, typecheck clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)