### PR TITLE
Encyclopedia: the reading measure holds everywhere

### DIFF
--- a/apps/web/src/components/encyclopedia/EntryView.js
+++ b/apps/web/src/components/encyclopedia/EntryView.js
@@ -184,7 +184,7 @@ export default function EntryView() {
                                             </Link>
                                         }
                                     >
-                                        <Prose text={rel.definition} except={rel.key} className="m-0 max-w-none text-small text-ink-2" />
+                                        <Prose text={rel.definition} except={rel.key} className="m-0 text-small text-ink-2" />
                                     </RecordRow>
                                 ))}
                             </Card>

--- a/apps/web/src/components/encyclopedia/Index.js
+++ b/apps/web/src/components/encyclopedia/Index.js
@@ -35,7 +35,7 @@ function IndexRecord({ entry }) {
                 </div>
             }
         >
-            <Prose text={entry.definition} except={entry.key} className="m-0 max-w-none text-small text-ink-2" />
+            <Prose text={entry.definition} except={entry.key} className="m-0 text-small text-ink-2" />
         </RecordRow>
     );
 }

--- a/apps/web/src/components/encyclopedia/Powers.js
+++ b/apps/web/src/components/encyclopedia/Powers.js
@@ -16,7 +16,7 @@ function EntryRecord({ entry }) {
                 </Link>
             }
         >
-            <Prose text={entry.definition} except={entry.key} className="m-0 max-w-none text-small text-ink-2" />
+            <Prose text={entry.definition} except={entry.key} className="m-0 text-small text-ink-2" />
         </RecordRow>
     );
 }
@@ -72,7 +72,7 @@ export default function Powers() {
                             }
                         >
                             {p.entry ? (
-                                <Prose text={p.entry.definition} except={p.entry.key} className="m-0 max-w-none text-small text-ink-2" />
+                                <Prose text={p.entry.definition} except={p.entry.key} className="m-0 text-small text-ink-2" />
                             ) : (
                                 <p className="type-data m-0 text-small text-ink-3">
                                     No entry on file; see {p.planet ? p.planet.name : 'their homeworld'}.

--- a/apps/web/src/components/encyclopedia/Prose.js
+++ b/apps/web/src/components/encyclopedia/Prose.js
@@ -14,7 +14,7 @@ export default function Prose({ text, except, as: Tag = 'p', className = '' }) {
     if (!text) return null;
     const segments = lore.linkify(text, { except });
     return (
-        <Tag className={`max-w-[62ch] font-body text-body text-ink ${className}`.trim()}>
+        <Tag className={`measure font-body text-body text-ink ${className}`.trim()}>
             {segments.map((seg, i) =>
                 seg.key ? (
                     <EntryHoverCard key={i} entryKey={seg.key}>

--- a/apps/web/src/components/encyclopedia/SpeciesView.js
+++ b/apps/web/src/components/encyclopedia/SpeciesView.js
@@ -263,7 +263,7 @@ export default function SpeciesView() {
                     {view.nameOrigin && (
                         <div className="flex flex-col gap-1">
                             <h3 className="type-heading m-0 text-[19px]">Name origin</h3>
-                            <p className="m-0 font-body text-body text-ink-2">{view.nameOrigin}</p>
+                            <p className="measure m-0 font-body text-body text-ink-2">{view.nameOrigin}</p>
                         </div>
                     )}
                     <Prose text={view.description} except={view.entry && view.entry.key} />
@@ -271,7 +271,7 @@ export default function SpeciesView() {
                     {Array.isArray(view.appearance) && view.appearance.length > 0 && (
                         <div className="flex flex-col gap-1">
                             <h3 className="type-heading m-0 text-[19px]">Appearance</h3>
-                            <ul className="m-0 flex list-none flex-col gap-1 p-0 font-body text-body text-ink-2">
+                            <ul className="measure m-0 flex list-none flex-col gap-1 p-0 font-body text-body text-ink-2">
                                 {view.appearance.map((quality) => (
                                     <li key={quality}>{quality}</li>
                                 ))}
@@ -282,7 +282,7 @@ export default function SpeciesView() {
                     {Array.isArray(view.fields) && view.fields.length > 0 && view.fields.map((field) => (
                         <div key={field.key} className="flex flex-col gap-1">
                             <h3 className="type-heading m-0 text-[19px]">{field.label}</h3>
-                            <p className="m-0 font-body text-body text-ink-2">{field.text}</p>
+                            <p className="measure m-0 font-body text-body text-ink-2">{field.text}</p>
                         </div>
                     ))}
                 </div>

--- a/apps/web/src/components/encyclopedia/Story.js
+++ b/apps/web/src/components/encyclopedia/Story.js
@@ -63,7 +63,7 @@ function NarratorBeat({ beat, indexInPart, beatCount }) {
 				</p>
 			)}
 			<h2 className="type-heading m-0">{beat.title}</h2>
-			<Prose text={beat.prose} className="max-w-none" />
+			<Prose text={beat.prose} />
 			<RecordsConsulted beat={beat} />
 		</Card>
 	);
@@ -113,7 +113,7 @@ function StoryParagraph({ world, index, text }) {
 			className="grid grid-cols-[8rem_minmax(0,1fr)] items-start gap-4 border-t border-edge py-4 first:border-t-0 max-sm:grid-cols-1"
 		>
 			<MarginNote world={world} index={index} read={read} />
-			<Prose text={text} className="m-0 max-w-none" />
+			<Prose text={text} className="m-0" />
 		</div>
 	);
 }

--- a/apps/web/src/components/encyclopedia/WorldView.js
+++ b/apps/web/src/components/encyclopedia/WorldView.js
@@ -253,16 +253,16 @@ export default function WorldView() {
 
                 <div className="flex min-w-0 flex-col gap-5">
                     <WorldLede world={world} />
-                </div>
-            </div>
 
-            <div className="mt-6 flex flex-col items-start gap-2 border-t border-edge pt-4">
-                <span className="type-legend whitespace-nowrap">In the story</span>
-                <nav className="min-w-0 flex flex-wrap gap-1" aria-label="In the story">
-                    {timeline.map((row) => (
-                        <ChronicleStation key={row.era.key} row={row} />
-                    ))}
-                </nav>
+                    <div className="flex flex-col items-start gap-2 border-t border-edge pt-4">
+                        <span className="type-legend whitespace-nowrap">In the story</span>
+                        <nav className="min-w-0 flex flex-wrap gap-1" aria-label="In the story">
+                            {timeline.map((row) => (
+                                <ChronicleStation key={row.era.key} row={row} />
+                            ))}
+                        </nav>
+                    </div>
+                </div>
             </div>
 
             <div className="mt-6 flex flex-col gap-6">
@@ -362,7 +362,7 @@ export default function WorldView() {
                                         </Link>
                                     }
                                 >
-                                    <Prose text={entry.definition} className="m-0 max-w-none text-small text-ink-2" />
+                                    <Prose text={entry.definition} className="m-0 text-small text-ink-2" />
                                 </RecordRow>
                             ))}
                         </Card>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -205,6 +205,9 @@
 	.type-heading { font-family: var(--font-legend); font-size: var(--text-heading); font-weight: 600; letter-spacing: var(--tracking-heading); text-transform: uppercase; color: var(--color-ink); }
 	.type-subhead { font-family: var(--font-legend); font-size: var(--text-subhead); font-weight: 500; letter-spacing: var(--tracking-heading); text-transform: uppercase; color: var(--color-ink); }
 	.type-data { font-family: var(--font-data); font-variant-numeric: tabular-nums; font-style: normal; }
+	/* The reading measure: running text sets near 62 characters however wide
+	   its container is. Every paragraph of prose on the site carries it. */
+	.measure { max-width: 62ch; }
 }
 
 @keyframes helix-rung {


### PR DESCRIPTION
Second page of the composition pass.

**The defect.** Running text is meant to set near 62 characters. On five views it did not, and I only caught it by measuring rendered paragraph widths rather than reading the source.

| View | Was | Why |
|---|---|---|
| Powers | 1118px, about 110 characters a line | passed `max-w-none` to `Prose` |
| World record, entries list | 1084px | same |
| Species record, five fields and name origin | 998px | never had a measure at all |
| Story beats | uncapped | opted out for no reason |

The `max-w-none` opt-out is correct inside a narrow card, where the cap never binds, and wrong in a full-width row, where it is the only thing holding the line length. Removing it changes nothing in the cards and fixes the rows.

**The measure is a named utility now** rather than a number retyped in each component, so the next paragraph someone writes inherits it instead of choosing one.

**One composition fix.** The world record's top block left its right half empty: a tall plate beside a single column of type, with a band of story chips in a separate band underneath. The chips move up into that column. It fills the space and puts what a world is next to where it appears in the story.

**Verified by paint** at 560, 760, 900, 1100 and 1440 across the reading room, the story, both record types, powers and the index. No paragraph now exceeds its measure at any width. The only truncation left is the chapter rail's one-line previews, which are deliberate.

1018 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)