### PR TITLE
Modernize frontend routing

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "react-dom": "18",
     "react-hook-form": "^7.87.0",
     "react-redux": "^8.0.1",
-    "react-router-dom": "^5.3.0",
+    "react-router-dom": "^7.18.3",
     "recharts": "3.8.0",
     "sonner": "^2.0.8",
     "tailwind-merge": "^3.6.0",

--- a/apps/web/src/App.js
+++ b/apps/web/src/App.js
@@ -24,10 +24,11 @@ import React, { Suspense, lazy } from 'react';
 
 import {
   BrowserRouter as Router,
-  Switch,
+  Routes,
   Route,
-  Redirect,
-  Link
+  Navigate,
+  useLocation,
+  useParams,
 } from "react-router-dom";
 
 import { Amplify } from 'aws-amplify';
@@ -71,15 +72,65 @@ const DevErrorPage = lazy(() => import('./pages/system/devErrorPage'));
 // species name instead, so this redirect resolves the incoming id against
 // species.json and hands the result to the new route. An id that matches
 // nothing lands on the Bestiary grid rather than a broken page.
-function RedirectSpecies({ match }) {
-  let inboundId = match.params.id ? match.params.id.toString() : '';
+function PreserveLocationRedirect({ to }) {
+  const location = useLocation();
+  return <Navigate replace to={{ pathname: to, search: location.search, hash: location.hash }} />;
+}
+
+function RedirectSpecies() {
+  const { id = '' } = useParams();
+  const location = useLocation();
+  let inboundId = id.toString();
   if (inboundId && inboundId.length < 5 && /^\d+$/.test(inboundId)) {
     inboundId = inboundId.padStart(5, '0');
   }
   let xal = species.find((x) =>
-    x.id === inboundId || x.name.toLowerCase() === match.params.id.toLowerCase()
+    x.id === inboundId || x.name.toLowerCase() === id.toLowerCase()
   );
-  return <Redirect to={xal ? `/encyclopedia/species/${xal.name.toLowerCase()}` : '/encyclopedia/species'} />;
+  const pathname = xal ? `/encyclopedia/species/${xal.name.toLowerCase()}` : '/encyclopedia/species';
+  return <Navigate replace to={{ pathname, search: location.search, hash: location.hash }} />;
+}
+
+function UserDetailsRoute() {
+  const { id } = useParams();
+  return <UserDetailsPage id={id} />;
+}
+
+export function AppRoutes() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/generator" element={<GeneratorPage />} />
+          {/* legacy lore pages retired in favor of the Encyclopedia (docs/design/xalian-encyclopedia-page.md) */}
+          <Route path="/species" element={<PreserveLocationRedirect to="/encyclopedia/species" />} />
+          <Route path="/species/:id" element={<RedirectSpecies />} />
+          <Route path="/user/:id" element={<UserDetailsRoute />} />
+          <Route path="/planets" element={<PreserveLocationRedirect to="/encyclopedia/worlds" />} />
+          <Route path="/glossary" element={<PreserveLocationRedirect to="/encyclopedia/index" />} />
+          <Route path="/encyclopedia/*" element={<EncyclopediaPage />} />
+          {/* the design system reference - unlinked from the navbar, it is a
+              developer tool rather than a page for players */}
+          {StyleGuidePage && <Route path="/styleguide" element={<StyleGuidePage />} />}
+          {/* throws on render, to exercise ErrorBoundary/ErrorPage - a developer
+              route, unlinked like /styleguide */}
+          <Route path="/dev/error" element={<DevErrorPage />} />
+          {/* the duel's own affordance reference - also a developer tool,
+              also deliberately unlinked */}
+          <Route path="/duel/reference" element={<DuelPlaygroundPage />} />
+          <Route path="/duel" element={<DuelStartPage />} />
+          <Route path="/reclamation" element={<ReclamationPage />} />
+          <Route path="/long-return" element={<LongReturnPage />} />
+          <Route path="/account" element={<UserAccountPage />} />
+          <Route path="/train" element={<TrainingGroundsPage />} />
+          <Route path="/train/match" element={<MatchCardGamePage />} />
+          <Route path="/train/physics" element={<PhysicsGamePage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </ErrorBoundary>
+    </Suspense>
+  );
 }
 
 class App extends React.Component {
@@ -91,41 +142,7 @@ class App extends React.Component {
       
       <TooltipProvider>
         <Router>
-         <Suspense fallback={<div>Loading...</div>}>
-          <ErrorBoundary>
-            <Switch>
-              <Route exact path="/"><Home /></Route>
-              <Route exact path="/generator"><GeneratorPage /></Route>
-              {/* legacy lore pages retired in favor of the Encyclopedia (docs/design/xalian-encyclopedia-page.md) */}
-              <Route exact path="/species"><Redirect to="/encyclopedia/species" /></Route>
-                <Route exact path="/species/:id" component={RedirectSpecies} />
-                <Route exact path="/user/:id"
-                  render={({ match }) => <UserDetailsPage id={match.params.id} />}
-                />
-              <Route exact path="/planets"><Redirect to="/encyclopedia/worlds" /></Route>
-              <Route exact path="/glossary"><Redirect to="/encyclopedia/index" /></Route>
-              <Route path="/encyclopedia"><EncyclopediaPage /></Route>
-              {/* the design system reference - unlinked from the navbar, it is a
-                  developer tool rather than a page for players */}
-              {StyleGuidePage && <Route exact path="/styleguide"><StyleGuidePage /></Route>}
-              {/* throws on render, to exercise ErrorBoundary/ErrorPage - a developer
-                  route, unlinked like /styleguide */}
-              <Route exact path="/dev/error"><DevErrorPage /></Route>
-              {/* the duel's own affordance reference - also a developer tool,
-                  also deliberately unlinked */}
-              <Route exact path="/duel/reference"><DuelPlaygroundPage /></Route>
-              <Route exact path="/duel"><DuelStartPage/></Route>
-              <Route exact path="/reclamation"><ReclamationPage/></Route>
-              <Route exact path="/long-return"><LongReturnPage /></Route>
-              <Route exact path="/account"><UserAccountPage /></Route>
-              <Route exact path="/train"><TrainingGroundsPage /></Route>
-                <Route exact path="/train/match"><MatchCardGamePage /></Route>
-                <Route exact path="/train/physics"><PhysicsGamePage /></Route>
-              {/* catch-all: keep this last */}
-              <Route><NotFoundPage /></Route>
-            </Switch>
-          </ErrorBoundary>
-      </Suspense>
+          <AppRoutes />
         </Router>
         <Toaster />
       </TooltipProvider>

--- a/apps/web/src/__tests__/appRoutes.test.js
+++ b/apps/web/src/__tests__/appRoutes.test.js
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('aws-amplify', () => ({ Amplify: { configure: vi.fn() } }));
+vi.mock('../components/navbar', () => ({ default: () => null }));
+
+vi.mock('../pages/home', () => ({ default: () => <div>route:home</div> }));
+vi.mock('../pages/styleGuidePage', () => ({ default: () => <div>route:styleguide</div> }));
+vi.mock('../pages/generatorPage', () => ({ default: () => <div>route:generator</div> }));
+vi.mock('../pages/userAccountPage', () => ({ default: () => <div>route:account</div> }));
+vi.mock('../pages/userDetailsPage', () => ({
+	default: ({ id }) => <div>route:user:{id}</div>,
+}));
+vi.mock('../pages/games/matchCardGamePage', () => ({ default: () => <div>route:match</div> }));
+vi.mock('../pages/games/physicsGamePage', () => ({ default: () => <div>route:physics</div> }));
+vi.mock('../pages/trainingGroundsPage', () => ({ default: () => <div>route:training</div> }));
+vi.mock('../pages/games/duelStartPage', () => ({ default: () => <div>route:duel</div> }));
+vi.mock('../pages/games/reclamationPage', () => ({ default: () => <div>route:reclamation</div> }));
+vi.mock('../pages/games/duelPlaygroundPage', () => ({ default: () => <div>route:duel-reference</div> }));
+vi.mock('../pages/encyclopediaPage', () => ({ default: () => <div>route:encyclopedia</div> }));
+vi.mock('../pages/games/longReturnPage', () => ({ default: () => <div>route:long-return</div> }));
+vi.mock('../pages/system/notFoundPage', () => ({ default: () => <div>route:not-found</div> }));
+vi.mock('../pages/system/devErrorPage', () => ({ default: () => <div>route:dev-error</div> }));
+
+import { AppRoutes } from '../App';
+
+function LocationProbe() {
+	const location = useLocation();
+	return <output data-testid="location">{location.pathname}{location.search}{location.hash}</output>;
+}
+
+function renderRoute(entry) {
+	return render(
+		<MemoryRouter initialEntries={[entry]}>
+			<AppRoutes />
+			<LocationProbe />
+		</MemoryRouter>
+	);
+}
+
+describe('application route contract', () => {
+	it.each([
+		['/', 'route:home'],
+		['/generator', 'route:generator'],
+		['/account', 'route:account'],
+		['/train', 'route:training'],
+		['/train/match', 'route:match'],
+		['/train/physics', 'route:physics'],
+		['/duel', 'route:duel'],
+		['/duel/reference', 'route:duel-reference'],
+		['/reclamation', 'route:reclamation'],
+		['/long-return', 'route:long-return'],
+		['/encyclopedia/worlds/xalia', 'route:encyclopedia'],
+	])('renders %s through its owning route', async (entry, marker) => {
+		renderRoute(entry);
+		expect(await screen.findByText(marker)).toBeInTheDocument();
+		expect(screen.getByTestId('location')).toHaveTextContent(entry);
+	});
+
+	it('passes the dynamic user id to the detail page', async () => {
+		renderRoute('/user/test-user');
+		expect(await screen.findByText('route:user:test-user')).toBeInTheDocument();
+	});
+
+	it.each([
+		['/species?view=grid#catalogue', '/encyclopedia/species?view=grid#catalogue'],
+		['/species/1?view=record#biology', '/encyclopedia/species/xylum?view=record#biology'],
+		['/species/missing?view=grid#catalogue', '/encyclopedia/species?view=grid#catalogue'],
+		['/planets?element=fire#ignis', '/encyclopedia/worlds?element=fire#ignis'],
+		['/glossary?q=rift#results', '/encyclopedia/index?q=rift#results'],
+	])('replaces retired address %s without losing URL state', async (entry, destination) => {
+		renderRoute(entry);
+		expect(await screen.findByText('route:encyclopedia')).toBeInTheDocument();
+		expect(screen.getByTestId('location')).toHaveTextContent(destination);
+	});
+
+	it('renders the not-found surface for an unknown address', async () => {
+		renderRoute('/missing/deep/link');
+		expect(await screen.findByText('route:not-found')).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/__tests__/bundleBoundaries.test.js
+++ b/apps/web/src/__tests__/bundleBoundaries.test.js
@@ -43,7 +43,7 @@ describe('production bundle boundaries', () => {
 
 		expect(app).toContain("import.meta.env.MODE === 'styleguide'");
 		expect(app).toContain('const StyleGuidePage = includeStyleGuide');
-		expect(app).toContain('StyleGuidePage && <Route exact path="/styleguide">');
+		expect(app).toContain('StyleGuidePage && <Route path="/styleguide" element={<StyleGuidePage />} />');
 		expect(app).not.toMatch(/^const StyleGuidePage = lazy\(/m);
 	});
 

--- a/apps/web/src/components/encyclopedia/EncyclopediaShell.js
+++ b/apps/web/src/components/encyclopedia/EncyclopediaShell.js
@@ -209,7 +209,7 @@ export default function EncyclopediaShell({ children }) {
                     <NavLink
                         key={s.to}
                         to={s.to}
-                        exact={s.exact}
+                        end={s.exact}
                         className={tabTriggerClass}
                         aria-current={s === activeSection ? 'page' : undefined}
                     >

--- a/apps/web/src/components/encyclopedia/GalaxyMap.js
+++ b/apps/web/src/components/encyclopedia/GalaxyMap.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import * as lore from '../../lore';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
@@ -42,7 +42,7 @@ const WRAITHIX_MOON = { x: 155, y: 210 };
 const PIN_OFFSET = { x: 16, y: -16 };
 
 function WorldEventPin({ world, events, eraKey, onHover, onLeave }) {
-	const history = useHistory();
+	const navigate = useNavigate();
 	const pos = POSITIONS[world.key];
 	// A single firm event routes straight to its own chronicle anchor; more
 	// than one routes to the era, filtered to this world, so the reader can
@@ -52,7 +52,7 @@ function WorldEventPin({ world, events, eraKey, onHover, onLeave }) {
 			? lore.routeFor('event', `${eraKey}:${events[0].key}`)
 			: `${lore.routeFor('era', eraKey)}?world=${world.key}`;
 
-	const go = () => history.push(route);
+	const go = () => navigate(route);
 	const onKeyDown = (e) => {
 		if (e.key === 'Enter' || e.key === ' ') {
 			e.preventDefault();
@@ -101,7 +101,7 @@ function WorldEventPin({ world, events, eraKey, onHover, onLeave }) {
 }
 
 function WorldMark({ world, compact, lit, dimLabel, era, onHover, onLeave }) {
-	const history = useHistory();
+	const navigate = useNavigate();
 	const pos = POSITIONS[world.key];
 	if (!pos) return null;
 	// With an era selected and this world lit in it, the record worth opening
@@ -110,7 +110,7 @@ function WorldMark({ world, compact, lit, dimLabel, era, onHover, onLeave }) {
 	const route =
 		era && lit !== false ? `${lore.routeFor('era', era)}?world=${world.key}` : lore.routeFor('world', world.key);
 
-	const go = () => history.push(route);
+	const go = () => navigate(route);
 	const onKeyDown = (e) => {
 		if (e.key === 'Enter' || e.key === ' ') {
 			e.preventDefault();

--- a/apps/web/src/components/encyclopedia/Index.js
+++ b/apps/web/src/components/encyclopedia/Index.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import * as lore from '../../lore';
 import Prose from './Prose';
 import { useReadMark } from './trail';
@@ -46,7 +46,7 @@ function IndexRecord({ entry }) {
  */
 export default function Index() {
     const location = useLocation();
-    const history = useHistory();
+    const navigate = useNavigate();
     const initialQuery = useMemo(() => {
         const params = new URLSearchParams(location.search);
         return params.get('q') || '';
@@ -86,7 +86,7 @@ export default function Index() {
 
     function pullRandom() {
         const record = lore.getRandomRecord();
-        history.push(lore.routeFor(record.kind, record.key));
+        navigate(lore.routeFor(record.kind, record.key));
     }
 
     return (

--- a/apps/web/src/components/encyclopedia/LoreSearch.js
+++ b/apps/web/src/components/encyclopedia/LoreSearch.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import * as lore from '../../lore';
 import { Input } from '@/components/ui/input';
 import { Kbd } from '@/components/ui/kbd';
@@ -20,7 +20,7 @@ export default function LoreSearch() {
     const [query, setQuery] = useState('');
     const [open, setOpen] = useState(false);
     const [activeIndex, setActiveIndex] = useState(-1);
-    const history = useHistory();
+    const navigate = useNavigate();
     const box = useRef(null);
     const inputRef = useRef(null);
 
@@ -66,7 +66,7 @@ export default function LoreSearch() {
         setOpen(false);
         setQuery('');
         setActiveIndex(-1);
-        history.push(hit.route);
+        navigate(hit.route);
     }
 
     function submit(e) {
@@ -77,7 +77,7 @@ export default function LoreSearch() {
         }
         if (!trimmed) return;
         setOpen(false);
-        history.push(`/encyclopedia/index?q=${encodeURIComponent(trimmed)}`);
+        navigate(`/encyclopedia/index?q=${encodeURIComponent(trimmed)}`);
     }
 
     function onKeyDownInput(e) {

--- a/apps/web/src/components/encyclopedia/Story.js
+++ b/apps/web/src/components/encyclopedia/Story.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import * as lore from '../../lore';
 import Prose from './Prose';
 import { useVisit, useReadMark, markRead, recordStoryPosition } from './trail';
@@ -342,7 +342,7 @@ function StoryContentsPage() {
 
 function StoryPart() {
 	const { era: eraKey } = useParams();
-	const history = useHistory();
+	const navigate = useNavigate();
 	const story = useMemo(() => lore.getStory(), []);
 	const part = lore.getStoryPart(eraKey);
 
@@ -392,14 +392,14 @@ function StoryPart() {
 			if (tag === 'INPUT' || tag === 'TEXTAREA' || (document.activeElement && document.activeElement.isContentEditable)) return;
 			if (!part) return;
 			if (e.key === 'ArrowLeft' && part.prev) {
-				history.push(lore.routeFor('era', part.prev));
+				navigate(lore.routeFor('era', part.prev));
 			} else if (e.key === 'ArrowRight' && part.next) {
-				history.push(lore.routeFor('era', part.next));
+				navigate(lore.routeFor('era', part.next));
 			}
 		}
 		window.addEventListener('keydown', onKeyDown);
 		return () => window.removeEventListener('keydown', onKeyDown);
-	}, [part, history]);
+	}, [part, navigate]);
 
 	if (!part) {
 		return (

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -127,8 +127,7 @@ function XalianNavbar({ authAlertCallback }: XalianNavbarProps) {
 							<NavLink
 								key={link.href}
 								to={link.href}
-								exact={link.href === '/'}
-								activeClassName=""
+								end={link.href === '/'}
 								className={navLinkClass}
 								aria-current={isActiveRoute(location.pathname, link.href) ? 'page' : undefined}
 							>
@@ -162,8 +161,7 @@ function XalianNavbar({ authAlertCallback }: XalianNavbarProps) {
 									<SheetClose asChild key={link.href}>
 										<NavLink
 											to={link.href}
-											exact={link.href === '/'}
-											activeClassName=""
+											end={link.href === '/'}
 											className="border-0 border-b border-edge bg-transparent px-1 py-3 font-legend text-[13px] font-medium uppercase tracking-legend text-ink-2 aria-[current=page]:text-viable-hi"
 											aria-current={isActiveRoute(location.pathname, link.href) ? 'page' : undefined}
 										>

--- a/apps/web/src/components/system/status.tsx
+++ b/apps/web/src/components/system/status.tsx
@@ -51,7 +51,7 @@ function NotFoundPage({ path }: { path?: string }) {
     <StatusFrame>
       <StatusBody
         kicker="Not found"
-        title={<span className="type-data normal-case tracking-normal">{shownPath}</span>}
+        title={<span className="type-data break-all normal-case tracking-normal">{shownPath}</span>}
         actions={
           <>
             <Button asChild>
@@ -125,7 +125,7 @@ function OfflinePage({ onRetry }: { onRetry?: () => void }) {
 
 type ErrorBoundaryState = { error: Error | null }
 
-/** Wraps the router `<Switch>` so a render error shows `ErrorPage` instead of a blank tab. */
+/** Wraps the router `<Routes>` so a render error shows `ErrorPage` instead of a blank tab. */
 class ErrorBoundary extends React.Component<{ children: React.ReactNode }, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
 

--- a/apps/web/src/lore/__tests__/lore.pronunciation.test.js
+++ b/apps/web/src/lore/__tests__/lore.pronunciation.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import { MemoryRouter, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import encyclopedia from '@xalians/content/encyclopedia.json';
 import Pronunciation from '../../components/encyclopedia/Pronunciation';
 import EntryView from '../../components/encyclopedia/EntryView';
@@ -80,7 +80,9 @@ describe('pronunciation rendering', () => {
 		const c = paint(
 			<MemoryRouter initialEntries={['/encyclopedia/index/telypso']}>
 				<EncyclopediaShell>
-					<Route path="/encyclopedia/index/:key"><EntryView /></Route>
+					<Routes>
+						<Route path="/encyclopedia/index/:key" element={<EntryView />} />
+					</Routes>
 				</EncyclopediaShell>
 			</MemoryRouter>
 		);

--- a/apps/web/src/pages/__tests__/encyclopediaRoutes.test.js
+++ b/apps/web/src/pages/__tests__/encyclopediaRoutes.test.js
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import tourData from '@xalians/content/tour.json';
+import { getEraForBeat, routeFor } from '../../lore';
+
+vi.mock('../../components/navbar', () => ({ default: () => null }));
+vi.mock('../../components/encyclopedia/EncyclopediaShell', () => ({
+	default: ({ children }) => <section>{children}</section>,
+}));
+vi.mock('../../components/encyclopedia/ReadingRoom', () => ({ default: () => <div>route:reading-room</div> }));
+vi.mock('../../components/encyclopedia/Story', () => ({ default: () => <div>route:story</div> }));
+vi.mock('../../components/encyclopedia/Worlds', () => ({ default: () => <div>route:worlds</div> }));
+vi.mock('../../components/encyclopedia/WorldView', () => ({ default: () => <div>route:world</div> }));
+vi.mock('../../components/encyclopedia/Bestiary', () => ({ default: () => <div>route:bestiary</div> }));
+vi.mock('../../components/encyclopedia/SpeciesView', () => ({ default: () => <div>route:species</div> }));
+vi.mock('../../components/encyclopedia/Powers', () => ({ default: () => <div>route:powers</div> }));
+vi.mock('../../components/encyclopedia/Index', () => ({ default: () => <div>route:index</div> }));
+vi.mock('../../components/encyclopedia/EntryView', () => ({ default: () => <div>route:entry</div> }));
+vi.mock('@/components/system/record', () => ({
+	EmptyState: ({ legend, children }) => <div>{legend}: {children}</div>,
+}));
+
+import EncyclopediaPage from '../encyclopediaPage';
+
+function LocationProbe() {
+	const location = useLocation();
+	return <output data-testid="location">{location.pathname}{location.search}{location.hash}</output>;
+}
+
+function renderRoute(entry) {
+	return render(
+		<MemoryRouter initialEntries={[entry]}>
+			<Routes>
+				<Route path="/encyclopedia/*" element={<EncyclopediaPage />} />
+			</Routes>
+			<LocationProbe />
+		</MemoryRouter>
+	);
+}
+
+beforeEach(() => {
+	vi.stubGlobal('scrollTo', vi.fn());
+});
+
+describe('encyclopedia route contract', () => {
+	it.each([
+		['/encyclopedia', 'route:reading-room'],
+		['/encyclopedia/story', 'route:story'],
+		['/encyclopedia/story/before-the-speaking-world', 'route:story'],
+		['/encyclopedia/worlds', 'route:worlds'],
+		['/encyclopedia/worlds/xalia', 'route:world'],
+		['/encyclopedia/species', 'route:bestiary'],
+		['/encyclopedia/species/xylum', 'route:species'],
+		['/encyclopedia/powers', 'route:powers'],
+		['/encyclopedia/index', 'route:index'],
+		['/encyclopedia/index/the-rift', 'route:entry'],
+	])('renders %s through its owning relative route', (entry, marker) => {
+		renderRoute(entry);
+		expect(screen.getByText(marker)).toBeInTheDocument();
+		expect(screen.getByTestId('location')).toHaveTextContent(entry);
+	});
+
+	it.each([
+		['/encyclopedia/chronicle?world=xalia#event-rift', '/encyclopedia/story?world=xalia#event-rift'],
+		['/encyclopedia/chronicle/deep-past?world=xalia#chapter-1', '/encyclopedia/story/deep-past?world=xalia#chapter-1'],
+		['/encyclopedia/read?mode=continuous#part-2', '/encyclopedia/story?mode=continuous#part-2'],
+		['/encyclopedia/read/deep-past?mode=continuous#part-2', '/encyclopedia/story/deep-past?mode=continuous#part-2'],
+		['/encyclopedia/tour?mode=guided#opening', '/encyclopedia/story?mode=guided#opening'],
+		['/encyclopedia/tour/unknown?mode=guided#opening', '/encyclopedia/story?mode=guided#opening'],
+	])('replaces retired address %s without losing URL state', async (entry, destination) => {
+		renderRoute(entry);
+		expect(await screen.findByText('route:story')).toBeInTheDocument();
+		expect(screen.getByTestId('location')).toHaveTextContent(destination);
+	});
+
+	it('maps a retired tour beat to its story era and beat anchor', async () => {
+		const beat = tourData.beats[0];
+		const destination = routeFor('tour', beat.key);
+		const [pathname, hash] = destination.split('#');
+		expect(getEraForBeat(beat.key)).toBe(beat.era);
+
+		renderRoute(`/encyclopedia/tour/${beat.key}?mode=guided`);
+		expect(await screen.findByText('route:story')).toBeInTheDocument();
+		expect(screen.getByTestId('location')).toHaveTextContent(`${pathname}?mode=guided#${hash}`);
+	});
+
+	it('renders the local not-found state inside the encyclopedia shell', () => {
+		renderRoute('/encyclopedia/missing/deep/link');
+		expect(screen.getByText('Not found: No record at this address.')).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/pages/encyclopediaPage.js
+++ b/apps/web/src/pages/encyclopediaPage.js
@@ -1,6 +1,6 @@
 // Tier: chrome. Reference reading -- browses and searches the archive, no play surface.
 import React, { useEffect, useRef } from 'react';
-import { Switch, Route, Redirect, useRouteMatch, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom';
 import * as lore from '../lore';
 import XalianNavbar from '../components/navbar';
 import EncyclopediaShell from '../components/encyclopedia/EncyclopediaShell';
@@ -24,22 +24,30 @@ import { EmptyState } from '@/components/system/record';
 function RedirectToEra() {
     const { era } = useParams();
     const location = useLocation();
-    return <Redirect to={{ pathname: lore.routeFor('era', era), hash: location.hash }} />;
+    return <Navigate replace to={{ pathname: lore.routeFor('era', era), search: location.search, hash: location.hash }} />;
 }
 
 function RedirectToStory() {
     const location = useLocation();
-    return <Redirect to={{ pathname: lore.routeFor('story'), hash: location.hash }} />;
+    return <Navigate replace to={{ pathname: lore.routeFor('story'), search: location.search, hash: location.hash }} />;
 }
 
 function RedirectTourBeat() {
     const { beat } = useParams();
+    const location = useLocation();
     const to = lore.getEraForBeat(beat) ? lore.routeFor('tour', beat) : lore.routeFor('story');
-    return <Redirect to={to} />;
+    const [pathname, routeHash] = to.split('#');
+    return (
+        <Navigate
+            replace
+            to={{ pathname, search: location.search, hash: location.hash || (routeHash ? `#${routeHash}` : '') }}
+        />
+    );
 }
 
 function RedirectTour() {
-    return <Redirect to={lore.routeFor('story')} />;
+    const location = useLocation();
+    return <Navigate replace to={{ pathname: lore.routeFor('story'), search: location.search, hash: location.hash }} />;
 }
 
 /**
@@ -50,7 +58,6 @@ function RedirectTour() {
  * src/lore (never the JSON). Contract: docs/design/xalian-encyclopedia-story-pass.md
  */
 export default function EncyclopediaPage() {
-    const { path } = useRouteMatch();
     const location = useLocation();
     // null until the first effect runs, so a cold load with a hash still
     // scrolls to its anchor (a bookmark or a shared chapter link).
@@ -88,7 +95,7 @@ export default function EncyclopediaPage() {
         return true;
     }
 
-    // React Router v5 does not reset scroll on navigation. Reset to the top
+    // React Router does not reset scroll on navigation. Reset to the top
     // on a route change (a different pathname), unless the new location
     // carries a hash: then let the target element's scrollIntoView win. A
     // hash-only change on the *same* pathname (e.g. a Connections sample
@@ -132,27 +139,27 @@ export default function EncyclopediaPage() {
         <main className="min-h-screen bg-room font-body text-ink" data-tier="chrome">
             <XalianNavbar />
             <EncyclopediaShell>
-                <Switch>
-                    <Route exact path={`${path}`}><ReadingRoom /></Route>
-                    <Route exact path={`${path}/story`}><Story /></Route>
-                    <Route exact path={`${path}/story/:era`}><Story /></Route>
-                    <Route exact path={`${path}/worlds`}><Worlds /></Route>
-                    <Route exact path={`${path}/worlds/:key`}><WorldView /></Route>
-                    <Route exact path={`${path}/species`}><Bestiary /></Route>
-                    <Route exact path={`${path}/species/:key`}><SpeciesView /></Route>
-                    <Route exact path={`${path}/powers`}><Powers /></Route>
-                    <Route exact path={`${path}/index`}><Index /></Route>
-                    <Route exact path={`${path}/index/:key`}><EntryView /></Route>
+                <Routes>
+                    <Route index element={<ReadingRoom />} />
+                    <Route path="story" element={<Story />} />
+                    <Route path="story/:era" element={<Story />} />
+                    <Route path="worlds" element={<Worlds />} />
+                    <Route path="worlds/:key" element={<WorldView />} />
+                    <Route path="species" element={<Bestiary />} />
+                    <Route path="species/:key" element={<SpeciesView />} />
+                    <Route path="powers" element={<Powers />} />
+                    <Route path="index" element={<Index />} />
+                    <Route path="index/:key" element={<EntryView />} />
                     {/* Retired routes: First Survey, Chronicle and Read collapsed into
                         The Story (docs/design/xalian-encyclopedia-story-pass.md). */}
-                    <Route exact path={`${path}/tour`}><RedirectTour /></Route>
-                    <Route exact path={`${path}/tour/:beat`}><RedirectTourBeat /></Route>
-                    <Route exact path={`${path}/chronicle`}><RedirectToStory /></Route>
-                    <Route exact path={`${path}/chronicle/:era`}><RedirectToEra /></Route>
-                    <Route exact path={`${path}/read`}><RedirectToStory /></Route>
-                    <Route exact path={`${path}/read/:era`}><RedirectToEra /></Route>
-                    <Route><EmptyState legend="Not found">No record at this address.</EmptyState></Route>
-                </Switch>
+                    <Route path="tour" element={<RedirectTour />} />
+                    <Route path="tour/:beat" element={<RedirectTourBeat />} />
+                    <Route path="chronicle" element={<RedirectToStory />} />
+                    <Route path="chronicle/:era" element={<RedirectToEra />} />
+                    <Route path="read" element={<RedirectToStory />} />
+                    <Route path="read/:era" element={<RedirectToEra />} />
+                    <Route path="*" element={<EmptyState legend="Not found">No record at this address.</EmptyState>} />
+                </Routes>
             </EncyclopediaShell>
         </main>
     );

--- a/apps/web/src/types/react-router-dom.d.ts
+++ b/apps/web/src/types/react-router-dom.d.ts
@@ -1,5 +1,0 @@
-// react-router-dom 5 ships no types and `@types/react-router-dom` is not
-// installed in this worktree's (shared, symlinked) node_modules. This is
-// the first .tsx file to import it (`Link` in the record view); untyped
-// rather than blocking `tsc --noEmit` for every consumer after it.
-declare module 'react-router-dom';

--- a/docs/design/frontend-modernization-roadmap.md
+++ b/docs/design/frontend-modernization-roadmap.md
@@ -184,7 +184,7 @@ Legacy CSS ownership audit.
 - Deploy: [frontend run 34622085179](https://github.com/nickcjordan/Xalians/actions/runs/34622085179) passed its production build, S3 sync, and CloudFront invalidation with an empty job-annotation response.
 - Production verification: the served HTML contains exactly one audited Google Fonts stylesheet plus both preconnects. All eleven route entries render without loading/error residue at 1,440×900 and 390×844, and the active field-terminal typography remains visually identical to the local reviewed build.
 
-### 4. Cognito authentication integration coverage — In progress
+### 4. Cognito authentication integration coverage — Complete
 
 **Scope**
 
@@ -210,9 +210,12 @@ Prefer after route modernization if test helpers would otherwise be rewritten tw
 - Contract and deterministic scenario matrix: [`docs/design/frontend-auth-integration.md`](frontend-auth-integration.md).
 - Focused local verification: six auth/account/generator suites / 32 tests cover verified, unverified, signed-out, expired/absent-token, invalid-credential, generic service-error, protected API, and anonymous-generation paths.
 - Full local verification: typecheck, 55 files / 1,054 tests, zero production vulnerabilities, production build, and every bundle budget pass. Browser smoke confirms the signed-out account recovery surface, sign-in dialog/client validation, and anonymous showroom generation at desktop and phone widths without using or storing real credentials.
-- PR, CI, deployment, and production smoke evidence pending.
+- PR: [#238, Cover frontend authentication integration](https://github.com/nickcjordan/Xalians/pull/238), merged as `e2370bd` on 2026-09-11.
+- CI: [CI run 34623107821](https://github.com/nickcjordan/Xalians/actions/runs/34623107821) and [Terraform-plan run 34623107801](https://github.com/nickcjordan/Xalians/actions/runs/34623107801) passed; Linux reproduced 55 frontend files / 1,054 tests, 12 content files / 37 tests, zero dependency vulnerabilities, and every bundle budget. All three job-annotation responses were empty.
+- Deploy: [frontend run 34623269872](https://github.com/nickcjordan/Xalians/actions/runs/34623269872) passed its production build, S3 sync, and CloudFront invalidation with an empty job-annotation response.
+- Production verification: signed-out `/account`, the sign-in dialog and client-side validation, phone layout, and the anonymous Generator showroom all rendered without loading/error residue. No real credentials were entered or stored.
 
-### 5. React Router modernization — Planned
+### 5. React Router modernization — In progress
 
 **Scope**
 
@@ -235,7 +238,11 @@ Coordinate with CSS route loading so both changes agree on route boundaries. Kee
 
 **Evidence / links**
 
-Pending.
+- Migration contract, route inventory, and compatibility decision: [`docs/design/frontend-router-migration.md`](frontend-router-migration.md).
+- Implementation: `react-router-dom` 7.18.3 replaces 5.3.4; route elements, `Routes`, `Navigate`, `useNavigate`, relative encyclopedia routes, `NavLink end`, and typed upstream declarations replace every v5-only API and the blanket local module shim.
+- Deterministic route verification: two new suites / 36 tests cover the application and encyclopedia boundaries, canonical/deep/dynamic routes, catch-alls, and all retired redirects with search/hash state. The tests exposed and now guard a v7 structured-path incompatibility in the retired tour-beat redirect.
+- Local verification: typecheck, 57 frontend files / 1,090 tests, zero production vulnerabilities, production build, and every bundle budget pass. Browser checks cover direct numeric-species and retired-tour links, query/hash preservation, navbar navigation, back/forward, deep story loading, and the catch-all at desktop and phone widths. A discovered long-path phone overflow is fixed and remeasured at 390 px content width in a 390 px viewport with no console errors.
+- PR, CI, deployment, and production smoke evidence pending.
 
 ### 6. Redux Toolkit and React runtime — Planned
 
@@ -323,6 +330,7 @@ Pending.
 | 2026-09-11 | Keep application builds on Node 22 while upgrading action runtime majors. | GitHub's warning concerns the Node runtime bundled by each action. Changing the app runtime in the same slice would add unrelated risk. |
 | 2026-09-11 | Preserve distinct terminal typography until actual selectors and routes are audited. | Visual character is a product constraint; request-count reduction alone does not justify flattening it. |
 | 2026-09-11 | Separate router modernization from React/Redux modernization. | Each has independent breaking APIs and deserves isolated regression evidence. |
+| 2026-09-11 | Move React 18 to `react-router-dom` 7.18.3; defer React Router 8 and its package-import change to the React 19 workstream. | Router 7 is the current compatible upgrade for this deliberately isolated slice. Router 8 requires React 19.2.7 or newer and removes `react-router-dom`, which would collapse two independently risky migrations into one review. |
 | 2026-09-11 | Frackworm is ratified and live. The earlier species-art replacement concern applies to Tetrahive, not Avili/Avilily. | Prevent stale art assumptions from entering frontend regression work. |
 
 ## Change log
@@ -339,6 +347,7 @@ Pending.
 | 2026-09-11 | Completed the first selector-audit deletion and began the training-style ownership split from deployed `main` at `9394d49`. | [PR #230](https://github.com/nickcjordan/Xalians/pull/230); clean CI/deploy annotations, shipped bundle reduction, and live cross-game evidence recorded in workstream 2. |
 | 2026-09-11 | Completed the training-style ownership split and began removing the retired type-colour utility contract from deployed `main` at `82f6b9d`. | [PR #231](https://github.com/nickcjordan/Xalians/pull/231); clean CI/deploy annotations, shipped bundle and route-JavaScript reductions, and live cross-game evidence recorded in workstream 2. |
 | 2026-09-11 | Completed the type-colour utility deletion and resumed the residual shared-selector audit from deployed `main` at `b3d73d0`. | [PR #232](https://github.com/nickcjordan/Xalians/pull/232); clean CI/deploy annotations, shipped CSS reduction, and live type-badge evidence recorded in workstream 2. |
+| 2026-09-11 | Completed the authentication integration slice and began React Router modernization from deployed `main` at `e2370bd`. | [PR #238](https://github.com/nickcjordan/Xalians/pull/238); authentication evidence is complete in workstream 4. Router implementation, 36 route-contract tests, full local gates, and browser evidence are recorded in workstream 5; PR pending. |
 | 2026-09-11 | Completed the retired-navbar CSS deletion and continued the residual selector audit from deployed `main` at `9e3924b`. | [PR #233](https://github.com/nickcjordan/Xalians/pull/233); clean CI/deploy annotations, shipped CSS reduction, and live desktop/mobile navigation evidence recorded in workstream 2. |
 | 2026-09-11 | Completed the unreachable chrome-page CSS deletion and continued the residual selector audit from deployed `main` at `1129875`. | [PR #234](https://github.com/nickcjordan/Xalians/pull/234); clean CI/deploy annotations, shipped CSS reduction, and live cross-route evidence recorded in workstream 2. |
 | 2026-09-11 | Completed the residual shared-selector deletion and folded the final element defaults from deployed `main` at `1b1f7f6`. | [PR #235](https://github.com/nickcjordan/Xalians/pull/235); clean CI/deploy annotations, shipped CSS reduction, and live active-game evidence recorded in workstream 2. |

--- a/docs/design/frontend-router-migration.md
+++ b/docs/design/frontend-router-migration.md
@@ -1,0 +1,40 @@
+# Frontend router migration contract
+
+Audit date: 2026-09-11  
+Starting point: `e2370bd` (`main` after PR #238)
+
+## Version boundary
+
+This slice upgrades `react-router-dom` from 5.3.4 to 7.18.3 while retaining React 18.3.1. It adopts the supported declarative v7 API without changing the application's rendering model: `Routes`, route `element` values, `Navigate`, `useNavigate`, relative nested routes, and `NavLink end` replace their v5 counterparts.
+
+React Router 8 is intentionally part of the later React runtime decision. It requires React 19.2.7 or newer and removes the `react-router-dom` package in favor of imports from `react-router`; taking it here would combine the router, React runtime, and package-import migrations in one review.
+
+## Route ownership
+
+| Boundary | Canonical paths | Fallback |
+| --- | --- | --- |
+| Application shell | `/`, `/generator`, `/account`, `/user/:id`, `/duel`, `/duel/reference`, `/reclamation`, `/long-return`, `/train`, `/train/match`, `/train/physics` | Application not-found page |
+| Encyclopedia shell | `/encyclopedia`, `/encyclopedia/story/:era?`, `/encyclopedia/worlds/:key?`, `/encyclopedia/species/:key?`, `/encyclopedia/powers`, `/encyclopedia/index/:key?` | Encyclopedia-local empty state |
+| Developer-only | `/dev/error`; `/styleguide` only in development or an explicit styleguide build | Production `/styleguide` reaches the application fallback |
+
+The application route component is exported separately from its providers so `MemoryRouter` tests can exercise routing without recreating Redux, browser history, or authentication infrastructure. The encyclopedia keeps its nested `Routes` beneath the application's `/encyclopedia/*` match, which supplies the relative route context used in production.
+
+## Retired-address compatibility
+
+| Retired address | Destination |
+| --- | --- |
+| `/species` | `/encyclopedia/species` |
+| `/species/:id` | Canonical species-name record; an unknown id falls back to the Bestiary |
+| `/planets` | `/encyclopedia/worlds` |
+| `/glossary` | `/encyclopedia/index` |
+| `/encyclopedia/chronicle/:era?` | `/encyclopedia/story/:era?` |
+| `/encyclopedia/read/:era?` | `/encyclopedia/story/:era?` |
+| `/encyclopedia/tour/:beat?` | The beat's canonical story-era anchor, or the story index if unknown |
+
+All redirects replace rather than append browser history and preserve incoming query strings and hashes. A known tour beat supplies its canonical `#beat-*` anchor when the old URL has no explicit hash; an explicit incoming hash wins so existing bookmarks are not discarded.
+
+## Regression matrix
+
+`appRoutes.test.js` owns top-level canonical routes, the dynamic user id, retired application addresses, query/hash preservation, species-id normalization, and the application fallback. `encyclopediaRoutes.test.js` owns relative section/detail routes, retired story addresses, canonical tour-beat anchors, and the local fallback. Together they add 36 deterministic route-contract cases.
+
+The production-build browser smoke covers a numeric species deep link, a retired tour-beat deep link, query/hash preservation, navbar navigation, browser back/forward, a hash-targeted story page, and the not-found page at 1,440×900 and 390×844. It also checks loading/error residue, console errors, and document overflow. The smoke found an unbreakable long path on the phone not-found surface; the path now wraps within the viewport.

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "react-dom": "18",
         "react-hook-form": "^7.87.0",
         "react-redux": "^8.0.1",
-        "react-router-dom": "^5.3.0",
+        "react-router-dom": "^7.18.3",
         "recharts": "3.8.0",
         "sonner": "^2.0.8",
         "tailwind-merge": "^3.6.0",
@@ -8999,20 +8999,6 @@
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.5.tgz",
       "integrity": "sha512-G7HLD+WKcrOyJP5VQwYZNC3Z6FcQ7YYjEFiFoIj8PfEr73mu421o8B1N5DKUcc8K37EsJ2XXWA8DtrDz/2dReg=="
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -11723,63 +11709,55 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "react-router": "7.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
@@ -11928,12 +11906,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT"
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
@@ -12340,6 +12312,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -13020,12 +12998,6 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -13444,12 +13416,6 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",


### PR DESCRIPTION
## Summary
- upgrade React Router DOM from 5.3.4 to 7.18.3 without coupling the React 19 workstream
- migrate application and encyclopedia routes to the supported declarative API while preserving legacy URL, query, and hash behavior
- add 36 route-contract tests and fix narrow-screen not-found path overflow discovered in browser verification

## Verification
- 
pm run typecheck -w apps/web
- 
pm test -w apps/web -- --run (57 files / 1,090 tests)
- workspace API/content/rules tests (12/65, 12/37, 12/311)
- 
pm audit --omit=dev (0 vulnerabilities)
- 
pm run build -w apps/web (all bundle budgets pass)
- production-build browser smoke at 1,440x900 and 390x844: canonical/deep routes, numeric species and tour redirects, search/hash preservation, navbar navigation, back/forward, catch-all, overflow, and console errors