### PR TITLE
Guard Physics animation setup

### DIFF
--- a/apps/web/src/pages/games/physicsGamePage.js
+++ b/apps/web/src/pages/games/physicsGamePage.js
@@ -28,14 +28,22 @@ class PhysicsGamePage extends React.Component {
 
 
 	componentDidMount() {
-        InertiaPlugin.track("#target", "x,y"); 
-     
-        gsap.set('#figzy-body', { transformOrigin: '50%, bottom'});
-        gsap.set('#figzy-inside-spinner, #figzy-outside-spinner', { transformOrigin: '50%, 50%' });
-        gsap.to('#figzy-inside-spinner, #figzy-outside-spinner', {scale: ((this.state.powerValue + 50) / 100)});
-
         // window.addEventListener('resize', this.updateSize);
 		this.updateSize(() => {
+            // The arena is conditional on `size`, so these nodes do not exist
+            // until the state update above has committed. Initialise GSAP from
+            // this callback instead of asking it to animate missing targets.
+            const target = document.getElementById('target');
+            const arena = document.getElementById('arena');
+            const figzyBody = document.getElementById('figzy-body');
+            const figzySpinners = document.querySelectorAll('#figzy-inside-spinner, #figzy-outside-spinner');
+            if (!target || !arena || !figzyBody || figzySpinners.length === 0) return;
+
+            InertiaPlugin.track(target, "x,y");
+            gsap.set(figzyBody, { transformOrigin: '50%, bottom'});
+            gsap.set(figzySpinners, { transformOrigin: '50%, 50%' });
+            gsap.to(figzySpinners, {scale: ((this.state.powerValue + 50) / 100)});
+
             // Draggable.create('#figzy-outside-spinner', {
 
                 // gsap.to('#target', {
@@ -44,8 +52,8 @@ class PhysicsGamePage extends React.Component {
                 //     }
                 // });
 
-            Draggable.create('#target', {
-                bounds: document.getElementById("arena"),
+            Draggable.create(target, {
+                bounds: arena,
                 // edgeResistance: 1,
                 type: 'x,y',
                 inertia: true,

--- a/docs/design/frontend-final-regression.md
+++ b/docs/design/frontend-final-regression.md
@@ -39,7 +39,7 @@ Every route above was checked for document overflow, loading residue, missing im
 | FR-04 | P2 | Duel setup switches had no accessible names. | Added stable purpose-specific labels. | Duel / none |
 | FR-05 | P2 | Duel reference overflowed a 390 px document by 146 px. | Constrained the bench and isolated unavoidable specimen width inside local scrollers. | Duel / none |
 | FR-06 | P2 | Several phone controls exposed 18–39 px targets. | Applied the 44 px interaction contract to shared controls, Encyclopedia category tabs, and Reclamation segments; enlarged switch hit areas without visual inflation. | Frontend / none |
-| FR-07 | P3 | Training subgames lacked primary headings and Match emitted a React key warning. | Added route headings and keyed the repeated fragment. | Training / none |
+| FR-07 | P3 | Training subgames lacked primary headings, Match emitted a React key warning, and Physics asked GSAP to animate its conditional SVG before mount. | Added route headings, keyed the repeated fragment, and moved Physics animation setup behind the arena's committed render. | Training / none |
 
 No open regression remains from this matrix.
 


### PR DESCRIPTION
## Summary
- initialize Physics training's GSAP targets only after the conditional arena render commits
- use the resolved DOM nodes for animation and draggable setup
- record the clean-console fix in the final audit

## Verification
- 58 web files / 1,110 tests
- web typecheck
- production build and every bundle budget
- Chromium 390x844: arena, target, and both spinners render with no GSAP missing-target warnings