### PR TITLE
Navbar: the bar no longer overflows the viewport

### DIFF
--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -114,7 +114,10 @@ function XalianNavbar({ authAlertCallback }: XalianNavbarProps) {
 				<Shell className="flex min-h-14 items-center gap-6">
 					<BrandLockup />
 
-					<nav className="ml-2 hidden flex-1 items-center gap-5 md:flex" aria-label="Primary">
+					{/* The bar needs about 1155px for seven links plus the two auth keys,
+					    which is between lg and xl, so the switch to the sheet is measured
+					    rather than named. Below it the whole bar overflowed the viewport. */}
+					<nav className="ml-2 hidden flex-1 items-center gap-5 min-[1180px]:flex" aria-label="Primary">
 						{NAV_LINKS.map((link) => (
 							<NavLink
 								key={link.href}
@@ -129,7 +132,7 @@ function XalianNavbar({ authAlertCallback }: XalianNavbarProps) {
 						))}
 					</nav>
 
-					<div className="ml-auto hidden items-center gap-2 md:flex">
+					<div className="ml-auto hidden items-center gap-2 min-[1180px]:flex">
 						<AuthButtonGroup size="sm" authAlertCallback={handleUserAuthAction} />
 					</div>
 
@@ -138,7 +141,7 @@ function XalianNavbar({ authAlertCallback }: XalianNavbarProps) {
 							variant="ghost"
 							size="icon"
 							aria-label="Open menu"
-							className="ml-auto md:hidden"
+							className="ml-auto min-[1180px]:hidden"
 							onClick={() => setMenuOpen(true)}
 						>
 							<Menu />


### PR DESCRIPTION
Found while verifying the composition pass on the deployed site.

**The defect.** Every page scrolled sideways by 255 pixels at any viewport between 720 and 1000 wide. The navbar switched from its sheet menu to the full bar at `md`, but the bar needs about 1155 pixels for seven links plus the two auth keys. For roughly 280 pixels of the range it ran off the screen and dragged the whole document with it.

**Why nobody caught it.** Every audit so far sampled 390 and 1440, which sit on either side of the broken band.

**The fix.** The switch is a measured 1180 pixels now rather than a named breakpoint, which is where the content actually fits with headroom for a signed-in username. Below that the sheet menu covers the range it was always meant to. Moving it to `lg` was not enough; that only shifted the overflow to 1000 through 1155.

**Verified** at 390, 520, 720, 900, 1000, 1100, 1179, 1180, 1200, 1440 and 1920. No horizontal overflow at any of them.

**One thing for you.** The real reason the bar is that wide is that it carries seven top-level links, four of which are games. If the games were grouped under one Play entry the bar would fit comfortably from about 900 up. That is a navigation decision rather than a layout fix, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)