### PR TITLE
Cover frontend authentication boundaries

### DIFF
--- a/apps/web/src/components/auth/authButtonGroup.test.js
+++ b/apps/web/src/components/auth/authButtonGroup.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
@@ -11,11 +11,25 @@ vi.mock('aws-amplify/utils', () => ({
 vi.mock('../../utils/authUtil', () => ({
 	currentUser: vi.fn().mockResolvedValue(null),
 	buildAuthState: vi.fn(),
+	confirmSignUp: vi.fn(),
+	resendConfirmationCode: vi.fn(),
 	signIn: vi.fn(),
 	signOut: vi.fn().mockResolvedValue(true),
+	signUp: vi.fn(),
 }));
 
 import AuthButtonGroup from './authButtonGroup';
+import * as authUtil from '../../utils/authUtil';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	authUtil.currentUser.mockResolvedValue(null);
+	authUtil.buildAuthState.mockImplementation((data) => ({
+		username: data.username,
+		hasVerifiedEmail: data.attributes.email_verified === true,
+	}));
+	authUtil.signUp.mockResolvedValue({ isSignUpComplete: false });
+});
 
 describe('AuthButtonGroup', () => {
 	it('loads the sign-in form only after the user asks for it', async () => {
@@ -31,5 +45,75 @@ describe('AuthButtonGroup', () => {
 		await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
 		expect(await screen.findByRole('heading', { name: 'Sign in' })).toBeInTheDocument();
+	});
+
+	it('keeps signed-out controls usable when the initial Cognito probe fails', async () => {
+		authUtil.currentUser.mockRejectedValue(new Error('service unavailable'));
+		render(
+			<MemoryRouter>
+				<AuthButtonGroup authAlertCallback={vi.fn()} />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByRole('button', { name: 'Sign in' })).toBeEnabled();
+		expect(screen.getByRole('button', { name: 'Create account' })).toBeEnabled();
+	});
+
+	it('renders the unverified session as its signed-in identity', async () => {
+		authUtil.currentUser.mockResolvedValue({
+			username: 'nick-user',
+			attributes: { email_verified: false },
+		});
+		render(
+			<MemoryRouter>
+				<AuthButtonGroup authAlertCallback={vi.fn()} />
+			</MemoryRouter>
+		);
+
+		expect(await screen.findByRole('button', { name: 'nick-user' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Create account' })).not.toBeInTheDocument();
+	});
+
+	it('moves an unconfirmed sign-in into the verification dialog', async () => {
+		authUtil.signIn.mockRejectedValue(Object.assign(new Error('confirm first'), {
+			name: 'UserNotConfirmedException',
+		}));
+		const user = userEvent.setup();
+		render(
+			<MemoryRouter>
+				<AuthButtonGroup authAlertCallback={vi.fn()} />
+			</MemoryRouter>
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Sign in' }));
+		const signInDialog = await screen.findByRole('dialog');
+		await user.type(within(signInDialog).getByLabelText('Username'), 'nick-user');
+		await user.type(within(signInDialog).getByLabelText('Password'), 'password1');
+		await user.click(within(signInDialog).getByRole('button', { name: 'Sign in' }));
+
+		expect(await screen.findByRole('heading', { name: 'Verify email address' })).toBeInTheDocument();
+		expect(screen.getByLabelText('Username')).toHaveValue('nick-user');
+	});
+
+	it('moves a successful sign-up into the prefilled verification dialog', async () => {
+		const user = userEvent.setup();
+		render(
+			<MemoryRouter>
+				<AuthButtonGroup authAlertCallback={vi.fn()} />
+			</MemoryRouter>
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Create account' }));
+		const signUpDialog = await screen.findByRole('dialog');
+		await user.type(within(signUpDialog).getByLabelText('Username'), 'nick-user');
+		await user.type(within(signUpDialog).getByLabelText('Email address'), 'nick@example.com');
+		await user.type(within(signUpDialog).getByLabelText('Password'), 'password1');
+		await user.type(within(signUpDialog).getByLabelText('Confirm password'), 'password1');
+		await user.click(within(signUpDialog).getByRole('button', { name: 'Create account' }));
+
+		expect(await screen.findByRole('heading', { name: 'Verify email address' })).toBeInTheDocument();
+		expect(screen.getByLabelText('Username')).toHaveValue('nick-user');
+		expect(screen.getByLabelText('Email address')).toHaveValue('nick@example.com');
 	});
 });

--- a/apps/web/src/components/auth/authButtonGroup.tsx
+++ b/apps/web/src/components/auth/authButtonGroup.tsx
@@ -35,11 +35,16 @@ function AuthButtonGroup({ authAlertCallback, size = "default" }: AuthButtonGrou
 
 	const handleSignInEvent = React.useCallback(
 		async () => {
-			const data = await authUtil.currentUser();
-			if (!data) return;
-			const authState = authUtil.buildAuthState(data);
-			setLoggedInUser(authState);
-			authAlertCallback(authState);
+			try {
+				const data = await authUtil.currentUser();
+				if (!data) return;
+				const authState = authUtil.buildAuthState(data);
+				setLoggedInUser(authState);
+				authAlertCallback(authState);
+			} catch {
+				// A Hub event can race a failed attribute refresh. Leave the last
+				// known state in place; the owning page handles service feedback.
+			}
 		},
 		[authAlertCallback]
 	);
@@ -50,11 +55,16 @@ function AuthButtonGroup({ authAlertCallback, size = "default" }: AuthButtonGrou
 	}, [authAlertCallback]);
 
 	React.useEffect(() => {
-		authUtil.currentUser().then((data: any) => {
-			if (data && data.attributes) {
-				setLoggedInUser(authUtil.buildAuthState(data));
-			}
-		});
+		authUtil.currentUser()
+			.then((data: any) => {
+				if (data && data.attributes) {
+					setLoggedInUser(authUtil.buildAuthState(data));
+				}
+			})
+			.catch(() => {
+				// The controls remain usable as signed-out controls. Pages that need
+				// to distinguish signed-out from unavailable resolve auth themselves.
+			});
 
 		const authListener = (data: any) => {
 			switch (data.payload.event) {

--- a/apps/web/src/components/auth/signInModal.test.js
+++ b/apps/web/src/components/auth/signInModal.test.js
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const auth = vi.hoisted(() => ({ signIn: vi.fn() }));
+const toast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+
+vi.mock('../../utils/authUtil', () => auth);
+vi.mock('sonner', () => ({ toast }));
+
+import SignInModal from './signInModal';
+
+function renderModal(overrides = {}) {
+	const props = {
+		show: true,
+		onHide: vi.fn(),
+		callback: vi.fn(),
+		mustVerifyEmailCallback: vi.fn(),
+		...overrides,
+	};
+	render(<SignInModal {...props} />);
+	return props;
+}
+
+async function submitCredentials(user, username = 'nick-user', password = 'password1') {
+	await user.type(screen.getByLabelText('Username'), username);
+	await user.type(screen.getByLabelText('Password'), password);
+	await user.click(screen.getByRole('button', { name: 'Sign in' }));
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('SignInModal Cognito boundary', () => {
+	it('closes and reports a successful sign-in', async () => {
+		auth.signIn.mockResolvedValue({ isSignedIn: true });
+		const user = userEvent.setup();
+		const props = renderModal();
+
+		await submitCredentials(user);
+
+		await waitFor(() => expect(auth.signIn).toHaveBeenCalledWith('nick-user', 'password1'));
+		expect(props.callback).toHaveBeenCalledTimes(1);
+		expect(props.onHide).toHaveBeenCalledTimes(1);
+	});
+
+	it.each(['NotAuthorizedException', 'UserNotFoundException'])(
+		'shows a non-enumerating credential error for %s',
+		async (name) => {
+			auth.signIn.mockRejectedValue(Object.assign(new Error('raw Cognito message'), { name }));
+			const user = userEvent.setup();
+			renderModal();
+
+			await submitCredentials(user);
+
+			expect(await screen.findByText('Username or password is incorrect.')).toBeInTheDocument();
+			expect(toast.error).not.toHaveBeenCalled();
+		}
+	);
+
+	it('moves an unconfirmed user into verification', async () => {
+		auth.signIn.mockRejectedValue(Object.assign(new Error('confirm first'), { name: 'UserNotConfirmedException' }));
+		const user = userEvent.setup();
+		const props = renderModal();
+
+		await submitCredentials(user);
+
+		await waitFor(() => expect(props.mustVerifyEmailCallback).toHaveBeenCalledWith('nick-user'));
+		expect(props.onHide).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the form recoverable and reports a generic service error', async () => {
+		auth.signIn.mockRejectedValue(new Error('Cognito is unavailable'));
+		const user = userEvent.setup();
+		const props = renderModal();
+
+		await submitCredentials(user);
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Cognito is unavailable'));
+		expect(props.onHide).not.toHaveBeenCalled();
+		expect(screen.getByRole('button', { name: 'Sign in' })).toBeEnabled();
+	});
+});

--- a/apps/web/src/components/auth/signInModal.tsx
+++ b/apps/web/src/components/auth/signInModal.tsx
@@ -60,8 +60,10 @@ function SignInModal({ show, onHide, callback, mustVerifyEmailCallback, username
 				if (code === 'UserNotConfirmedException') {
 					onHide();
 					mustVerifyEmailCallback(values.username);
-				} else if (code === 'UserNotFoundException') {
-					form.setError('username', { message: 'User not found.' });
+				} else if (code === 'UserNotFoundException' || code === 'NotAuthorizedException') {
+					// Do not disclose whether a username exists. Cognito uses both
+					// exceptions for invalid credentials depending on pool settings.
+					form.setError('password', { message: 'Username or password is incorrect.' });
 				} else {
 					toast.error(e.message || 'Sign in failed.');
 				}

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -88,11 +88,16 @@ function XalianNavbar({ authAlertCallback }: XalianNavbarProps) {
 		};
 		window.addEventListener('scroll', scrollListener);
 
-		authUtil.currentUser().then((data: any) => {
-			if (data && data.attributes) {
-				handleUserAuthAction(authUtil.buildAuthState(data));
-			}
-		});
+		authUtil.currentUser()
+			.then((data: any) => {
+				if (data && data.attributes) {
+					handleUserAuthAction(authUtil.buildAuthState(data));
+				}
+			})
+			.catch(() => {
+				// Keep navigation available when Cognito is temporarily unavailable.
+				// Auth-aware pages resolve and present their own recoverable state.
+			});
 
 		return () => {
 			stopListening();

--- a/apps/web/src/pages/__tests__/generatorPage.test.js
+++ b/apps/web/src/pages/__tests__/generatorPage.test.js
@@ -72,6 +72,15 @@ describe('GeneratorPage, signed out', () => {
 		await waitFor(() => expect(dbApi.callShowroomXalian).toHaveBeenCalledTimes(2));
 		expect(dbApi.callGenerateXalian).not.toHaveBeenCalled();
 	});
+
+	it('keeps anonymous generation available when the Cognito probe is unavailable', async () => {
+		currentUser.mockRejectedValue(new Error('service unavailable'));
+		renderPage();
+
+		await waitFor(() => expect(dbApi.callShowroomXalian).toHaveBeenCalledTimes(1));
+		expect(dbApi.callGenerateXalian).not.toHaveBeenCalled();
+		expect(await screen.findByText('Showroom creature')).toBeInTheDocument();
+	});
 });
 
 describe('GeneratorPage, signed in', () => {

--- a/apps/web/src/pages/__tests__/userAccountPage.test.js
+++ b/apps/web/src/pages/__tests__/userAccountPage.test.js
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const auth = vi.hoisted(() => ({
+	currentUser: vi.fn(),
+	buildAuthState: vi.fn((data) => ({
+		userId: data.attributes.sub,
+		username: data.username,
+		email: data.attributes.email,
+		hasVerifiedEmail: data.attributes.email_verified === true,
+	})),
+	signIn: vi.fn(),
+	signUp: vi.fn(),
+	confirmSignUp: vi.fn(),
+	resendConfirmationCode: vi.fn(),
+}));
+const db = vi.hoisted(() => ({
+	callListXalians: vi.fn(),
+	callReleaseXalian: vi.fn(),
+}));
+const hub = vi.hoisted(() => ({ listen: vi.fn(() => vi.fn()) }));
+
+vi.mock('../../utils/authUtil', () => auth);
+vi.mock('../../utils/dbApi', () => db);
+vi.mock('aws-amplify/utils', () => ({ Hub: hub }));
+vi.mock('../../components/navbar', () => ({ default: () => <nav aria-label="Test navigation" /> }));
+vi.mock('../../components/record/RecordTile', () => ({ default: () => null }));
+vi.mock('../../components/record/RecordView', () => ({ default: () => null }));
+
+import UserAccountPage from '../userAccountPage';
+
+function renderPage() {
+	return render(
+		<MemoryRouter>
+			<UserAccountPage />
+		</MemoryRouter>
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	db.callListXalians.mockResolvedValue({ items: [], nextCursor: undefined });
+});
+
+describe('account auth integration', () => {
+	it('renders an intentional signed-out state without calling the protected API', async () => {
+		auth.currentUser.mockResolvedValue(null);
+		const user = userEvent.setup();
+		renderPage();
+
+		expect(await screen.findByText('Sign in to see your Xalians')).toBeInTheDocument();
+		expect(db.callListXalians).not.toHaveBeenCalled();
+
+		await user.click(screen.getByRole('button', { name: 'Sign in' }));
+		expect(await screen.findByRole('heading', { name: 'Sign in' })).toBeInTheDocument();
+	});
+
+	it('loads the caller collection after a verified session resolves', async () => {
+		auth.currentUser.mockResolvedValue({
+			username: 'nick-user',
+			attributes: { sub: 'subject-1', email: 'nick@example.com', email_verified: true },
+		});
+		renderPage();
+
+		await waitFor(() => expect(db.callListXalians).toHaveBeenCalledWith());
+		expect(await screen.findByText('No Xalians yet')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { level: 1, name: 'nick-user' })).toBeInTheDocument();
+		expect(screen.getAllByRole('link', { name: 'Generate a Xalian' })
+			.every((link) => link.getAttribute('href') === '/generator')).toBe(true);
+	});
+
+	it('distinguishes a Cognito outage from a signed-out session', async () => {
+		auth.currentUser.mockRejectedValue(new Error('service unavailable'));
+		renderPage();
+
+		expect(await screen.findByText('Could not check your sign-in status. Please try again later.')).toBeInTheDocument();
+		expect(screen.queryByText('Sign in to see your Xalians')).not.toBeInTheDocument();
+		expect(db.callListXalians).not.toHaveBeenCalled();
+	});
+
+	it('renders a recoverable protected-API error after authentication succeeds', async () => {
+		auth.currentUser.mockResolvedValue({
+			username: 'nick-user',
+			attributes: { sub: 'subject-1', email: 'nick@example.com', email_verified: true },
+		});
+		db.callListXalians.mockRejectedValue(new Error('API unavailable'));
+		renderPage();
+
+		expect(await screen.findByText('Could not load your Xalians. Please try again later.')).toBeInTheDocument();
+		expect(screen.queryByText('No Xalians yet')).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/pages/userAccountPage.tsx
+++ b/apps/web/src/pages/userAccountPage.tsx
@@ -37,7 +37,7 @@ function UserAccountPage() {
 	const [loggedInUser, setLoggedInUser] = React.useState<AuthUser>(null);
 	const [records, setRecords] = React.useState<XalianRecord[]>([]);
 	const [cursor, setCursor] = React.useState<string | undefined>();
-	const [isLoading, setIsLoading] = React.useState(false);
+	const [isLoading, setIsLoading] = React.useState(true);
 	const [isLoadingMore, setIsLoadingMore] = React.useState(false);
 	const [signedOut, setSignedOut] = React.useState(false);
 	const [message, setMessage] = React.useState<string | null>(null);
@@ -94,12 +94,20 @@ function UserAccountPage() {
 					loadFirstPage();
 				} else {
 					setIsLoading(false);
+					setLoggedInUser(null);
+					setRecords([]);
+					setCursor(undefined);
+					setMessage(null);
 					setSignedOut(true);
 				}
 			})
 			.catch(() => {
 				setIsLoading(false);
-				setSignedOut(true);
+				setLoggedInUser(null);
+				setRecords([]);
+				setCursor(undefined);
+				setSignedOut(false);
+				setMessage('Could not check your sign-in status. Please try again later.');
 			});
 	}, [loadFirstPage]);
 
@@ -113,6 +121,8 @@ function UserAccountPage() {
 			if (data.payload.event === 'signedOut') {
 				setLoggedInUser(null);
 				setRecords([]);
+				setCursor(undefined);
+				setMessage(null);
 				setSignedOut(true);
 			}
 		};
@@ -200,7 +210,7 @@ function UserAccountPage() {
 					</EmptyState>
 				)}
 
-				{!isLoading && !signedOut && records.length > 0 && (
+				{!isLoading && !signedOut && !message && records.length > 0 && (
 					<React.Fragment>
 						<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
 							{records.map((record) => (

--- a/apps/web/src/utils/__tests__/authUtil.test.js
+++ b/apps/web/src/utils/__tests__/authUtil.test.js
@@ -45,6 +45,34 @@ describe('Amplify 6 auth boundary', () => {
 		await expect(authUtil.currentUser()).resolves.toBeNull();
 	});
 
+	it('normalizes Cognito NotAuthorized as an absent or expired session', async () => {
+		amplifyAuth.getCurrentUser.mockRejectedValue(Object.assign(new Error('session expired'), {
+			name: 'NotAuthorizedException',
+		}));
+
+		await expect(authUtil.currentUser()).resolves.toBeNull();
+	});
+
+	it('does not hide service failures as a signed-out session', async () => {
+		amplifyAuth.getCurrentUser.mockRejectedValue(Object.assign(new Error('service unavailable'), {
+			name: 'ServiceUnavailableException',
+		}));
+
+		await expect(authUtil.currentUser()).rejects.toMatchObject({
+			name: 'ServiceUnavailableException',
+			message: 'service unavailable',
+		});
+	});
+
+	it('retains an unverified email as an explicit auth state', async () => {
+		amplifyAuth.getCurrentUser.mockResolvedValue({ username: 'nick', userId: 'subject-1' });
+		amplifyAuth.fetchUserAttributes.mockResolvedValue({ email: 'nick@example.com', email_verified: 'false' });
+
+		const user = await authUtil.currentUser();
+
+		expect(authUtil.buildAuthState(user)).toMatchObject({ hasVerifiedEmail: false });
+	});
+
 	it('uses the Amplify 6 named input shapes', async () => {
 		await authUtil.signUp('nick@example.com', 'nick-user', 'password');
 		await authUtil.confirmSignUp('nick-user', '123456');
@@ -65,5 +93,11 @@ describe('Amplify 6 auth boundary', () => {
 		amplifyAuth.fetchAuthSession.mockResolvedValue({ tokens: { idToken: { toString: () => 'jwt-token' } } });
 
 		await expect(authUtil.getIdToken()).resolves.toBe('jwt-token');
+	});
+
+	it('rejects an absent ID token before a protected request can be sent', async () => {
+		amplifyAuth.fetchAuthSession.mockResolvedValue({ tokens: {} });
+
+		await expect(authUtil.getIdToken()).rejects.toThrow('The signed-in session did not include an ID token.');
 	});
 });

--- a/apps/web/src/utils/__tests__/dbApi.test.js
+++ b/apps/web/src/utils/__tests__/dbApi.test.js
@@ -4,7 +4,14 @@ import sampleGraviclaw from '../../../../../docs/design/sample-record-graviclaw.
 const getIdToken = vi.hoisted(() => vi.fn());
 vi.mock('../authUtil', () => ({ getIdToken }));
 
-import { callCreateUser, callGetUser, callShowroomXalian } from '../dbApi';
+import {
+	callCreateUser,
+	callGenerateXalian,
+	callGetUser,
+	callListXalians,
+	callReleaseXalian,
+	callShowroomXalian,
+} from '../dbApi';
 
 beforeEach(() => {
 	vi.restoreAllMocks();
@@ -34,6 +41,31 @@ describe('native API client', () => {
 			headers: { Authorization: 'Bearer jwt-token', 'content-type': 'application/json' },
 			body: JSON.stringify({ userId: 'nick', xalianIds: [] }),
 		});
+	});
+
+	it('propagates the current ID token to protected reads and deletes', async () => {
+		vi.spyOn(globalThis, 'fetch')
+			.mockResolvedValueOnce(new Response(JSON.stringify({ items: [], nextCursor: undefined }), { status: 200 }))
+			.mockResolvedValueOnce(new Response(JSON.stringify({ message: 'ok' }), { status: 200 }));
+
+		await callListXalians(undefined, 'page 2');
+		await callReleaseXalian('xal/one');
+
+		expect(fetch).toHaveBeenNthCalledWith(1, 'https://api.xalians.com/prod/xalians?cursor=page+2', {
+			headers: { Authorization: 'Bearer jwt-token' },
+		});
+		expect(fetch).toHaveBeenNthCalledWith(2, 'https://api.xalians.com/prod/xalians/xal%2Fone', {
+			method: 'DELETE',
+			headers: { Authorization: 'Bearer jwt-token' },
+		});
+	});
+
+	it('does not send a protected request when the session has no usable token', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		getIdToken.mockRejectedValue(new Error('The signed-in session did not include an ID token.'));
+
+		await expect(callGenerateXalian(undefined, 'full')).rejects.toThrow('did not include an ID token');
+		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
 	it('turns a failed HTTP response into a useful error', async () => {

--- a/docs/design/frontend-auth-integration.md
+++ b/docs/design/frontend-auth-integration.md
@@ -1,0 +1,29 @@
+# Frontend authentication integration contract
+
+Audit date: 2026-09-11  
+Starting point: `0965b6d` (`main` after PR #237)
+
+## Boundary
+
+The frontend tests the contract it owns: Amplify response normalization, modal transitions, route state, and authorization headers sent to the Xalians API. Cognito itself is not duplicated in tests. All automated auth responses are deterministic mocks, and production smoke is non-destructive: it never submits credentials or stores an account secret.
+
+## Scenario matrix
+
+| State or action | Expected UI/API behavior | Enforcement |
+| --- | --- | --- |
+| Signed out | Account shows an intentional sign-in/create-account recovery surface; protected collection API is not called | `userAccountPage.test.js` |
+| Verified session | Account normalizes the Cognito identity, requests the caller's collection, and renders the signed-in name/empty collection state | `authUtil.test.js`, `userAccountPage.test.js` |
+| Unverified session | `email_verified` remains false; identity stays signed in and an unconfirmed sign-in moves to verification | `authUtil.test.js`, `authButtonGroup.test.js`, `signInModal.test.js` |
+| Successful sign-in | Amplify receives the submitted username/password; the modal calls its owner and closes | `signInModal.test.js` |
+| Invalid credentials | `NotAuthorizedException` and `UserNotFoundException` use the same inline message, avoiding username enumeration | `signInModal.test.js` |
+| Generic Cognito error | Form remains open/enabled and presents a recoverable service message | `signInModal.test.js` |
+| Sign-up succeeds | Auth controls transition to a verification dialog prefilled with the submitted username/email | `authButtonGroup.test.js` |
+| Expired or absent session | Auth normalization returns signed out for Cognito's auth exceptions; a missing ID token rejects before `fetch` | `authUtil.test.js`, `dbApi.test.js` |
+| Cognito session probe fails | Global navigation/auth controls remain usable; account distinguishes outage from signed out | `authButtonGroup.test.js`, `userAccountPage.test.js` |
+| Protected API calls | Current ID token is sent as `Authorization: Bearer …` on reads, writes, and deletes; identifiers/cursors are encoded | `dbApi.test.js` |
+| Anonymous showroom | Generates through the public endpoint with no token lookup and no Authorization header, even when the auth probe is unavailable | `dbApi.test.js`, `generatorPage.test.js` |
+| Protected API fails | Account replaces collection content with an explicit retry-later state rather than an empty or stale collection | `userAccountPage.test.js` |
+
+## Production smoke
+
+The production check is limited to observable, non-destructive states: load `/account` signed out, open the sign-in dialog, exercise client-side validation without submitting valid credentials, and load `/generator` through its anonymous showroom path. Signed-in and Cognito failure responses stay in deterministic tests unless a dedicated disposable test identity and CI secret policy are approved later.

--- a/docs/design/frontend-modernization-roadmap.md
+++ b/docs/design/frontend-modernization-roadmap.md
@@ -151,7 +151,7 @@ Do before the font pass so font consumers can be attributed to their final CSS o
 - Final consolidation CI: [CI run 34620786800](https://github.com/nickcjordan/Xalians/actions/runs/34620786800) and [Terraform-plan run 34620786888](https://github.com/nickcjordan/Xalians/actions/runs/34620786888) passed; Linux reproduced 52 frontend files / 1,031 tests, 12 content files / 37 tests, zero dependency vulnerabilities, the byte-identical asset, and every bundle budget. All three job-annotation responses were empty.
 - Final consolidation deploy: [frontend run 34620942570](https://github.com/nickcjordan/Xalians/actions/runs/34620942570) passed its production build, S3 sync, and CloudFront invalidation with an empty job-annotation response. Because the emitted artifact was byte-for-byte identical to the already verified #235 production asset, the deployment introduced no browser-visible route delta to re-test.
 
-### 3. Font loading — In progress
+### 3. Font loading — Complete
 
 **Scope**
 
@@ -179,9 +179,12 @@ Legacy CSS ownership audit.
 - Checked-in family/variant/route audit: [`docs/design/frontend-font-loading.md`](frontend-font-loading.md).
 - Automated guard: `fontLoading.test.js` enforces one request, both connection hints, `display=swap`, the exact retained variants, and the retired-family set.
 - Local verification: focused font/ownership/design-system tests, typecheck, 53 files / 1,034 tests, zero production vulnerabilities, production build, and every bundle budget pass. All eleven route entries render without loading/error residue at 1,440×900 and 390×844; desktop chrome and mobile Reclamation typography remain visually consistent with production.
-- PR, CI, deployment, and production font-resource evidence pending.
+- PR: [#237, Consolidate frontend font loading](https://github.com/nickcjordan/Xalians/pull/237), merged as `0965b6d` on 2026-09-11.
+- CI: [CI run 34621935617](https://github.com/nickcjordan/Xalians/actions/runs/34621935617) and [Terraform-plan run 34621935557](https://github.com/nickcjordan/Xalians/actions/runs/34621935557) passed; Linux reproduced 53 frontend files / 1,034 tests, 12 content files / 37 tests, zero dependency vulnerabilities, the 57.51/11.78 kB immersive asset, and every bundle budget. All three job-annotation responses were empty.
+- Deploy: [frontend run 34622085179](https://github.com/nickcjordan/Xalians/actions/runs/34622085179) passed its production build, S3 sync, and CloudFront invalidation with an empty job-annotation response.
+- Production verification: the served HTML contains exactly one audited Google Fonts stylesheet plus both preconnects. All eleven route entries render without loading/error residue at 1,440×900 and 390×844, and the active field-terminal typography remains visually identical to the local reviewed build.
 
-### 4. Cognito authentication integration coverage — Planned
+### 4. Cognito authentication integration coverage — In progress
 
 **Scope**
 
@@ -189,7 +192,7 @@ Test the UI-to-Amplify/API boundary, not Cognito itself. Cover sign-in success, 
 
 **Measured baseline**
 
-There are unit tests for `authUtil`, `dbApi`, and `AuthButtonGroup`, all with mocked Amplify functions. There is no route-level integration harness that exercises authentication state through the navbar/account/generator surfaces together, and no browser-level Cognito contract test.
+The baseline had unit tests for `authUtil`, `dbApi`, and `AuthButtonGroup`, all with mocked Amplify functions, but no route-level account harness or modal-level error/transition coverage. The first integration slice adds two test files and expands four existing suites, taking the frontend from 53 files / 1,034 tests to 55 files / 1,054 tests. It also corrects two observed boundary behaviors: account-session service failures are no longer misreported as signed out, and navbar/auth-control session probes no longer create unhandled promise rejections.
 
 **Acceptance criteria**
 
@@ -204,7 +207,10 @@ Prefer after route modernization if test helpers would otherwise be rewritten tw
 
 **Evidence / links**
 
-Pending.
+- Contract and deterministic scenario matrix: [`docs/design/frontend-auth-integration.md`](frontend-auth-integration.md).
+- Focused local verification: six auth/account/generator suites / 32 tests cover verified, unverified, signed-out, expired/absent-token, invalid-credential, generic service-error, protected API, and anonymous-generation paths.
+- Full local verification: typecheck, 55 files / 1,054 tests, zero production vulnerabilities, production build, and every bundle budget pass. Browser smoke confirms the signed-out account recovery surface, sign-in dialog/client validation, and anonymous showroom generation at desktop and phone widths without using or storing real credentials.
+- PR, CI, deployment, and production smoke evidence pending.
 
 ### 5. React Router modernization — Planned
 


### PR DESCRIPTION
## Summary
- add deterministic UI integration coverage for sign-in, verification, signed-out/signed-in account, session errors, API errors, and anonymous generator behavior
- use one non-enumerating invalid-credential message for Cognito's NotAuthorized/UserNotFound responses
- distinguish a Cognito outage from a signed-out account and prevent stale/empty-state flashes
- contain failed global auth probes so navigation and auth controls remain usable
- record the auth contract and complete the deployed font-loading evidence

## Verification
- focused auth/account/generator suites: 6 files, 32 tests
- npm run typecheck -w apps/web
- npm test -w apps/web -- --run (55 files, 1,054 tests)
- npm audit --omit=dev (0 vulnerabilities)
- npm run build -w apps/web (all bundle budgets pass)
- browser: signed-out account, sign-in validation, anonymous showroom at desktop and 390x844; no real credentials submitted