### PR TITLE
Record plate: four columns wait until they fit

### DIFF
--- a/apps/web/src/components/system/record.tsx
+++ b/apps/web/src/components/system/record.tsx
@@ -23,8 +23,11 @@ function SpecPlate({
       data-slot="spec-plate"
       className={cn(
         "m-0 grid items-baseline gap-x-6 gap-y-2",
+        // Four columns need real width: two 9rem labels alone are 288px, so in
+        // a 350px column (the record header at 760) the value tracks collapsed
+        // to nothing and their content spilled off the page. It waits for lg.
         columns === 2
-          ? "grid-cols-[minmax(7rem,max-content)_minmax(0,1fr)] md:grid-cols-[minmax(9rem,max-content)_minmax(0,1fr)_minmax(9rem,max-content)_minmax(0,1fr)]"
+          ? "grid-cols-[minmax(7rem,max-content)_minmax(0,1fr)] lg:grid-cols-[minmax(9rem,max-content)_minmax(0,1fr)_minmax(9rem,max-content)_minmax(0,1fr)]"
           : "grid-cols-[minmax(7rem,max-content)_minmax(0,1fr)]",
         className
       )}
@@ -33,7 +36,7 @@ function SpecPlate({
       {entries.map((e, i) => (
         <React.Fragment key={i}>
           <dt className="type-legend">{e.key}</dt>
-          <dd className={cn("m-0 text-small text-ink", e.body ? "font-body" : "type-data", nowrap && "whitespace-nowrap")}>{e.value}</dd>
+          <dd className={cn("m-0 min-w-0 text-small text-ink wrap-anywhere", e.body ? "font-body" : "type-data", nowrap && "whitespace-nowrap")}>{e.value}</dd>
         </React.Fragment>
       ))}
     </dl>


### PR DESCRIPTION
Last defect from the composition pass, found on the deployed site at a width the earlier sweeps did not sample.

**The defect.** The generator pushed 53 pixels off the right edge at 760 wide, and 93 at 720. The two-across spec plate switched to four columns at `md`, but two 9rem label tracks alone are 288 pixels, and in the record header at that width the plate sits in a 350 pixel column. The value tracks collapsed to zero and their contents, an origin link and a 40-character identifier, spilled past the viewport and dragged the document with them.

**The fix.** Four columns wait for `lg`, where there is room for them. A value also wraps anywhere now rather than running out of its track, so a long identifier or seed breaks instead of escaping. Both matter: the breakpoint fixes this case, the wrapping stops the next one.

**Verified** at 390, 560, 720, 760, 820, 900, 1000, 1100 and 1440. No horizontal overflow at any of them, and the identity block reads as a clean two-column list at the narrow end.

With this, all eleven in-scope pages are clean across five widths: no horizontal overflow and no prose past its measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)