### PR TITLE
Generator and account: the measure reaches the shared components

### DIFF
--- a/apps/web/src/components/record/RecordView.tsx
+++ b/apps/web/src/components/record/RecordView.tsx
@@ -75,7 +75,7 @@ function Ability({ ability }: { ability: XalianRecord['abilities'][number] }) {
 				{', through '}
 				<span title={medium.nature}>{medium.name.toLowerCase()}</span>.
 			</p>
-			{ability.description ? <p className="mt-2 mb-0 font-body text-body text-ink">{ability.description}</p> : null}
+			{ability.description ? <p className="measure mt-2 mb-0 font-body text-body text-ink">{ability.description}</p> : null}
 		</li>
 	);
 }

--- a/apps/web/src/components/system/readouts.tsx
+++ b/apps/web/src/components/system/readouts.tsx
@@ -128,7 +128,7 @@ function Callout({
       <Icon className={cn("mt-0.5 size-4 shrink-0", CALLOUT_ICON_CLASS[variant])} />
       <div className="min-w-0">
         <p className="type-legend m-0">{title}</p>
-        <div className="mt-1 font-body text-small text-ink-2">{children}</div>
+        <div className="measure mt-1 font-body text-small text-ink-2">{children}</div>
       </div>
     </div>
   )

--- a/apps/web/src/components/system/record.tsx
+++ b/apps/web/src/components/system/record.tsx
@@ -130,7 +130,7 @@ function EmptyState({
   return (
     <div data-slot="empty-state" className={cn("surface-0 border border-edge bg-s0 p-6", className)} {...props}>
       <p className="type-legend mb-3">{legend}</p>
-      <div className="font-body text-body text-ink-2">{children}</div>
+      <div className="measure font-body text-body text-ink-2">{children}</div>
     </div>
   )
 }

--- a/apps/web/src/pages/generatorPage.tsx
+++ b/apps/web/src/pages/generatorPage.tsx
@@ -159,7 +159,7 @@ function GeneratorPage() {
 					<Card variant="glass" className="mb-6 flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
 						<div className="min-w-0">
 							<p className="type-legend m-0">Generator profile</p>
-							<p className="mt-1 m-0 font-body text-small text-ink-2">
+							<p className="measure mt-1 m-0 font-body text-small text-ink-2">
 								Showroom prints commoners: standard finish, no rare traits, a single element. Unrestricted
 								is the full generator. This control is temporary while the economy is being explored.
 							</p>

--- a/apps/web/src/pages/userAccountPage.tsx
+++ b/apps/web/src/pages/userAccountPage.tsx
@@ -178,7 +178,9 @@ function UserAccountPage() {
 
 				{!isLoading && signedOut && (
 					<EmptyState legend="Sign in to see your Xalians">
-						<div className="mt-1 flex items-center gap-4">
+						Anything the Generator prints for you is written into the registry under your name, kept
+						at its own record, and drawn on for every game on the site.
+						<div className="mt-4 flex items-center gap-4">
 							<Button onClick={() => setSignInModalShow(true)}>Sign in</Button>
 							<Button variant="link" onClick={() => setSignupModalShow(true)}>Create account</Button>
 						</div>


### PR DESCRIPTION
Third and last page of the composition pass.

**Generator.** Two paragraphs ran past the reading measure, the widest at 1284 pixels. Rather than cap each one where it sits, the components they come from carry the measure now: a callout's body and an empty state's body are prose in a full-width band, so both take it, and every page using them inherits it rather than rediscovering the problem. The generator profile line and a record's ability description take it directly.

**Account.** The signed-out page said what to do without ever saying what for. It now names what an account is: what the Generator prints is written into the registry under your name, kept at its own record, and drawn on by every game on the site. That is the one page a visitor reaches with no idea what they would get.

**Verified by paint** at 1440. No paragraph on either page exceeds its measure.

With this the pass is done across home, the eight encyclopedia views, the generator and the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)