### PR TITLE
Add an at-a-glance brief to generated Xalians

### DIFF
--- a/apps/web/src/components/record/RecordView.tsx
+++ b/apps/web/src/components/record/RecordView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router';
 import type { XalianRecord } from '@xalians/content/schema';
 import { getSpeciesTemplate, speciesDisplayName } from '@xalians/rules/generator';
+import { gradeWithBundledCalibration } from '@xalians/rules/generator/grade';
 
 import XalianImage from '../xalianImage';
 import * as lore from '../../lore';
@@ -80,6 +81,25 @@ function Ability({ ability }: { ability: XalianRecord['abilities'][number] }) {
 	);
 }
 
+function BriefCard({ label, value, caption }: { label: string; value: React.ReactNode; caption: React.ReactNode }) {
+	return (
+		<Card variant="recessed" className="gap-2 p-4">
+			<p className="type-legend m-0">{label}</p>
+			<p className="type-subhead m-0 text-ink">{value}</p>
+			<p className="m-0 font-body text-small text-ink-2">{caption}</p>
+		</Card>
+	);
+}
+
+function ordinal(value: number): string {
+	const lastTwo = value % 100;
+	if (lastTwo >= 11 && lastTwo <= 13) return `${value}th`;
+	if (value % 10 === 1) return `${value}st`;
+	if (value % 10 === 2) return `${value}nd`;
+	if (value % 10 === 3) return `${value}rd`;
+	return `${value}th`;
+}
+
 function RecordView({ record, kicker = 'Record' }: RecordViewProps) {
 	const template = getSpeciesTemplate(record.species);
 	const name = speciesDisplayName(record.species);
@@ -90,6 +110,16 @@ function RecordView({ record, kicker = 'Record' }: RecordViewProps) {
 	const archetype = archetypeTerm(record.archetype.key);
 	const finish = record.appearance.finish;
 	const appearance = template ? template.lore.appearance : [];
+	const strongestAttributes = ATTRIBUTE_ORDER
+		.map((key) => ({ key, value: record.attributes[key as keyof XalianRecord['attributes']] }))
+		.sort((a, b) => b.value - a.value)
+		.slice(0, 2);
+	const strongestCapability = CAPABILITY_ORDER
+		.map((key) => ({ key, value: physiology.capabilities[key as keyof typeof physiology.capabilities] }))
+		.sort((a, b) => b.value - a.value)[0];
+	const signatureAbility = record.abilities.find((ability) => ability.signature) || record.abilities[0];
+	const distinction = template ? gradeWithBundledCalibration(record, template).percentile : null;
+	const roundedDistinction = distinction == null ? null : Math.round(distinction);
 
 	const speciesRoute = lore.getSpecies(record.species) ? lore.routeFor('species', record.species) : null;
 	const originKey = record.provenance.origin;
@@ -168,6 +198,44 @@ function RecordView({ record, kicker = 'Record' }: RecordViewProps) {
 						]} />
 				</div>
 			</header>
+
+			<section aria-labelledby="creature-brief-title" className="border-y border-edge py-6">
+				<p className="type-legend m-0">Creature brief</p>
+				<h3 id="creature-brief-title" className="type-heading mt-2 mb-2 text-[19px]">Read this one at a glance</h3>
+				<p className="measure mt-0 mb-5 font-body text-body text-ink-2">
+					{name} presents as {archetype.name.toLowerCase()}, led by{' '}
+					{strongestAttributes.map(({ key }) => attributeTerm(key).name.toLowerCase()).join(' and ')}.
+					{strongestCapability ? ` Its strongest physical aptitude is ${capabilityTerm(strongestCapability.key).name.toLowerCase()}.` : ''}
+					{signatureAbility ? ` ${signatureAbility.name} is its signature ability.` : ''}
+				</p>
+
+				<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+					<BriefCard
+						label="Disposition"
+						value={archetype.name}
+						caption={record.archetype.favors.length > 0
+							? `Naturally favors ${record.archetype.favors.map((key) => attributeTerm(key).name.toLowerCase()).join(' and ')}.`
+							: 'Its broad natural bearing.'}
+					/>
+					<BriefCard
+						label="Strongest aptitude"
+						value={strongestCapability ? capabilityTerm(strongestCapability.key).name : '—'}
+						caption={strongestCapability ? `${strongestCapability.value} out of 100 in its natural capability record.` : 'No capability reading.'}
+					/>
+					<BriefCard
+						label="Signature ability"
+						value={signatureAbility ? signatureAbility.name : '—'}
+						caption={signatureAbility
+							? `${intensityBand(signatureAbility.intensity)} expression through ${elementTerm(signatureAbility.medium).name.toLowerCase()}.`
+							: 'No signature ability recorded.'}
+					/>
+					<BriefCard
+						label="Registry distinction"
+						value={roundedDistinction == null ? 'Uncalibrated' : `${ordinal(roundedDistinction)} percentile`}
+						caption="How unusual this record is among calibrated generations—not combat power."
+					/>
+				</div>
+			</section>
 
 			<Layer title="Physiology">
 				<SpecPlate

--- a/apps/web/src/components/record/RecordView.tsx
+++ b/apps/web/src/components/record/RecordView.tsx
@@ -201,7 +201,9 @@ function RecordView({ record, kicker = 'Record' }: RecordViewProps) {
 
 			<section aria-labelledby="creature-brief-title" className="border-y border-edge py-6">
 				<p className="type-legend m-0">Creature brief</p>
-				<h3 id="creature-brief-title" className="type-heading mt-2 mb-2 text-[19px]">Read this one at a glance</h3>
+				<p id="creature-brief-title" className="type-heading mt-2 mb-2 text-[19px]">
+					Read this one at a glance
+				</p>
 				<p className="measure mt-0 mb-5 font-body text-body text-ink-2">
 					{name} presents as {archetype.name.toLowerCase()}, led by{' '}
 					{strongestAttributes.map(({ key }) => attributeTerm(key).name.toLowerCase()).join(' and ')}.

--- a/apps/web/src/pages/generatorPage.tsx
+++ b/apps/web/src/pages/generatorPage.tsx
@@ -189,7 +189,7 @@ function GeneratorPage() {
 					) : record ? (
 						<React.Fragment>
 							{mode === 'owned' ? (
-								<Callout variant="viable" title="Saved to your collection" className="mb-6">
+								<Callout variant="viable" title="Kept" className="mb-6">
 									<p className="m-0">This one is yours. It is in the registry under your name.</p>
 									<div className="mt-3 flex flex-wrap gap-2">
 										<Button disabled={isGenerating} onClick={() => generate(true, profile)}>
@@ -201,7 +201,7 @@ function GeneratorPage() {
 									</div>
 								</Callout>
 							) : signedIn ? (
-								<Callout variant="note" title="Preview only" className="mb-6">
+								<Callout variant="note" title="Showroom creature" className="mb-6">
 									<p className="m-0">
 										The first creature is a showroom preview, so it was not saved. Generate again and the next
 										creature will be written to your collection.
@@ -213,7 +213,7 @@ function GeneratorPage() {
 									</div>
 								</Callout>
 							) : (
-								<Callout variant="note" title="Preview only" className="mb-6">
+								<Callout variant="note" title="Showroom creature" className="mb-6">
 									<p className="m-0">
 										Showroom creatures cannot be kept. This one is real, and it is gone the moment the lever turns
 										again. Sign in and the Generator writes what it prints into the registry under your name.

--- a/apps/web/src/pages/generatorPage.tsx
+++ b/apps/web/src/pages/generatorPage.tsx
@@ -188,32 +188,50 @@ function GeneratorPage() {
 						</Card>
 					) : record ? (
 						<React.Fragment>
-							<Card variant="glass">
-								<RecordView record={record} kicker={mode === 'owned' ? 'Yours' : 'Showroom'} />
-							</Card>
-
 							{mode === 'owned' ? (
-								<Callout variant="viable" title="Kept" className="mt-6">
+								<Callout variant="viable" title="Saved to your collection" className="mb-6">
 									<p className="m-0">This one is yours. It is in the registry under your name.</p>
-									<div className="mt-3">
+									<div className="mt-3 flex flex-wrap gap-2">
+										<Button disabled={isGenerating} onClick={() => generate(true, profile)}>
+											Generate another
+										</Button>
 										<Button variant="secondary" asChild>
 											<Link to="/account">See your Xalians</Link>
 										</Button>
 									</div>
 								</Callout>
+							) : signedIn ? (
+								<Callout variant="note" title="Preview only" className="mb-6">
+									<p className="m-0">
+										The first creature is a showroom preview, so it was not saved. Generate again and the next
+										creature will be written to your collection.
+									</p>
+									<div className="mt-3">
+										<Button disabled={isGenerating} onClick={() => generate(true, profile)}>
+											Generate yours
+										</Button>
+									</div>
+								</Callout>
 							) : (
-								<Callout variant="note" title="Showroom creature" className="mt-6">
+								<Callout variant="note" title="Preview only" className="mb-6">
 									<p className="m-0">
 										Showroom creatures cannot be kept. This one is real, and it is gone the moment the lever turns
 										again. Sign in and the Generator writes what it prints into the registry under your name.
 									</p>
-									<div className="mt-3">
+									<div className="mt-3 flex flex-wrap gap-2">
+										<Button disabled={isGenerating} onClick={() => generate(false, profile)}>
+											Generate another preview
+										</Button>
 										<Button variant="secondary" onClick={() => setSignInShow(true)}>
 											Sign in to generate
 										</Button>
 									</div>
 								</Callout>
 							)}
+
+							<Card variant="glass">
+								<RecordView record={record} kicker={mode === 'owned' ? 'Yours' : 'Showroom'} />
+							</Card>
 						</React.Fragment>
 					) : (
 						<EmptyState legend="No Xalian yet">


### PR DESCRIPTION
## What changed\n- adds a concise creature brief above the detailed record\n- surfaces disposition, strongest aptitude, signature ability, and registry distinction\n- keeps registry distinction explicitly separate from combat power\n- moves preview/ownership actions before the long dossier\n- fixes the signed-in first-preview state to offer Generate yours instead of Sign in\n\n## Verification\n- npm run typecheck --workspace apps/web\n- npm run build --workspace apps/web\n- visually checked desktop and 390px mobile layouts\n\nNo test files were added or changed.