### PR TITLE
Add creature comparison and public registry sharing

### DIFF
--- a/apps/api/src/handlers/listPublicRegistryXalians.ts
+++ b/apps/api/src/handlers/listPublicRegistryXalians.ts
@@ -1,0 +1,26 @@
+// GET /registry/owners/{ownerId}/xalians. Public read-only binder route. The owner
+// must be explicit so this route never guesses identity from an unverified request.
+import { withApi } from '../lib/api.ts';
+import { PublicRegistryListQuerySchema, PublicRegistryOwnerParamsSchema } from '../lib/schemas.ts';
+import * as registryRepo from '../repositories/registry.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ params, query, requestId }) => {
+    const result = await registryRepo.listByOwner(params.ownerId.toLowerCase(), {
+      limit: query.limit,
+      cursor: query.cursor,
+    });
+
+    log.info('listPublicRegistryXalians success', {
+      requestId,
+      ownerId: params.ownerId,
+      count: result.items.length,
+    });
+    return {
+      status: 200,
+      body: result.nextCursor ? { items: result.items, nextCursor: result.nextCursor } : { items: result.items },
+    };
+  },
+  { auth: 'none', params: PublicRegistryOwnerParamsSchema, query: PublicRegistryListQuerySchema }
+);

--- a/apps/api/src/handlers/retrievePublicRegistryXalian.ts
+++ b/apps/api/src/handlers/retrievePublicRegistryXalian.ts
@@ -1,0 +1,18 @@
+// GET /registry/xalians/{xalianId}. Public read-only record route for share links.
+// Records are public by product contract; mutations remain on authenticated routes.
+import { ApiError, withApi } from '../lib/api.ts';
+import { RetrieveRegistryXalianParamsSchema } from '../lib/schemas.ts';
+import * as registryRepo from '../repositories/registry.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ params, requestId }) => {
+    const record = await registryRepo.getRecord(params.xalianId);
+    if (!record) {
+      throw new ApiError(404, 'XALIAN_NOT_FOUND', `Did not find xalian with xalianId=${params.xalianId}`);
+    }
+    log.info('retrievePublicRegistryXalian success', { requestId, xalianId: params.xalianId });
+    return { status: 200, body: record };
+  },
+  { auth: 'none', params: RetrieveRegistryXalianParamsSchema }
+);

--- a/apps/api/src/lib/schemas.ts
+++ b/apps/api/src/lib/schemas.ts
@@ -72,6 +72,19 @@ export const RetrieveRegistryXalianParamsSchema = z.object({
 });
 export type RetrieveRegistryXalianParams = z.infer<typeof RetrieveRegistryXalianParamsSchema>;
 
+// Public binder route: explicit owner in the path, with the same bounded pagination
+// controls as the authenticated collection route.
+export const PublicRegistryOwnerParamsSchema = z.object({
+  ownerId: z.string().min(1),
+});
+export type PublicRegistryOwnerParams = z.infer<typeof PublicRegistryOwnerParamsSchema>;
+
+export const PublicRegistryListQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(200).optional(),
+  cursor: z.string().min(1).optional(),
+});
+export type PublicRegistryListQuery = z.infer<typeof PublicRegistryListQuerySchema>;
+
 // DELETE /xalians/{xalianId}
 export const ReleaseRegistryXalianParamsSchema = z.object({
   xalianId: z.string().min(1),

--- a/apps/web/src/App.js
+++ b/apps/web/src/App.js
@@ -52,6 +52,7 @@ const StyleGuidePage = includeStyleGuide
 const GeneratorPage = lazy(() => import('./pages/generatorPage'));
 const UserAccountPage = lazy(() => import('./pages/userAccountPage'));
 const UserDetailsPage = lazy(() => import('./pages/userDetailsPage'));
+const RecordPage = lazy(() => import('./pages/recordPage'));
 const MatchCardGamePage = lazy(() => import('./pages/games/matchCardGamePage'));
 const PhysicsGamePage = lazy(() => import('./pages/games/physicsGamePage'));
 const TrainingGroundsPage = lazy(() => import('./pages/trainingGroundsPage'));
@@ -94,6 +95,11 @@ function UserDetailsRoute() {
   return <UserDetailsPage id={id} />;
 }
 
+function RecordRoute() {
+  const { id } = useParams();
+  return <RecordPage id={id} />;
+}
+
 export function AppRoutes() {
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -105,6 +111,7 @@ export function AppRoutes() {
           <Route path="/species" element={<PreserveLocationRedirect to="/encyclopedia/species" />} />
           <Route path="/species/:id" element={<RedirectSpecies />} />
           <Route path="/user/:id" element={<UserDetailsRoute />} />
+          <Route path="/xalian/:id" element={<RecordRoute />} />
           <Route path="/planets" element={<PreserveLocationRedirect to="/encyclopedia/worlds" />} />
           <Route path="/glossary" element={<PreserveLocationRedirect to="/encyclopedia/index" />} />
           <Route path="/encyclopedia/*" element={<EncyclopediaPage />} />

--- a/apps/web/src/components/record/RecordCompare.tsx
+++ b/apps/web/src/components/record/RecordCompare.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import type { XalianRecord } from '@xalians/content/schema';
+import { getSpeciesTemplate, speciesDisplayName } from '@xalians/rules/generator';
+import { gradeWithBundledCalibration } from '@xalians/rules/generator/grade';
+
+import XalianImage from '../xalianImage';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import {
+	ATTRIBUTE_ORDER,
+	CAPABILITY_ORDER,
+	TEMPERAMENT_ORDER,
+	attributeTerm,
+	archetypeTerm,
+	capabilityTerm,
+	elementTerm,
+	physiologyTerm,
+	temperamentTerm,
+	traitTerm,
+	capitalize,
+	heightBoth,
+	intensityBand,
+	weightBoth,
+} from './vocabulary';
+
+type RecordSummary = {
+	record: XalianRecord;
+	name: string;
+	secondary: string | null;
+	archetype: string;
+	strongestAttributes: Array<{ name: string; value: number }>;
+	strongestCapability: { name: string; value: number };
+	leadingTemperament: { name: string; value: number };
+	signature: XalianRecord['abilities'][number] | undefined;
+	percentile: number | null;
+};
+
+function summarize(record: XalianRecord): RecordSummary {
+	const affinities = record.element.affinities as Record<string, number>;
+	const secondary = Object.keys(affinities).find((key) => key !== record.element.primary) || null;
+	const template = getSpeciesTemplate(record.species);
+	return {
+		record,
+		name: speciesDisplayName(record.species),
+		secondary,
+		archetype: archetypeTerm(record.archetype.key).name,
+		strongestAttributes: ATTRIBUTE_ORDER
+			.map((key) => ({ name: attributeTerm(key).name, value: record.attributes[key as keyof XalianRecord['attributes']] }))
+			.sort((a, b) => b.value - a.value)
+			.slice(0, 2),
+		strongestCapability: CAPABILITY_ORDER
+			.map((key) => ({ name: capabilityTerm(key).name, value: record.physiology.capabilities[key as keyof typeof record.physiology.capabilities] }))
+			.sort((a, b) => b.value - a.value)[0],
+		leadingTemperament: TEMPERAMENT_ORDER
+			.map((key) => ({ name: temperamentTerm(key).name, value: record.temperament[key as keyof XalianRecord['temperament']] }))
+			.sort((a, b) => b.value - a.value)[0],
+		signature: record.abilities.find((ability) => ability.signature) || record.abilities[0],
+		percentile: template ? gradeWithBundledCalibration(record, template).percentile : null,
+	};
+}
+
+function CompareRow({ label, left, right }: { label: string; left: React.ReactNode; right: React.ReactNode }) {
+	return (
+		<section className="border-t border-edge py-4">
+			<h3 className="type-legend mt-0 mb-3">{label}</h3>
+			<div className="grid grid-cols-2 gap-3">
+				<div className="min-w-0 font-body text-small text-ink">{left}</div>
+				<div className="min-w-0 font-body text-small text-ink">{right}</div>
+			</div>
+		</section>
+	);
+}
+
+function Affinity({ summary }: { summary: RecordSummary }) {
+	const primary = summary.record.element.primary;
+	return (
+		<div className="flex flex-wrap gap-2">
+			<span className={`el-${primary}`}><Badge variant="chip">{elementTerm(primary).name}</Badge></span>
+			{summary.secondary ? (
+				<span className={`el-${summary.secondary}`}><Badge variant="chip-outline">{elementTerm(summary.secondary).name}</Badge></span>
+			) : null}
+		</div>
+	);
+}
+
+function RecordCompare({ records }: { records: [XalianRecord, XalianRecord] }) {
+	const [left, right] = records.map(summarize) as [RecordSummary, RecordSummary];
+	return (
+		<div data-slot="record-compare">
+			<p className="measure mt-0 mb-5 font-body text-small text-ink-2">
+				Compare what these creatures are. The registry does not declare a winner, and games derive their own rules.
+			</p>
+
+			<div className="mb-5 grid grid-cols-2 gap-3">
+				{[left, right].map((summary) => (
+					<Card key={summary.record.id} variant="recessed" className={`el-${summary.record.element.primary} min-w-0 gap-3 p-3 sm:p-4`}>
+						<XalianImage
+							colored
+							speciesName={summary.record.species}
+							primaryType={summary.record.element.primary}
+							secondaryType={summary.secondary || undefined}
+							moreClasses="mx-auto w-full max-w-[180px]"
+						/>
+						<div>
+							<p className="type-subhead m-0 truncate">{summary.name}</p>
+							<p className="mt-1 mb-0 font-body text-small text-ink-2">{summary.archetype}</p>
+						</div>
+					</Card>
+				))}
+			</div>
+
+			<CompareRow label="Affinity" left={<Affinity summary={left} />} right={<Affinity summary={right} />} />
+			<CompareRow
+				label="Natural strengths"
+				left={left.strongestAttributes.map((item) => `${item.name} ${item.value}`).join(' · ')}
+				right={right.strongestAttributes.map((item) => `${item.name} ${item.value}`).join(' · ')}
+			/>
+			<CompareRow
+				label="Strongest aptitude"
+				left={`${left.strongestCapability.name} ${left.strongestCapability.value}`}
+				right={`${right.strongestCapability.name} ${right.strongestCapability.value}`}
+			/>
+			<CompareRow
+				label="Signature ability"
+				left={left.signature ? `${left.signature.name} · ${intensityBand(left.signature.intensity)}` : 'None recorded'}
+				right={right.signature ? `${right.signature.name} · ${intensityBand(right.signature.intensity)}` : 'None recorded'}
+			/>
+			<CompareRow
+				label="Traits"
+				left={left.record.traits.length > 0 ? left.record.traits.map((key) => traitTerm(key).name).join(' · ') : 'No rolled traits'}
+				right={right.record.traits.length > 0 ? right.record.traits.map((key) => traitTerm(key).name).join(' · ') : 'No rolled traits'}
+			/>
+			<CompareRow
+				label="Physiology"
+				left={`${physiologyTerm('bodyPlan', left.record.physiology.bodyPlan).name} · ${heightBoth(left.record.physiology.heightCm)} · ${weightBoth(left.record.physiology.weightKg)}`}
+				right={`${physiologyTerm('bodyPlan', right.record.physiology.bodyPlan).name} · ${heightBoth(right.record.physiology.heightCm)} · ${weightBoth(right.record.physiology.weightKg)}`}
+			/>
+			<CompareRow
+				label="Leading temperament"
+				left={`${left.leadingTemperament.name} ${left.leadingTemperament.value}`}
+				right={`${right.leadingTemperament.name} ${right.leadingTemperament.value}`}
+			/>
+			<CompareRow
+				label="Finish and distinction"
+				left={`${capitalize(left.record.appearance.finish)} · ${left.percentile == null ? 'Uncalibrated' : `Percentile ${Math.round(left.percentile)}`}`}
+				right={`${capitalize(right.record.appearance.finish)} · ${right.percentile == null ? 'Uncalibrated' : `Percentile ${Math.round(right.percentile)}`}`}
+			/>
+		</div>
+	);
+}
+
+export default RecordCompare;

--- a/apps/web/src/components/record/RecordTile.tsx
+++ b/apps/web/src/components/record/RecordTile.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { XalianRecord } from '@xalians/content/schema';
 import { speciesDisplayName } from '@xalians/rules/generator';
+import { Check, Plus } from 'lucide-react';
 
 import XalianImage from '../xalianImage';
 import { archetypeTerm, elementTerm, generatedOnShort, capitalize } from './vocabulary';
@@ -18,9 +19,14 @@ type RecordTileProps = {
 	onOpen: (record: XalianRecord) => void;
 	/** Rendered over the art, top right: a release key, or nothing. */
 	action?: React.ReactNode;
+	comparison?: {
+		selected: boolean;
+		disabled?: boolean;
+		onToggle: (record: XalianRecord) => void;
+	};
 };
 
-function RecordTile({ record, onOpen, action }: RecordTileProps) {
+function RecordTile({ record, onOpen, action, comparison }: RecordTileProps) {
 	const element = record.element.primary;
 	const affinities = record.element.affinities as Record<string, number>;
 	const secondary = Object.keys(affinities).find((key) => key !== element) || null;
@@ -62,6 +68,20 @@ function RecordTile({ record, onOpen, action }: RecordTileProps) {
 					<span className="type-data text-small text-ink-3 whitespace-nowrap">{generatedOnShort(record.provenance.generatedAt)}</span>
 				</TileMeta>
 			</Tile>
+			{comparison ? (
+				<div className="absolute top-2 left-2">
+					<button
+						type="button"
+						className="inline-flex size-10 items-center justify-center border border-edge-strong bg-s0 text-ink transition-colors hover:bg-s2 focus-visible:outline-2 focus-visible:outline-ring disabled:opacity-40"
+						aria-label={`${comparison.selected ? 'Remove' : 'Add'} ${name} ${comparison.selected ? 'from' : 'to'} comparison`}
+						aria-pressed={comparison.selected}
+						disabled={comparison.disabled}
+						onClick={() => comparison.onToggle(record)}
+					>
+						{comparison.selected ? <Check className="size-4 text-viable-hi" /> : <Plus className="size-4" />}
+					</button>
+				</div>
+			) : null}
 			{action ? <div className="absolute top-2 right-2">{action}</div> : null}
 		</div>
 	);

--- a/apps/web/src/components/record/RecordView.tsx
+++ b/apps/web/src/components/record/RecordView.tsx
@@ -8,6 +8,7 @@ import XalianImage from '../xalianImage';
 import * as lore from '../../lore';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { SpecPlate, Meter } from '@/components/system/record';
@@ -41,6 +42,8 @@ type RecordViewProps = {
 	record: XalianRecord;
 	/** A legend above the designation: what this record is on this page. */
 	kicker?: React.ReactNode;
+	/** Direct registry route when this persisted record can be shared. */
+	recordLink?: string;
 };
 
 function Layer({ title, children, className }: { title: string; children: React.ReactNode; className?: string }) {
@@ -100,7 +103,7 @@ function ordinal(value: number): string {
 	return `${value}th`;
 }
 
-function RecordView({ record, kicker = 'Record' }: RecordViewProps) {
+function RecordView({ record, kicker = 'Record', recordLink }: RecordViewProps) {
 	const template = getSpeciesTemplate(record.species);
 	const name = speciesDisplayName(record.species);
 	const element = record.element.primary;
@@ -196,6 +199,14 @@ function RecordView({ record, kicker = 'Record' }: RecordViewProps) {
 							{ key: 'Seed', value: <span className="break-all">{record.provenance.seed}</span> },
 							{ key: 'Generator', value: `v${record.provenance.generatorVersion}` },
 						]} />
+
+					{recordLink ? (
+						<div className="mt-1">
+							<Button variant="secondary" asChild>
+								<Link to={recordLink}>Open shareable record</Link>
+							</Button>
+						</div>
+					) : null}
 				</div>
 			</header>
 

--- a/apps/web/src/pages/generatorPage.tsx
+++ b/apps/web/src/pages/generatorPage.tsx
@@ -230,7 +230,11 @@ function GeneratorPage() {
 							)}
 
 							<Card variant="glass">
-								<RecordView record={record} kicker={mode === 'owned' ? 'Yours' : 'Showroom'} />
+								<RecordView
+									record={record}
+									kicker={mode === 'owned' ? 'Yours' : 'Showroom'}
+									recordLink={mode === 'owned' ? `/xalian/${record.id}` : undefined}
+								/>
 							</Card>
 						</React.Fragment>
 					) : (

--- a/apps/web/src/pages/recordPage.tsx
+++ b/apps/web/src/pages/recordPage.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { Link } from 'react-router';
+import { Copy, Library } from 'lucide-react';
+import { toast } from 'sonner';
+import type { XalianRecord } from '@xalians/content/schema';
+import { speciesDisplayName } from '@xalians/rules/generator';
+
+import XalianNavbar from '../components/navbar';
+import RecordView from '../components/record/RecordView';
+import * as dbApi from '../utils/dbApi';
+
+import { Shell, Masthead } from '@/components/system/masthead';
+import { HelixSpinner } from '@/components/system/brand';
+import { EmptyState } from '@/components/system/record';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+
+function RecordPage({ id }: { id: string }) {
+	const [record, setRecord] = React.useState<XalianRecord | null>(null);
+	const [isLoading, setIsLoading] = React.useState(true);
+	const [message, setMessage] = React.useState<string | null>(null);
+
+	React.useEffect(() => {
+		let cancelled = false;
+		setIsLoading(true);
+		setMessage(null);
+		dbApi.callGetPublicXalian(id)
+			.then((next: XalianRecord) => {
+				if (!cancelled) setRecord(next);
+			})
+			.catch((error: any) => {
+				if (cancelled) return;
+				setMessage(error?.status === 404
+					? 'This Xalian is not in the registry.'
+					: 'The registry could not load this Xalian. Please try again later.');
+			})
+			.finally(() => {
+				if (!cancelled) setIsLoading(false);
+			});
+		return () => { cancelled = true; };
+	}, [id]);
+
+	const copyLink = () => {
+		navigator.clipboard.writeText(window.location.href)
+			.then(() => toast.success('Record link copied'))
+			.catch(() => toast.error('Could not copy the record link'));
+	};
+
+	return (
+		<main id="main" className="min-h-screen bg-room text-ink font-body" data-tier="chrome">
+			<XalianNavbar />
+			<Shell className="pb-16">
+				<Masthead
+					kicker="Registry"
+					title={record ? speciesDisplayName(record.species) : 'Xalian record'}
+					subtitle="A permanent creature record. Its nature is shared; each game decides how to read it."
+					aside={record ? (
+						<Button onClick={copyLink}><Copy /> Copy link</Button>
+					) : undefined}
+				/>
+
+				{isLoading ? (
+					<div className="flex justify-center py-16"><HelixSpinner /></div>
+				) : message ? (
+					<EmptyState legend={message}>
+						<Button variant="secondary" asChild>
+							<Link to="/generator">Visit the Generator</Link>
+						</Button>
+					</EmptyState>
+				) : record ? (
+					<Card variant="glass">
+						<RecordView record={record} kicker="Registry record" />
+					</Card>
+				) : null}
+
+				{record ? (
+					<div className="mt-6 flex justify-center">
+						<Button variant="secondary" asChild>
+							<Link to="/generator"><Library /> Generate your own</Link>
+						</Button>
+					</div>
+				) : null}
+			</Shell>
+		</main>
+	);
+}
+
+export default RecordPage;

--- a/apps/web/src/pages/userAccountPage.tsx
+++ b/apps/web/src/pages/userAccountPage.tsx
@@ -20,6 +20,7 @@ import SignUpModal from '../components/auth/signUpModal';
 import VerifyEmailModal from '../components/auth/verifyEmailModal';
 import RecordTile from '../components/record/RecordTile';
 import RecordView from '../components/record/RecordView';
+import RecordCompare from '../components/record/RecordCompare';
 import * as authUtil from '../utils/authUtil';
 import * as dbApi from '../utils/dbApi';
 
@@ -27,6 +28,7 @@ import { Shell, Masthead } from '@/components/system/masthead';
 import { HelixSpinner } from '@/components/system/brand';
 import { EmptyState } from '@/components/system/record';
 import { FilterBar, SearchField } from '@/components/system/filters';
+import { Callout } from '@/components/system/readouts';
 import { VisuallyHidden } from '@/components/system/a11y';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -59,6 +61,9 @@ function UserAccountPage() {
 	const [query, setQuery] = React.useState('');
 	const [affinity, setAffinity] = React.useState('all');
 	const [sort, setSort] = React.useState<CollectionSort>('newest');
+	const [compareMode, setCompareMode] = React.useState(false);
+	const [compareIds, setCompareIds] = React.useState<string[]>([]);
+	const [compareOpen, setCompareOpen] = React.useState(false);
 
 	const availableAffinities = React.useMemo(() => {
 		const keys = new Set<string>();
@@ -99,6 +104,19 @@ function UserAccountPage() {
 		setQuery('');
 		setAffinity('all');
 		setSort('newest');
+	};
+	const compareRecords = compareIds
+		.map((id) => records.find((record) => record.id === id))
+		.filter((record): record is XalianRecord => !!record);
+	const toggleCompareMode = () => {
+		setCompareMode((current) => !current);
+		setCompareIds([]);
+		setCompareOpen(false);
+	};
+	const toggleComparisonRecord = (record: XalianRecord) => {
+		setCompareIds((current) => current.includes(record.id)
+			? current.filter((id) => id !== record.id)
+			: current.length < 2 ? [...current, record.id] : current);
 	};
 
 	const loadFirstPage = React.useCallback(() => {
@@ -198,6 +216,7 @@ function UserAccountPage() {
 
 	const onReleased = () => {
 		setRecords((prev) => prev.filter((x) => x.id !== (recordToRelease && recordToRelease.id)));
+		setCompareIds((prev) => prev.filter((id) => id !== (recordToRelease && recordToRelease.id)));
 		if (openRecord && recordToRelease && openRecord.id === recordToRelease.id) {
 			setOpenRecord(null);
 		}
@@ -221,9 +240,16 @@ function UserAccountPage() {
 					subtitle={records.length > 0 ? `${records.length} generated` : undefined}
 					aside={
 						!signedOut ? (
-							<Button asChild>
-								<Link to="/generator">Generate a Xalian</Link>
-							</Button>
+							<div className="flex w-full flex-col gap-3 sm:flex-row md:w-auto">
+								{records.length > 1 ? (
+									<Button variant="secondary" onClick={toggleCompareMode}>
+										{compareMode ? 'Done comparing' : 'Compare Xalians'}
+									</Button>
+								) : null}
+								<Button asChild>
+									<Link to="/generator">Generate a Xalian</Link>
+								</Button>
+							</div>
 						) : undefined
 					}
 				/>
@@ -260,6 +286,22 @@ function UserAccountPage() {
 
 				{!isLoading && !signedOut && !message && records.length > 0 && (
 					<React.Fragment>
+						{compareMode ? (
+							<Callout variant="note" title="Choose two Xalians" className="mb-4">
+								<p className="m-0">
+									{compareIds.length === 0
+										? 'Use the plus keys on two collection tiles.'
+										: compareIds.length === 1 ? 'One chosen. Pick one more.' : 'Two chosen and ready to compare.'}
+								</p>
+								{compareIds.length === 2 ? (
+									<div className="mt-3 flex flex-wrap gap-2">
+										<Button onClick={() => setCompareOpen(true)}>Compare selected</Button>
+										<Button variant="ghost" onClick={() => setCompareIds([])}>Start over</Button>
+									</div>
+								) : null}
+							</Callout>
+						) : null}
+
 						<FilterBar
 							className="mb-3"
 							search={
@@ -328,6 +370,11 @@ function UserAccountPage() {
 												<Trash2 />
 											</Button>
 										}
+										comparison={compareMode ? {
+											selected: compareIds.includes(record.id),
+											disabled: compareIds.length >= 2 && !compareIds.includes(record.id),
+											onToggle: toggleComparisonRecord,
+										} : undefined}
 									/>
 								))}
 							</div>
@@ -352,7 +399,20 @@ function UserAccountPage() {
 						</VisuallyHidden>
 					</DialogHeader>
 					<ScrollArea className="max-h-[75vh] pr-4">
-						{openRecord && <RecordView record={openRecord} kicker="Yours" />}
+						{openRecord && <RecordView record={openRecord} kicker="Yours" recordLink={`/xalian/${openRecord.id}`} />}
+					</ScrollArea>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={compareOpen} onOpenChange={setCompareOpen}>
+				<DialogContent className="sm:max-w-4xl">
+					<DialogHeader>
+						<DialogTitle>Compare Xalians</DialogTitle>
+					</DialogHeader>
+					<ScrollArea className="max-h-[75vh] pr-4">
+						{compareRecords.length === 2 ? (
+							<RecordCompare records={compareRecords as [XalianRecord, XalianRecord]} />
+						) : null}
 					</ScrollArea>
 				</DialogContent>
 			</Dialog>

--- a/apps/web/src/pages/userDetailsPage.tsx
+++ b/apps/web/src/pages/userDetailsPage.tsx
@@ -4,6 +4,8 @@
 import * as React from 'react';
 import type { XalianRecord } from '@xalians/content/schema';
 import { speciesDisplayName } from '@xalians/rules/generator';
+import { Copy } from 'lucide-react';
+import { toast } from 'sonner';
 
 import XalianNavbar from '../components/navbar';
 import RecordTile from '../components/record/RecordTile';
@@ -33,7 +35,7 @@ function UserDetailsPage({ id }: UserDetailsPageProps) {
 	React.useEffect(() => {
 		setIsLoading(true);
 		dbApi
-			.callListXalians(id)
+			.callListPublicXalians(id)
 			.then((page: any) => {
 				setRecords(page.items);
 				setCursor(page.nextCursor);
@@ -49,7 +51,7 @@ function UserDetailsPage({ id }: UserDetailsPageProps) {
 		if (!cursor) return;
 		setIsLoadingMore(true);
 		dbApi
-			.callListXalians(id, cursor)
+			.callListPublicXalians(id, cursor)
 			.then((page: any) => {
 				setRecords((prev) => [...prev, ...page.items]);
 				setCursor(page.nextCursor);
@@ -61,6 +63,12 @@ function UserDetailsPage({ id }: UserDetailsPageProps) {
 			});
 	};
 
+	const copyBinderLink = () => {
+		navigator.clipboard.writeText(window.location.href)
+			.then(() => toast.success('Binder link copied'))
+			.catch(() => toast.error('Could not copy the binder link'));
+	};
+
 	return (
 		<main id="main" className="min-h-screen bg-room text-ink font-body" data-tier="chrome">
 			<XalianNavbar />
@@ -70,6 +78,7 @@ function UserDetailsPage({ id }: UserDetailsPageProps) {
 					kicker="Account"
 					title={id}
 					subtitle={records.length > 0 ? `${records.length} generated` : undefined}
+					aside={<Button variant="secondary" onClick={copyBinderLink}><Copy /> Copy binder link</Button>}
 				/>
 
 				{isLoading && (
@@ -111,7 +120,7 @@ function UserDetailsPage({ id }: UserDetailsPageProps) {
 						</VisuallyHidden>
 					</DialogHeader>
 					<ScrollArea className="max-h-[75vh] pr-4">
-						{openRecord && <RecordView record={openRecord} kicker="Record" />}
+						{openRecord && <RecordView record={openRecord} kicker="Record" recordLink={`/xalian/${openRecord.id}`} />}
 					</ScrollArea>
 				</DialogContent>
 			</Dialog>

--- a/apps/web/src/utils/dbApi.js
+++ b/apps/web/src/utils/dbApi.js
@@ -158,6 +158,30 @@ export const callGetXalian = (id) => {
   return callGet(`${API}/xalians/${encodeURIComponent(id)}`).then((data) => XalianRecordSchema.parse(data));
 };
 
+/** Public read used by shareable creature pages; sends no identity or token. */
+export const callGetPublicXalian = (id) => {
+  if (useCache()) {
+    return Promise.resolve(XalianRecordSchema.parse(sampleRecords(1)[0]));
+  }
+  return requestJson(`${API}/registry/xalians/${encodeURIComponent(id)}`)
+    .then((data) => XalianRecordSchema.parse(data));
+};
+
+/** Public read used by shareable binder pages; sends no identity or token. */
+export const callListPublicXalians = (ownerId, cursor) => {
+  if (useCache()) {
+    return Promise.resolve({ items: sampleRecords(3).map((r) => XalianRecordSchema.parse(r)), nextCursor: undefined });
+  }
+  const params = new URLSearchParams();
+  if (cursor) params.set("cursor", cursor);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  return requestJson(`${API}/registry/owners/${encodeURIComponent(ownerId)}/xalians${suffix}`)
+    .then((data) => ({
+      items: data.items.map((item) => XalianRecordSchema.parse(item)),
+      nextCursor: data.nextCursor,
+    }));
+};
+
 /** Releases one of the caller's own records. Owner-only; the server enforces it. */
 export const callReleaseXalian = (id) => {
   if (useCache()) {

--- a/main.tf
+++ b/main.tf
@@ -407,6 +407,48 @@ module "retrieve_registry_xalian_lambda_module" {
 
 #########################################################
 #####               LAMBDA INSTANCE                 #####
+##       Public Retrieve Registry Xalian Lambda        ##
+#########################################################
+module "retrieve_public_registry_xalian_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "RetrievePublicRegistryXalian"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "retrievePublicRegistryXalian/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "GET /registry/xalians/{xalianId}"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "NONE"
+}
+#####                                               #####
+#########################################################
+
+#########################################################
+#####               LAMBDA INSTANCE                 #####
+##        Public List Registry Xalians Lambda          ##
+#########################################################
+module "list_public_registry_xalians_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "ListPublicRegistryXalians"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "listPublicRegistryXalians/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "GET /registry/owners/{ownerId}/xalians"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "NONE"
+}
+#####                                               #####
+#########################################################
+
+#########################################################
+#####               LAMBDA INSTANCE                 #####
 ##           Release Registry Xalian Lambda            ##
 #########################################################
 module "release_registry_xalian_lambda_module" {


### PR DESCRIPTION
## What changed
- add an in-collection two-creature comparison focused on intrinsic records, not winners
- add public, shareable creature record pages and binder links
- add anonymous read-only registry API routes for shared records and binders
- preserve authenticated ownership and release routes

## Validation
- web and API type checks
- web production build and bundle budgets
- API build
- Terraform formatting
- desktop and mobile visual review

No Playwright or new automated test work was added.