### PR TITLE
Consolidate frontend font loading

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -20,28 +20,12 @@
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
-  <link href='https://fonts.googleapis.com/css?family=Abel' rel='stylesheet'>
-
-  <!-- Google Fonts -->
-
-  <!-- Generator Console: technical display + the machine's monospace voice.
-       Barlow Condensed is the core --g-font-legend face (round3-coherence.md
-       "one type system"), loaded at 500/600; Oswald stays only as its
-       fallback in the --g-font-legend stack, no longer read directly by any
-       terminal. -->
+  <!-- The requested faces are limited to live type roles and consolidated so
+       parsing waits on one Google Fonts stylesheet instead of four. The CSS
+       stacks retain local/system fallbacks for offline and failed-font use. -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600&family=Oswald:wght@400;500;600;700&family=Barlow:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-
-  <!-- v3 terminals ("one relay, many terminals", docs/DESIGN_SYSTEM.md): one
-       legend/output/paper face per terminal, plus the fonts its furniture
-       uses (Caveat for the archive's pencil note). Kept until every page
-       migrates off data-terminal (section 11). -->
-  <link href="https://fonts.googleapis.com/css2?family=Michroma&family=Share+Tech+Mono&family=Cinzel:wght@500;700&family=Spectral:ital,wght@0,400;0,600;1,400&family=Chakra+Petch:wght@500;600&family=Space+Mono&family=Special+Elite&family=Caveat:wght@500&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet">
-
-  <!-- Design system v4 (docs/DESIGN_SYSTEM.md section 4 and 8): Saira for
-       anything that labels or heads, Atkinson Hyperlegible for prose,
-       Martian Mono for values, Iceland for the wordmark only. -->
-  <link href="https://fonts.googleapis.com/css2?family=Saira:wght@500;600;700&family=Atkinson+Hyperlegible:wght@400;700&family=Martian+Mono:wght@400;500&family=Iceland&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Abel&family=Atkinson+Hyperlegible:wght@400;700&family=Cinzel:wght@500&family=Iceland&family=Martian+Mono:wght@400;500&family=Michroma&family=Saira:wght@500;600;700&display=swap" rel="stylesheet">
   <!-- Immersive v3 compatibility CSS is imported only by the lazy game entries.
        Chrome pages receive the Tailwind/v4 layer above and nothing legacy. -->
 

--- a/apps/web/src/__tests__/fontLoading.test.js
+++ b/apps/web/src/__tests__/fontLoading.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+const WEB_ROOT = path.resolve(__dirname, '../..');
+const read = (relativePath) => fs.readFileSync(path.join(WEB_ROOT, relativePath), 'utf8');
+
+describe('font loading', () => {
+	const html = read('index.html');
+	const stylesheetUrls = [...html.matchAll(/<link\s+href="([^"]+)"\s+rel="stylesheet">/g)]
+		.map((match) => match[1])
+		.filter((href) => href.startsWith('https://fonts.googleapis.com/'));
+
+	it('uses one Google Fonts request and preconnects both origins', () => {
+		expect(stylesheetUrls).toHaveLength(1);
+		expect(html).toContain('<link rel="preconnect" href="https://fonts.googleapis.com">');
+		expect(html).toContain('<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>');
+	});
+
+	it('requests only the audited live families and variants', () => {
+		const url = new URL(stylesheetUrls[0]);
+		expect(url.searchParams.getAll('family')).toEqual([
+			'Abel',
+			'Atkinson Hyperlegible:wght@400;700',
+			'Cinzel:wght@500',
+			'Iceland',
+			'Martian Mono:wght@400;500',
+			'Michroma',
+			'Saira:wght@500;600;700',
+		]);
+		expect(url.searchParams.get('display')).toBe('swap');
+	});
+
+	it('keeps retired remote fallbacks out of the blocking request', () => {
+		const requested = stylesheetUrls[0];
+		[
+			'Barlow',
+			'IBM+Plex',
+			'Oswald',
+			'Share+Tech',
+			'Space+Mono',
+			'Special+Elite',
+			'Caveat',
+			'Spectral',
+			'Chakra+Petch',
+		].forEach((family) => expect(requested).not.toContain(family));
+	});
+});

--- a/apps/web/src/styles/legacy/system.css
+++ b/apps/web/src/styles/legacy/system.css
@@ -231,16 +231,10 @@
 	--g-chart-cursor-fill: #ffffff25;
 	--g-chart-axis: #ddd4bd;
 
-	/* --- type -------------------------------------------------------------
-	   Oswald is a mid-century poster and signage face: the condensed caps
-	   stencilled onto equipment and painted on placards. IBM Plex Mono is the
-	   machine's own output — a terminal line, a printed slip. Neither is a
-	   "sci-fi" typeface, because the fiction is industrial, not futuristic. */
+	/* --- type ------------------------------------------------------------- */
 	--g-font-ui: var(--g-font-body);
 
-	/* --g-size-micro/--g-size-tiny bumped a hair for Barlow Condensed: its
-	   caps run a touch smaller than Oswald's at the same rem size, and the
-	   smallest legends (asset plates, tabs) were the first to feel thin. */
+	/* Small legends stay a hair larger so condensed Saira caps remain legible. */
 	--g-size-micro: 0.7rem;
 	--g-size-tiny: 0.8125rem;
 	--g-size-small: 0.875rem;
@@ -251,11 +245,7 @@
 	--g-size-h1: clamp(2.5rem, 1.8rem + 3.4vw, 4.25rem);
 	--g-size-readout: clamp(1.75rem, 1.2rem + 2.2vw, 2.75rem);
 
-	/* Re-tuned once for Barlow Condensed (round3-coherence.md): it is already
-	   a condensed face, unlike Oswald's semi-condensed, so the same tracking
-	   read airy rather than stencilled. Pulled in a touch and the small
-	   sizes bumped so caps at --g-size-tiny/--g-size-micro stay legible at
-	   the tighter spacing. */
+	/* Tracking is tuned for condensed Saira at the smallest legend sizes. */
 	--g-track-label: 0.1em;
 	--g-track-wide: 0.2em;
 
@@ -343,12 +333,9 @@
 	--g-paper-ink-faint: #5c584d;
 	--g-paper-rule: rgba(35, 35, 26, 0.2);
 
-	/* One type system, core (Rule A / round3-coherence.md): Barlow Condensed
-	   is the legend face everywhere, IBM Plex Mono the machine's output
-	   everywhere, Special Elite the typewriter everywhere, Barlow the prose
-	   everywhere. No [data-terminal] block below overrides any of these four
-	   — the v3 build let each terminal set its own legend face and that was
-	   the single biggest thing that made the site read as six unrelated
+	/* One type system, core (Rule A / round3-coherence.md): no
+	   [data-terminal] block overrides the shared legend, output, paper, or
+	   prose roles. The v3 build did, making the site read as unrelated
 	   products (docs/DESIGN_SYSTEM.md Rule A). */
 	/* --g-font-legend is declared once, above, as the v4 primitive (Saira). */
 	--g-font-out: var(--g-font-data);

--- a/apps/web/src/styles/legacy/tokens.css
+++ b/apps/web/src/styles/legacy/tokens.css
@@ -83,10 +83,6 @@
 	--x-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.5);
 	--x-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.6);
 
-	/* the old display font is gone; these now resolve to the console faces */
-	--x-font-display: 'Oswald', 'Barlow Condensed', Impact, sans-serif;
-	--x-font-body: 'Barlow', system-ui, sans-serif;
-
 	--x-text-xs: 0.75rem;
 	--x-text-sm: 0.875rem;
 	--x-text-md: 1rem;

--- a/docs/design/frontend-css-ownership.md
+++ b/docs/design/frontend-css-ownership.md
@@ -104,8 +104,8 @@ The remaining 885-byte `style.css` contains only element defaults and no class/i
 
 Focused ownership/design-system tests, typecheck, 52 files / 1,031 tests, dependency audit, production build, and every existing budget pass.
 
-## Remaining audit sequence
+PR [#236, Fold final immersive defaults into system CSS](https://github.com/nickcjordan/Xalians/pull/236) merged as `ccd2af6`. CI run `34620786800`, Terraform-plan run `34620786888`, and production deploy `34620942570` passed with empty annotation streams. The deployed stylesheet was byte-identical to the already verified #235 artifact, so the source consolidation had no browser-visible production delta.
 
-1. Continue the selector-use report for non-foundation sections of `system.css`; verify ambiguous selectors and library-generated state classes in the browser before deletion.
-2. Move any surviving route-only rules from `system.css` to the narrowest owner.
-3. Tighten route CSS budgets after every deletion, then remove Tailwind's temporary `important` interop once no legacy specificity requires it.
+## Completion boundary
+
+The ownership audit is complete: chrome receives no immersive compatibility CSS, every route stylesheet has an explicit importer set and budget, and the shared immersive graph contains only tokens plus cross-game terminal foundations. Further removal from `system.css` now belongs to an individual experience's visual migration, where selectors can be retired with that route's markup rather than guessed globally. Tailwind's temporary `important` interop remains a separate runtime-stack concern after the immersive routes leave the compatibility layer.

--- a/docs/design/frontend-font-loading.md
+++ b/docs/design/frontend-font-loading.md
@@ -1,0 +1,44 @@
+# Frontend font loading audit
+
+Audit date: 2026-09-11  
+Starting point: `ccd2af6` (`main` after PR #236)
+
+## Loading boundary
+
+The application shell owns font loading because the chrome is present on every route and immersive routes retain the same v4 core type roles. `index.html` now makes one Google Fonts CSS request with `display=swap` and preconnects both `fonts.googleapis.com` and `fonts.gstatic.com`. CSS stacks retain system fallbacks so content remains readable when remote fonts are unavailable.
+
+## Retained request
+
+| Family | Requested variants | Live role | Live routes |
+| --- | --- | --- | --- |
+| Abel | 400 | Final immersive `body` default for content that has not yet adopted a role token | Match, Physics, Duel board/reference, Reclamation, Long Return |
+| Atkinson Hyperlegible | 400, 700 | `--font-body` and `--g-font-body`; regular prose plus inherited bold prose | All chrome routes and all immersive routes |
+| Cinzel | 500 | Registry `--g-font-nameplate`, rendered by `.g-nameplate` | Duel board and Duel reference |
+| Iceland | 400 | `--font-brand` and `--g-font-brand` wordmarks | Application shell and immersive brand lockups |
+| Martian Mono | 400, 500 | `--font-data` and `--g-font-data`; readouts and values | All chrome routes and all immersive routes |
+| Michroma | 400 | Field `--g-font-nameplate`, rendered by `.g-nameplate` | Reclamation |
+| Saira | 500, 600, 700 | `--font-legend` and `--g-font-legend`; labels, headings, and emphasized immersive legends | All chrome routes and all immersive routes |
+
+The retained request therefore contains 7 families and 11 explicit family/weight variants. Existing synthetic weights are intentionally unchanged: for example, Michroma 500 and Martian Mono 600/700 already resolve from their nearest requested face.
+
+## Removed from the request
+
+| Family | Previous variants | Reason |
+| --- | --- | --- |
+| Barlow Condensed | 500, 600 | Remote fallback behind live Saira; never selected when the primary face loads |
+| Oswald | 400, 500, 600, 700 | Only referenced by two unused legacy aliases, which were deleted |
+| Barlow | 400, 500, 600 | Remote fallback behind live Atkinson Hyperlegible; never selected when the primary face loads |
+| IBM Plex Mono | 400, 500, 600 | Remote fallback behind live Martian Mono or inside dormant paper/panel roles |
+| Share Tech Mono | 400 | No executable selector or token consumer |
+| Space Mono | 400 | No executable selector or token consumer |
+| IBM Plex Sans | 400, 500 | No executable selector or token consumer |
+| Special Elite | 400 | Only the dormant `.g-paper` compatibility role; no executable markup emits it |
+| Caveat | 500 | Only dormant `.g-pencil`; no executable markup emits it |
+| Spectral | normal 400/600, italic 400 | Nameplate for dormant `data-terminal="archive"`; no executable route emits that terminal |
+| Chakra Petch | 500, 600 | Nameplate for dormant `data-terminal="relay"`; no executable route emits that terminal |
+
+The dormant compatibility selectors keep their authored font stacks. If one returns to executable markup, its primary face must be deliberately restored to the request or replaced as part of that route's migration.
+
+## Guardrail
+
+`fontLoading.test.js` locks the single-request boundary, both preconnects, `display=swap`, the exact retained family/variant list, and the retired remote families. Any new face therefore requires an explicit audit update rather than silently expanding the blocking application-shell request.

--- a/docs/design/frontend-modernization-roadmap.md
+++ b/docs/design/frontend-modernization-roadmap.md
@@ -73,7 +73,7 @@ None. This is first because every later PR benefits from clean workflow output.
 - Deploy: [frontend run 34608744209](https://github.com/nickcjordan/Xalians/actions/runs/34608744209) and [backend run 34608744217](https://github.com/nickcjordan/Xalians/actions/runs/34608744217) passed with checkout v7, setup-node v7, AWS credentials v6, and Terraform setup v4. Both production job-annotation responses were empty.
 - Production verification: `https://xalians.com/` and `/duel` loaded at 1,440×900 and 390×844 with no page/console errors or document-level horizontal overflow. Home and Duel setup paints matched the pre-change smoke check.
 
-### 2. Legacy CSS ownership and route boundaries — In progress
+### 2. Legacy CSS ownership and route boundaries — Complete
 
 **Scope**
 
@@ -147,8 +147,11 @@ Do before the font pass so font consumers can be attributed to their final CSS o
 - Sixth selector-audit deploy: [frontend run 34620056308](https://github.com/nickcjordan/Xalians/actions/runs/34620056308) passed its production build, S3 sync, and CloudFront invalidation with an empty job-annotation response.
 - Sixth selector-audit production verification: all eleven routes loaded at 1,440×900 and 390×844 without console errors or new overflow. A started Match rendered all 16 faces and backs, and a started Duel rendered 64 cells plus eight aligned, gradient-painted badges at both widths. The previously tracked Duel-reference phone overflow is unchanged.
 - Final shared-file consolidation: the 885-byte, zero-class residual `style.css` is appended unchanged to `system.css`, preserving its final cascade position, then deleted from the shared import graph. The emitted immersive artifact remains byte-identical at `immersive-B5YtPtE8.css` (57.63/11.79 kB), so no route budget changes. Focused ownership/design-system tests, typecheck, 52 files / 1,031 tests, zero production vulnerabilities, production build, and every budget pass.
+- Final consolidation PR: [#236, Fold final immersive defaults into system CSS](https://github.com/nickcjordan/Xalians/pull/236), merged as `ccd2af6` on 2026-09-11.
+- Final consolidation CI: [CI run 34620786800](https://github.com/nickcjordan/Xalians/actions/runs/34620786800) and [Terraform-plan run 34620786888](https://github.com/nickcjordan/Xalians/actions/runs/34620786888) passed; Linux reproduced 52 frontend files / 1,031 tests, 12 content files / 37 tests, zero dependency vulnerabilities, the byte-identical asset, and every bundle budget. All three job-annotation responses were empty.
+- Final consolidation deploy: [frontend run 34620942570](https://github.com/nickcjordan/Xalians/actions/runs/34620942570) passed its production build, S3 sync, and CloudFront invalidation with an empty job-annotation response. Because the emitted artifact was byte-for-byte identical to the already verified #235 production asset, the deployment introduced no browser-visible route delta to re-test.
 
-### 3. Font loading — Planned
+### 3. Font loading — In progress
 
 **Scope**
 
@@ -156,7 +159,9 @@ Map actual face/weight/style use after CSS ownership is clear; consolidate reque
 
 **Measured baseline**
 
-At the program baseline, `index.html` issued four Google Fonts stylesheet requests representing 18 families and approximately 35 requested face/style variants. It includes a standalone Abel request, broad legacy terminal families, and the v4 family request. Only `fonts.gstatic.com` is preconnected; `fonts.googleapis.com` is not. The first selector-audit slice removes both unused 10,144-byte copies of `ProcrastinatingPixie-WyVOO.ttf` and its dead `@font-face`; the broader live-face audit remains here.
+At the program baseline, `index.html` issued four Google Fonts stylesheet requests representing 18 families and approximately 35 requested face/style variants. It included a standalone Abel request, broad legacy terminal families, and the v4 family request. Only `fonts.gstatic.com` was preconnected; `fonts.googleapis.com` was not. The first selector-audit slice removed both unused 10,144-byte copies of `ProcrastinatingPixie-WyVOO.ttf` and its dead `@font-face`.
+
+The live-consumer audit now narrows the request to seven families and eleven explicit family/weight variants. With the same Chrome user agent, Google Fonts returns 11,682 bytes / 27 subset `@font-face` rules for the consolidated request versus 45,453 bytes / 124 rules across the four prior requests, a 74.3% CSS response reduction. The two active terminal nameplate faces are retained; remote fallback-only, unreferenced, and dormant-terminal faces are removed from the request while their readable CSS fallback stacks remain.
 
 **Acceptance criteria**
 
@@ -171,7 +176,10 @@ Legacy CSS ownership audit.
 
 **Evidence / links**
 
-Pending.
+- Checked-in family/variant/route audit: [`docs/design/frontend-font-loading.md`](frontend-font-loading.md).
+- Automated guard: `fontLoading.test.js` enforces one request, both connection hints, `display=swap`, the exact retained variants, and the retired-family set.
+- Local verification: focused font/ownership/design-system tests, typecheck, 53 files / 1,034 tests, zero production vulnerabilities, production build, and every bundle budget pass. All eleven route entries render without loading/error residue at 1,440×900 and 390×844; desktop chrome and mobile Reclamation typography remain visually consistent with production.
+- PR, CI, deployment, and production font-resource evidence pending.
 
 ### 4. Cognito authentication integration coverage — Planned
 


### PR DESCRIPTION
## Summary
- consolidate four Google Fonts stylesheets into one request with both origin preconnects
- remove remote fallback-only, unreferenced, and dormant-terminal faces while preserving live visual roles
- add a checked-in family/variant/route audit and an automated loading contract
- close out the completed CSS ownership workstream evidence

## Measured result
- requested families: 18 -> 7
- explicit family/weight variants: 35 -> 11
- Google Fonts CSS response (same Chrome UA): 45,453 -> 11,682 bytes (-74.3%)
- generated subset rules: 124 -> 27

## Verification
- npm run typecheck -w apps/web
- npm test -w apps/web -- --run (53 files, 1,034 tests)
- npm audit --omit=dev (0 vulnerabilities)
- npm run build -w apps/web (all bundle budgets pass)
- all 11 route entries at 1440x900 and 390x844; chrome and active terminal typography visually checked