### PR TITLE
Add direct Xalian swap links

### DIFF
--- a/apps/api/src/handlers/acceptTrade.ts
+++ b/apps/api/src/handlers/acceptTrade.ts
@@ -1,0 +1,27 @@
+import { ApiError, withApi } from '../lib/api.ts';
+import { TradeParamsSchema } from '../lib/schemas.ts';
+import * as tradesRepo from '../repositories/trades.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ subject, params, requestId }) => {
+    const trade = await tradesRepo.getTrade(params.tradeId);
+    if (!trade) throw new ApiError(404, 'TRADE_NOT_FOUND', 'This trade offer was not found');
+    if (trade.recipientId !== subject) {
+      throw new ApiError(403, 'NOT_TRADE_RECIPIENT', 'Only the recipient may accept this offer');
+    }
+    if (trade.status !== 'open') throw new ApiError(409, 'TRADE_CONFLICT', 'This offer is no longer open');
+
+    try {
+      const accepted = await tradesRepo.acceptTrade(trade, new Date().toISOString());
+      log.info('acceptTrade success', { requestId, tradeId: trade.id, recipientId: subject });
+      return { status: 200, body: accepted };
+    } catch (err) {
+      if (err instanceof tradesRepo.TradeConflictError) {
+        throw new ApiError(409, 'TRADE_CONFLICT', err.message);
+      }
+      throw err;
+    }
+  },
+  { auth: 'jwt', params: TradeParamsSchema }
+);

--- a/apps/api/src/handlers/cancelTrade.ts
+++ b/apps/api/src/handlers/cancelTrade.ts
@@ -1,0 +1,27 @@
+import { ApiError, withApi } from '../lib/api.ts';
+import { TradeParamsSchema } from '../lib/schemas.ts';
+import * as tradesRepo from '../repositories/trades.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ subject, params, requestId }) => {
+    const trade = await tradesRepo.getTrade(params.tradeId);
+    if (!trade) throw new ApiError(404, 'TRADE_NOT_FOUND', 'This trade offer was not found');
+    if (trade.proposerId !== subject) {
+      throw new ApiError(403, 'NOT_TRADE_PROPOSER', 'Only the proposer may cancel this offer');
+    }
+    if (trade.status !== 'open') throw new ApiError(409, 'TRADE_CONFLICT', 'This offer is no longer open');
+
+    try {
+      const cancelled = await tradesRepo.cancelTrade(trade, subject as string, new Date().toISOString());
+      log.info('cancelTrade success', { requestId, tradeId: trade.id, proposerId: subject });
+      return { status: 200, body: cancelled };
+    } catch (err) {
+      if (err instanceof tradesRepo.TradeConflictError) {
+        throw new ApiError(409, 'TRADE_CONFLICT', err.message);
+      }
+      throw err;
+    }
+  },
+  { auth: 'jwt', params: TradeParamsSchema }
+);

--- a/apps/api/src/handlers/createTrade.ts
+++ b/apps/api/src/handlers/createTrade.ts
@@ -1,0 +1,65 @@
+import { randomBytes } from 'node:crypto';
+import { TradeOfferSchema } from '@xalians/content/schema';
+import { ApiError, withApi } from '../lib/api.ts';
+import { CreateTradeBodySchema } from '../lib/schemas.ts';
+import * as registryRepo from '../repositories/registry.ts';
+import * as tradesRepo from '../repositories/trades.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ subject, body, requestId }) => {
+    const proposerId = subject as string;
+    const recipientId = body.recipientId.toLowerCase();
+    if (recipientId === proposerId) {
+      throw new ApiError(400, 'INVALID_TRADE', 'Choose a different owner for a trade');
+    }
+
+    if (body.counterTo) {
+      const original = await tradesRepo.getTrade(body.counterTo);
+      if (!original) throw new ApiError(404, 'TRADE_NOT_FOUND', 'The original trade was not found');
+      if (original.status !== 'open') throw new ApiError(409, 'TRADE_CONFLICT', 'The original offer is no longer open');
+      if (original.recipientId !== proposerId || original.proposerId !== recipientId) {
+        throw new ApiError(403, 'NOT_TRADE_PARTICIPANT', 'Only the recipient may counter this offer');
+      }
+    }
+
+    const allIds = [...body.offeredXalianIds, ...body.requestedXalianIds];
+    const items = await Promise.all(allIds.map((id) => registryRepo.getItem(id)));
+    if (items.some((item) => !item)) {
+      throw new ApiError(404, 'XALIAN_NOT_FOUND', 'One or more Xalians in this proposal no longer exist');
+    }
+
+    const offered = items.slice(0, body.offeredXalianIds.length);
+    const requested = items.slice(body.offeredXalianIds.length);
+    if (offered.some((item) => item?.ownerId !== proposerId)) {
+      throw new ApiError(403, 'NOT_OWNER', 'You may only offer Xalians you own');
+    }
+    if (requested.some((item) => item?.ownerId !== recipientId)) {
+      throw new ApiError(409, 'TRADE_CONFLICT', 'One or more requested Xalians changed owners');
+    }
+
+    const trade = TradeOfferSchema.parse({
+      id: `trd_${randomBytes(12).toString('hex')}`,
+      proposerId,
+      recipientId,
+      offeredXalianIds: body.offeredXalianIds,
+      requestedXalianIds: body.requestedXalianIds,
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      counterTo: body.counterTo,
+    });
+
+    try {
+      await tradesRepo.createTrade(trade);
+    } catch (err) {
+      if (err instanceof tradesRepo.TradeConflictError) {
+        throw new ApiError(409, 'TRADE_CONFLICT', err.message);
+      }
+      throw err;
+    }
+
+    log.info('createTrade success', { requestId, tradeId: trade.id, proposerId, recipientId });
+    return { status: 201, body: trade };
+  },
+  { auth: 'jwt', body: CreateTradeBodySchema }
+);

--- a/apps/api/src/handlers/retrieveTrade.ts
+++ b/apps/api/src/handlers/retrieveTrade.ts
@@ -1,0 +1,14 @@
+import { ApiError, withApi } from '../lib/api.ts';
+import { TradeParamsSchema } from '../lib/schemas.ts';
+import * as tradesRepo from '../repositories/trades.ts';
+import * as log from '../lib/log.ts';
+
+export const handler = withApi(
+  async ({ params, requestId }) => {
+    const trade = await tradesRepo.getTrade(params.tradeId);
+    if (!trade) throw new ApiError(404, 'TRADE_NOT_FOUND', 'This trade offer was not found');
+    log.info('retrieveTrade success', { requestId, tradeId: trade.id, status: trade.status });
+    return { status: 200, body: trade };
+  },
+  { auth: 'none', params: TradeParamsSchema }
+);

--- a/apps/api/src/lib/schemas.ts
+++ b/apps/api/src/lib/schemas.ts
@@ -90,3 +90,29 @@ export const ReleaseRegistryXalianParamsSchema = z.object({
   xalianId: z.string().min(1),
 });
 export type ReleaseRegistryXalianParams = z.infer<typeof ReleaseRegistryXalianParamsSchema>;
+
+const TradeXalianIdsSchema = z
+  .array(z.string().regex(/^xal_/, 'xalian id must start with "xal_"'))
+  .min(1)
+  .max(6)
+  .refine((ids) => new Set(ids).size === ids.length, 'a trade side cannot repeat a Xalian');
+
+// POST /trades. Both sides are required: trades are direct swaps, not gifts, listings,
+// auctions, or price-bearing marketplace offers.
+export const CreateTradeBodySchema = z
+  .object({
+    recipientId: z.string().min(1),
+    offeredXalianIds: TradeXalianIdsSchema,
+    requestedXalianIds: TradeXalianIdsSchema,
+    counterTo: z.string().regex(/^trd_/, 'counter trade id must start with "trd_"').optional(),
+  })
+  .refine(
+    (trade) => trade.offeredXalianIds.every((id) => !trade.requestedXalianIds.includes(id)),
+    { message: 'the same Xalian cannot appear on both sides', path: ['requestedXalianIds'] }
+  );
+export type CreateTradeBody = z.infer<typeof CreateTradeBodySchema>;
+
+export const TradeParamsSchema = z.object({
+  tradeId: z.string().regex(/^trd_/, 'trade id must start with "trd_"'),
+});
+export type TradeParams = z.infer<typeof TradeParamsSchema>;

--- a/apps/api/src/repositories/trades.ts
+++ b/apps/api/src/repositories/trades.ts
@@ -1,0 +1,155 @@
+import { GetCommand, PutCommand, TransactWriteCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { TradeOfferSchema, type TradeOffer } from '@xalians/content/schema';
+import { ddb } from '../lib/db.ts';
+import * as log from '../lib/log.ts';
+
+const TABLE_NAME = 'XalianTradeOffers';
+const REGISTRY_TABLE_NAME = 'XalianRegistry';
+
+export class TradeConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TradeConflictError';
+  }
+}
+
+function isConditionalFailure(err: unknown): boolean {
+  return err instanceof Error && (
+    err.name === 'ConditionalCheckFailedException' || err.name === 'TransactionCanceledException'
+  );
+}
+
+export async function getTrade(tradeId: string): Promise<TradeOffer | null> {
+  try {
+    const result = await ddb.send(new GetCommand({ TableName: TABLE_NAME, Key: { tradeId } }));
+    return result.Item ? TradeOfferSchema.parse(result.Item) : null;
+  } catch (err) {
+    log.error('getTrade failed', { tradeId, errorName: err instanceof Error ? err.name : typeof err });
+    throw err;
+  }
+}
+
+export async function createTrade(trade: TradeOffer): Promise<void> {
+  const item = { ...trade, tradeId: trade.id };
+
+  try {
+    if (!trade.counterTo) {
+      await ddb.send(new PutCommand({
+        TableName: TABLE_NAME,
+        Item: item,
+        ConditionExpression: 'attribute_not_exists(tradeId)',
+      }));
+      return;
+    }
+
+    await ddb.send(new TransactWriteCommand({
+      TransactItems: [
+        {
+          Put: {
+            TableName: TABLE_NAME,
+            Item: item,
+            ConditionExpression: 'attribute_not_exists(tradeId)',
+          },
+        },
+        {
+          Update: {
+            TableName: TABLE_NAME,
+            Key: { tradeId: trade.counterTo },
+            UpdateExpression: 'SET #status = :countered, respondedAt = :respondedAt',
+            ConditionExpression: '#status = :open AND recipientId = :proposerId AND proposerId = :recipientId',
+            ExpressionAttributeNames: { '#status': 'status' },
+            ExpressionAttributeValues: {
+              ':open': 'open',
+              ':countered': 'countered',
+              ':respondedAt': trade.createdAt,
+              ':proposerId': trade.proposerId,
+              ':recipientId': trade.recipientId,
+            },
+          },
+        },
+      ],
+    }));
+  } catch (err) {
+    if (isConditionalFailure(err)) {
+      throw new TradeConflictError('The original offer is no longer open for a counteroffer');
+    }
+    log.error('createTrade failed', { tradeId: trade.id, errorName: err instanceof Error ? err.name : typeof err });
+    throw err;
+  }
+}
+
+// Ownership changes and the offer status transition are one DynamoDB transaction. If a
+// single creature changed hands or disappeared after the proposal was created, every
+// write is rolled back and the caller receives a conflict instead of a partial swap.
+export async function acceptTrade(trade: TradeOffer, respondedAt: string): Promise<TradeOffer> {
+  const ownershipUpdates = [
+    ...trade.offeredXalianIds.map((xalianId) => ({ xalianId, from: trade.proposerId, to: trade.recipientId })),
+    ...trade.requestedXalianIds.map((xalianId) => ({ xalianId, from: trade.recipientId, to: trade.proposerId })),
+  ];
+
+  try {
+    await ddb.send(new TransactWriteCommand({
+      TransactItems: [
+        ...ownershipUpdates.map(({ xalianId, from, to }) => ({
+          Update: {
+            TableName: REGISTRY_TABLE_NAME,
+            Key: { xalianId },
+            UpdateExpression: 'SET ownerId = :newOwner',
+            ConditionExpression: 'ownerId = :currentOwner AND attribute_exists(#record)',
+            ExpressionAttributeNames: { '#record': 'record' },
+            ExpressionAttributeValues: { ':currentOwner': from, ':newOwner': to },
+          },
+        })),
+        {
+          Update: {
+            TableName: TABLE_NAME,
+            Key: { tradeId: trade.id },
+            UpdateExpression: 'SET #status = :accepted, respondedAt = :respondedAt',
+            ConditionExpression: '#status = :open AND recipientId = :recipientId',
+            ExpressionAttributeNames: { '#status': 'status' },
+            ExpressionAttributeValues: {
+              ':open': 'open',
+              ':accepted': 'accepted',
+              ':respondedAt': respondedAt,
+              ':recipientId': trade.recipientId,
+            },
+          },
+        },
+      ],
+    }));
+  } catch (err) {
+    if (isConditionalFailure(err)) {
+      throw new TradeConflictError('This offer is stale or is no longer open');
+    }
+    log.error('acceptTrade failed', { tradeId: trade.id, errorName: err instanceof Error ? err.name : typeof err });
+    throw err;
+  }
+
+  return { ...trade, status: 'accepted', respondedAt };
+}
+
+export async function cancelTrade(trade: TradeOffer, proposerId: string, respondedAt: string): Promise<TradeOffer> {
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { tradeId: trade.id },
+      UpdateExpression: 'SET #status = :cancelled, respondedAt = :respondedAt',
+      ConditionExpression: '#status = :open AND proposerId = :proposerId',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: {
+        ':open': 'open',
+        ':cancelled': 'cancelled',
+        ':respondedAt': respondedAt,
+        ':proposerId': proposerId,
+      },
+    }));
+  } catch (err) {
+    if (isConditionalFailure(err)) {
+      throw new TradeConflictError('This offer is no longer open');
+    }
+    log.error('cancelTrade failed', { tradeId: trade.id, errorName: err instanceof Error ? err.name : typeof err });
+    throw err;
+  }
+
+  return { ...trade, status: 'cancelled', respondedAt };
+}

--- a/apps/web/src/App.js
+++ b/apps/web/src/App.js
@@ -53,6 +53,8 @@ const GeneratorPage = lazy(() => import('./pages/generatorPage'));
 const UserAccountPage = lazy(() => import('./pages/userAccountPage'));
 const UserDetailsPage = lazy(() => import('./pages/userDetailsPage'));
 const RecordPage = lazy(() => import('./pages/recordPage'));
+const TradeBuilderPage = lazy(() => import('./pages/tradeBuilderPage'));
+const TradePage = lazy(() => import('./pages/tradePage'));
 const MatchCardGamePage = lazy(() => import('./pages/games/matchCardGamePage'));
 const PhysicsGamePage = lazy(() => import('./pages/games/physicsGamePage'));
 const TrainingGroundsPage = lazy(() => import('./pages/trainingGroundsPage'));
@@ -100,6 +102,11 @@ function RecordRoute() {
   return <RecordPage id={id} />;
 }
 
+function TradeRoute() {
+  const { id } = useParams();
+  return <TradePage id={id} />;
+}
+
 export function AppRoutes() {
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -112,6 +119,8 @@ export function AppRoutes() {
           <Route path="/species/:id" element={<RedirectSpecies />} />
           <Route path="/user/:id" element={<UserDetailsRoute />} />
           <Route path="/xalian/:id" element={<RecordRoute />} />
+          <Route path="/trade/new" element={<TradeBuilderPage />} />
+          <Route path="/trade/:id" element={<TradeRoute />} />
           <Route path="/planets" element={<PreserveLocationRedirect to="/encyclopedia/worlds" />} />
           <Route path="/glossary" element={<PreserveLocationRedirect to="/encyclopedia/index" />} />
           <Route path="/encyclopedia/*" element={<EncyclopediaPage />} />

--- a/apps/web/src/components/record/RecordTile.tsx
+++ b/apps/web/src/components/record/RecordTile.tsx
@@ -22,6 +22,7 @@ type RecordTileProps = {
 	comparison?: {
 		selected: boolean;
 		disabled?: boolean;
+		label?: string;
 		onToggle: (record: XalianRecord) => void;
 	};
 };
@@ -73,7 +74,7 @@ function RecordTile({ record, onOpen, action, comparison }: RecordTileProps) {
 					<button
 						type="button"
 						className="inline-flex size-10 items-center justify-center border border-edge-strong bg-s0 text-ink transition-colors hover:bg-s2 focus-visible:outline-2 focus-visible:outline-ring disabled:opacity-40"
-						aria-label={`${comparison.selected ? 'Remove' : 'Add'} ${name} ${comparison.selected ? 'from' : 'to'} comparison`}
+						aria-label={`${comparison.selected ? 'Remove' : 'Add'} ${name} ${comparison.selected ? 'from' : 'to'} ${comparison.label || 'comparison'}`}
 						aria-pressed={comparison.selected}
 						disabled={comparison.disabled}
 						onClick={() => comparison.onToggle(record)}

--- a/apps/web/src/pages/tradeBuilderPage.tsx
+++ b/apps/web/src/pages/tradeBuilderPage.tsx
@@ -1,0 +1,195 @@
+import * as React from 'react';
+import type { XalianRecord } from '@xalians/content/schema';
+import { ArrowRightLeft } from 'lucide-react';
+import { Link, useNavigate, useSearchParams } from 'react-router';
+
+import XalianNavbar from '../components/navbar';
+import RecordTile from '../components/record/RecordTile';
+import * as authUtil from '../utils/authUtil';
+import * as dbApi from '../utils/dbApi';
+
+import { Shell, Masthead, SectionHead } from '@/components/system/masthead';
+import { HelixSpinner } from '@/components/system/brand';
+import { EmptyState } from '@/components/system/record';
+import { Callout } from '@/components/system/readouts';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+function queryIds(value: string | null): string[] {
+	return value ? value.split(',').filter((id) => id.startsWith('xal_')).slice(0, 6) : [];
+}
+
+function TradeBuilderPage() {
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const initialRecipient = (searchParams.get('with') || '').toLowerCase();
+	const [username, setUsername] = React.useState<string | null>(null);
+	const [authChecked, setAuthChecked] = React.useState(false);
+	const [ownRecords, setOwnRecords] = React.useState<XalianRecord[]>([]);
+	const [recipientId, setRecipientId] = React.useState(initialRecipient);
+	const [loadedRecipient, setLoadedRecipient] = React.useState('');
+	const [recipientRecords, setRecipientRecords] = React.useState<XalianRecord[]>([]);
+	const [offeredIds, setOfferedIds] = React.useState<string[]>(queryIds(searchParams.get('offer')));
+	const [requestedIds, setRequestedIds] = React.useState<string[]>(queryIds(searchParams.get('request')));
+	const [loadingRecipient, setLoadingRecipient] = React.useState(false);
+	const [submitting, setSubmitting] = React.useState(false);
+	const [message, setMessage] = React.useState<string | null>(null);
+	const counterTo = searchParams.get('counterTo') || undefined;
+
+	React.useEffect(() => {
+		authUtil.currentUser()
+			.then((user: any) => {
+				const name = user?.username?.toLowerCase() || null;
+				setUsername(name);
+				setAuthChecked(true);
+				if (!name) return;
+				return dbApi.callListXalians().then((page: any) => setOwnRecords(page.items));
+			})
+			.catch(() => {
+				setAuthChecked(true);
+				setMessage('Could not load your account. Please try again later.');
+			});
+	}, []);
+
+	const loadRecipient = React.useCallback((owner: string) => {
+		const normalized = owner.trim().toLowerCase();
+		if (!normalized) return;
+		if (normalized === username) {
+			setMessage('Choose another owner. A trade needs two different people.');
+			return;
+		}
+		setMessage(null);
+		setLoadingRecipient(true);
+		dbApi.callListPublicXalians(normalized)
+			.then((page: any) => {
+				setRecipientRecords(page.items);
+				setLoadedRecipient(normalized);
+				setRecipientId(normalized);
+				setRequestedIds((current) => current.filter((id) => page.items.some((record: XalianRecord) => record.id === id)));
+				setLoadingRecipient(false);
+			})
+			.catch(() => {
+				setLoadingRecipient(false);
+				setLoadedRecipient('');
+				setRecipientRecords([]);
+				setMessage(`Could not load ${normalized}'s binder.`);
+			});
+	}, [username]);
+
+	React.useEffect(() => {
+		if (authChecked && username && initialRecipient) loadRecipient(initialRecipient);
+	}, [authChecked, initialRecipient, loadRecipient, username]);
+
+	React.useEffect(() => {
+		if (ownRecords.length > 0) {
+			setOfferedIds((current) => current.filter((id) => ownRecords.some((record) => record.id === id)));
+		}
+	}, [ownRecords]);
+
+	const toggleId = (id: string, selected: string[], setSelected: React.Dispatch<React.SetStateAction<string[]>>) => {
+		setSelected(selected.includes(id) ? selected.filter((current) => current !== id) : selected.length < 6 ? [...selected, id] : selected);
+	};
+
+	const submit = () => {
+		if (!loadedRecipient || offeredIds.length === 0 || requestedIds.length === 0) return;
+		setSubmitting(true);
+		setMessage(null);
+		dbApi.callCreateTrade({
+			recipientId: loadedRecipient,
+			offeredXalianIds: offeredIds,
+			requestedXalianIds: requestedIds,
+			counterTo,
+		})
+			.then((trade: any) => navigate(`/trade/${trade.id}`))
+			.catch((error: Error) => {
+				setSubmitting(false);
+				setMessage(error.message || 'Could not create this trade.');
+			});
+	};
+
+	return (
+		<main id="main" className="min-h-screen bg-room text-ink font-body" data-tier="chrome">
+			<XalianNavbar />
+			<Shell className="pb-16">
+				<Masthead
+					kicker={counterTo ? 'Counteroffer' : 'Direct swap'}
+					title={counterTo ? 'Shape a counteroffer' : 'Propose a trade'}
+					subtitle="Choose creatures from two binders. No prices, listings, or game-specific power values are attached."
+				/>
+
+				{!authChecked ? <div className="flex justify-center py-16"><HelixSpinner /></div> : null}
+				{authChecked && !username ? (
+					<EmptyState legend="Sign in to trade">
+						Trade proposals come from a verified owner and can only include creatures in that owner's binder.
+						<div className="mt-4"><Button asChild><Link to="/account">Open your account</Link></Button></div>
+					</EmptyState>
+				) : null}
+
+				{authChecked && username ? (
+					<React.Fragment>
+						<form
+							className="mb-6 flex flex-col gap-3 border border-edge bg-s1 p-4 sm:flex-row sm:items-end"
+							onSubmit={(event) => { event.preventDefault(); loadRecipient(recipientId); }}
+						>
+							<label className="flex min-w-0 flex-1 flex-col gap-2">
+								<span className="type-legend">TRADE WITH</span>
+								<Input value={recipientId} onChange={(event) => setRecipientId(event.target.value)} placeholder="Owner username" />
+							</label>
+							<Button type="submit" variant="secondary" disabled={loadingRecipient}>
+								{loadingRecipient ? 'Loading binder' : 'View binder'}
+							</Button>
+						</form>
+
+						{message ? <Callout variant="caution" title="Trade unavailable" className="mb-6">{message}</Callout> : null}
+
+						{loadedRecipient ? (
+							<React.Fragment>
+								<Callout variant="note" title="Build the exchange" className="mb-6">
+									Choose at least one creature on each side, up to six each. The recipient can accept, counter, or leave the offer open.
+								</Callout>
+								<div className="grid gap-8 lg:grid-cols-2">
+									<section>
+										<SectionHead title="You offer" count={`${offeredIds.length} selected`} />
+										<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3">
+											{ownRecords.map((record) => (
+												<RecordTile
+													key={record.id}
+													record={record}
+													onOpen={() => toggleId(record.id, offeredIds, setOfferedIds)}
+													comparison={{ selected: offeredIds.includes(record.id), disabled: offeredIds.length >= 6 && !offeredIds.includes(record.id), label: 'trade offer', onToggle: () => toggleId(record.id, offeredIds, setOfferedIds) }}
+												/>
+											))}
+										</div>
+									</section>
+									<section>
+										<SectionHead title={`${loadedRecipient} sends`} count={`${requestedIds.length} selected`} />
+										{recipientRecords.length === 0 ? <EmptyState legend="Binder empty">There is nothing here to request.</EmptyState> : (
+											<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3">
+												{recipientRecords.map((record) => (
+													<RecordTile
+														key={record.id}
+														record={record}
+														onOpen={() => toggleId(record.id, requestedIds, setRequestedIds)}
+														comparison={{ selected: requestedIds.includes(record.id), disabled: requestedIds.length >= 6 && !requestedIds.includes(record.id), label: 'trade request', onToggle: () => toggleId(record.id, requestedIds, setRequestedIds) }}
+													/>
+												))}
+											</div>
+										)}
+									</section>
+								</div>
+								<div className="mt-8 flex flex-wrap items-center justify-between gap-4 border-t border-edge pt-6">
+									<p className="m-0 text-small text-ink-2">Ownership changes only if {loadedRecipient} accepts the complete offer.</p>
+									<Button disabled={submitting || offeredIds.length === 0 || requestedIds.length === 0} onClick={submit}>
+										<ArrowRightLeft /> {submitting ? 'Creating offer' : counterTo ? 'Send counteroffer' : 'Create trade link'}
+									</Button>
+								</div>
+							</React.Fragment>
+						) : null}
+					</React.Fragment>
+				) : null}
+			</Shell>
+		</main>
+	);
+}
+
+export default TradeBuilderPage;

--- a/apps/web/src/pages/tradePage.tsx
+++ b/apps/web/src/pages/tradePage.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import type { TradeOffer, XalianRecord } from '@xalians/content/schema';
+import { speciesDisplayName } from '@xalians/rules/generator';
+import { ArrowRightLeft, Copy } from 'lucide-react';
+import { Link } from 'react-router';
+import { toast } from 'sonner';
+
+import XalianNavbar from '../components/navbar';
+import RecordTile from '../components/record/RecordTile';
+import RecordView from '../components/record/RecordView';
+import * as authUtil from '../utils/authUtil';
+import * as dbApi from '../utils/dbApi';
+
+import { Shell, Masthead, SectionHead } from '@/components/system/masthead';
+import { HelixSpinner } from '@/components/system/brand';
+import { EmptyState } from '@/components/system/record';
+import { Callout } from '@/components/system/readouts';
+import { VisuallyHidden } from '@/components/system/a11y';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+type TradePageProps = { id: string };
+
+const statusLabel = { open: 'Open', accepted: 'Accepted', cancelled: 'Cancelled', countered: 'Countered' } as const;
+
+function TradePage({ id }: TradePageProps) {
+	const [trade, setTrade] = React.useState<TradeOffer | null>(null);
+	const [records, setRecords] = React.useState<Record<string, XalianRecord>>({});
+	const [username, setUsername] = React.useState<string | null>(null);
+	const [loading, setLoading] = React.useState(true);
+	const [message, setMessage] = React.useState<string | null>(null);
+	const [openRecord, setOpenRecord] = React.useState<XalianRecord | null>(null);
+	const [confirmation, setConfirmation] = React.useState<'accept' | 'cancel' | null>(null);
+	const [responding, setResponding] = React.useState(false);
+
+	React.useEffect(() => {
+		Promise.all([dbApi.callGetTrade(id), authUtil.currentUser().catch(() => null)])
+			.then(async ([loadedTrade, user]: [TradeOffer, any]) => {
+				setTrade(loadedTrade);
+				setUsername(user?.username?.toLowerCase() || null);
+				const ids = [...loadedTrade.offeredXalianIds, ...loadedTrade.requestedXalianIds];
+				const loaded = await Promise.all(ids.map((recordId) => dbApi.callGetPublicXalian(recordId).catch(() => null)));
+				const available = loaded.filter((record): record is XalianRecord => record !== null);
+				setRecords(Object.fromEntries(available.map((record) => [record.id, record])));
+				setLoading(false);
+			})
+			.catch((error: Error) => {
+				setLoading(false);
+				setMessage(error.message || 'Could not load this trade offer.');
+			});
+	}, [id]);
+
+	const copyLink = () => {
+		navigator.clipboard.writeText(window.location.href)
+			.then(() => toast.success('Trade link copied'))
+			.catch(() => toast.error('Could not copy the trade link'));
+	};
+
+	const respond = () => {
+		if (!trade || !confirmation) return;
+		setResponding(true);
+		const request = confirmation === 'accept' ? dbApi.callAcceptTrade(trade.id) : dbApi.callCancelTrade(trade.id);
+		request.then((updated: TradeOffer) => {
+			setTrade(updated);
+			setConfirmation(null);
+			setResponding(false);
+			toast.success(confirmation === 'accept' ? 'Trade accepted' : 'Trade cancelled');
+		}).catch((error: Error) => {
+			setConfirmation(null);
+			setResponding(false);
+			setMessage(error.message || 'The trade could not be updated.');
+		});
+	};
+
+	if (loading) {
+		return <main className="min-h-screen bg-room text-ink"><XalianNavbar /><div className="flex justify-center py-24"><HelixSpinner /></div></main>;
+	}
+
+	if (!trade) {
+		return <main className="min-h-screen bg-room text-ink"><XalianNavbar /><Shell><EmptyState legend="Trade unavailable">{message || 'This trade offer was not found.'}</EmptyState></Shell></main>;
+	}
+
+	const offeredRecords = trade.offeredXalianIds.map((recordId) => records[recordId]).filter(Boolean);
+	const requestedRecords = trade.requestedXalianIds.map((recordId) => records[recordId]).filter(Boolean);
+	const isRecipient = username === trade.recipientId;
+	const isProposer = username === trade.proposerId;
+	const counterParams = new URLSearchParams({
+		with: trade.proposerId,
+		counterTo: trade.id,
+		offer: trade.requestedXalianIds.join(','),
+		request: trade.offeredXalianIds.join(','),
+	});
+	const statusVariant = trade.status === 'accepted' ? 'ok' : trade.status === 'open' ? 'info' : 'warn';
+
+	return (
+		<main id="main" className="min-h-screen bg-room text-ink font-body" data-tier="chrome">
+			<XalianNavbar />
+			<Shell className="pb-16">
+				<Masthead
+					kicker="Direct swap"
+					title={`${trade.proposerId} ↔ ${trade.recipientId}`}
+					subtitle={`Proposed ${new Date(trade.createdAt).toLocaleDateString()}. This link is public; only the named recipient can accept it.`}
+					beside={<Badge variant={statusVariant}>{statusLabel[trade.status]}</Badge>}
+					aside={<Button variant="secondary" onClick={copyLink}><Copy /> Copy trade link</Button>}
+				/>
+
+				{message ? <Callout variant="caution" title="Trade update" className="mb-6">{message}</Callout> : null}
+				{trade.status === 'open' ? (
+					<Callout variant="note" title="One complete exchange" className="mb-6">
+						Accepting transfers every creature below at once. If any one changed owners after this offer was made, nothing moves.
+					</Callout>
+				) : (
+					<Callout variant={trade.status === 'accepted' ? 'viable' : 'note'} title={`Offer ${statusLabel[trade.status].toLowerCase()}`} className="mb-6">
+						{trade.status === 'accepted' ? 'The complete ownership exchange is recorded.' : 'This offer can no longer be accepted.'}
+					</Callout>
+				)}
+
+				<div className="grid gap-8 lg:grid-cols-[1fr_auto_1fr] lg:items-start">
+					<section>
+						<SectionHead title={`${trade.proposerId} offers`} count={`${trade.offeredXalianIds.length}`} />
+						<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3">
+							{offeredRecords.map((record) => <RecordTile key={record.id} record={record} onOpen={setOpenRecord} />)}
+						</div>
+					</section>
+					<div className="hidden pt-12 text-ink-3 lg:block"><ArrowRightLeft /></div>
+					<section>
+						<SectionHead title={`${trade.recipientId} sends`} count={`${trade.requestedXalianIds.length}`} />
+						<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3">
+							{requestedRecords.map((record) => <RecordTile key={record.id} record={record} onOpen={setOpenRecord} />)}
+						</div>
+					</section>
+				</div>
+
+				{offeredRecords.length !== trade.offeredXalianIds.length || requestedRecords.length !== trade.requestedXalianIds.length ? (
+					<Callout variant="caution" title="A record is unavailable" className="mt-6">This offer is stale and cannot complete as written.</Callout>
+				) : null}
+
+				{trade.status === 'open' ? (
+					<div className="mt-8 flex flex-wrap justify-end gap-3 border-t border-edge pt-6">
+						{!username ? <Button asChild variant="secondary"><Link to="/account">Sign in to respond</Link></Button> : null}
+						{isRecipient ? <Button asChild variant="secondary"><Link to={`/trade/new?${counterParams.toString()}`}>Shape a counteroffer</Link></Button> : null}
+						{isRecipient ? <Button onClick={() => setConfirmation('accept')}>Accept complete trade</Button> : null}
+						{isProposer ? <Button variant="destructive" onClick={() => setConfirmation('cancel')}>Cancel offer</Button> : null}
+					</div>
+				) : null}
+			</Shell>
+
+			<Dialog open={!!confirmation} onOpenChange={(open: boolean) => !open && setConfirmation(null)}>
+				<DialogContent>
+					<DialogHeader><DialogTitle>{confirmation === 'accept' ? 'Accept this complete trade?' : 'Cancel this offer?'}</DialogTitle></DialogHeader>
+					<p className="m-0 text-ink-2">
+						{confirmation === 'accept'
+							? `Every listed Xalian will change owners between ${trade.proposerId} and ${trade.recipientId}. This cannot be partly completed.`
+							: 'The recipient will no longer be able to accept this link.'}
+					</p>
+					<DialogFooter>
+						<Button variant="ghost" onClick={() => setConfirmation(null)}>Keep offer open</Button>
+						<Button variant={confirmation === 'accept' ? 'default' : 'destructive'} disabled={responding} onClick={respond}>
+							{responding ? 'Updating' : confirmation === 'accept' ? 'Confirm ownership swap' : 'Confirm cancellation'}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={!!openRecord} onOpenChange={(open: boolean) => !open && setOpenRecord(null)}>
+				<DialogContent className="sm:max-w-4xl">
+					<DialogHeader><VisuallyHidden><DialogTitle>{openRecord ? speciesDisplayName(openRecord.species) : 'Record'}</DialogTitle></VisuallyHidden></DialogHeader>
+					<ScrollArea className="max-h-[75vh] pr-4">{openRecord ? <RecordView record={openRecord} kicker="Trade record" recordLink={`/xalian/${openRecord.id}`} /> : null}</ScrollArea>
+				</DialogContent>
+			</Dialog>
+		</main>
+	);
+}
+
+export default TradePage;

--- a/apps/web/src/pages/userDetailsPage.tsx
+++ b/apps/web/src/pages/userDetailsPage.tsx
@@ -4,7 +4,8 @@
 import * as React from 'react';
 import type { XalianRecord } from '@xalians/content/schema';
 import { speciesDisplayName } from '@xalians/rules/generator';
-import { Copy } from 'lucide-react';
+import { ArrowRightLeft, Copy } from 'lucide-react';
+import { Link } from 'react-router';
 import { toast } from 'sonner';
 
 import XalianNavbar from '../components/navbar';
@@ -78,7 +79,12 @@ function UserDetailsPage({ id }: UserDetailsPageProps) {
 					kicker="Account"
 					title={id}
 					subtitle={records.length > 0 ? `${records.length} generated` : undefined}
-					aside={<Button variant="secondary" onClick={copyBinderLink}><Copy /> Copy binder link</Button>}
+					aside={
+						<div className="flex w-full flex-col gap-3 sm:flex-row md:w-auto">
+							<Button variant="secondary" onClick={copyBinderLink}><Copy /> Copy binder link</Button>
+							<Button asChild><Link to={`/trade/new?with=${encodeURIComponent(id)}`}><ArrowRightLeft /> Propose a trade</Link></Button>
+						</div>
+					}
 				/>
 
 				{isLoading && (

--- a/apps/web/src/utils/dbApi.js
+++ b/apps/web/src/utils/dbApi.js
@@ -1,4 +1,4 @@
-import { UserRecordSchema, PublicProfileSchema, XalianRecordSchema } from "@xalians/content/schema";
+import { UserRecordSchema, PublicProfileSchema, TradeOfferSchema, XalianRecordSchema } from "@xalians/content/schema";
 import { generateXalian, getSpeciesTemplates } from "@xalians/rules/generator";
 import { getIdToken } from './authUtil';
 
@@ -27,6 +27,8 @@ const useCache = () => import.meta.env.VITE_USE_CACHE === "true";
 // offline pull so repeated "Generate another" clicks under VITE_USE_CACHE=true actually
 // render a different creature, the way the real API's random seed does.
 let pullCounter = 0;
+const sampleRecordCache = new Map();
+const sampleTradeCache = new Map();
 
 function sampleRecords(count = 1, profile, pullSeed) {
   const templates = getSpeciesTemplates();
@@ -37,11 +39,13 @@ function sampleRecords(count = 1, profile, pullSeed) {
     const seed = pullSeed
       ? `sample-${template.key}-${pullSeed}-${profile || "full"}`
       : `sample-${template.key}-${index + 1}-${profile || "full"}`;
-    return generateXalian(template, seed, {
+    const record = generateXalian(template, seed, {
       origin: template.homePlanet,
       generatedAt: "2026-09-07T00:00:00Z",
       profile,
     });
+    sampleRecordCache.set(record.id, record);
+    return record;
   });
 }
 
@@ -60,8 +64,8 @@ async function requestJson(url, options = {}) {
   }
 
   if (!response.ok) {
-    const message = data && typeof data === 'object' && data.message
-      ? data.message
+    const message = data && typeof data === 'object' && (data.errorMessage || data.message)
+      ? data.errorMessage || data.message
       : `Xalians API request failed (${response.status}).`;
     const error = new Error(message);
     error.status = response.status;
@@ -161,7 +165,8 @@ export const callGetXalian = (id) => {
 /** Public read used by shareable creature pages; sends no identity or token. */
 export const callGetPublicXalian = (id) => {
   if (useCache()) {
-    return Promise.resolve(XalianRecordSchema.parse(sampleRecords(1)[0]));
+    const cached = sampleRecordCache.get(id) || sampleRecords(1, undefined, id)[0];
+    return Promise.resolve(XalianRecordSchema.parse(cached));
   }
   return requestJson(`${API}/registry/xalians/${encodeURIComponent(id)}`)
     .then((data) => XalianRecordSchema.parse(data));
@@ -170,7 +175,10 @@ export const callGetPublicXalian = (id) => {
 /** Public read used by shareable binder pages; sends no identity or token. */
 export const callListPublicXalians = (ownerId, cursor) => {
   if (useCache()) {
-    return Promise.resolve({ items: sampleRecords(3).map((r) => XalianRecordSchema.parse(r)), nextCursor: undefined });
+    return Promise.resolve({
+      items: sampleRecords(3, undefined, ownerId).map((r) => XalianRecordSchema.parse(r)),
+      nextCursor: undefined,
+    });
   }
   const params = new URLSearchParams();
   if (cursor) params.set("cursor", cursor);
@@ -188,6 +196,76 @@ export const callReleaseXalian = (id) => {
     return Promise.resolve({ message: "ok" });
   }
   return callDelete(`${API}/xalians/${encodeURIComponent(id)}`);
+};
+
+// ---------------------------------------------------------------------------
+// Direct swaps
+// ---------------------------------------------------------------------------
+
+function sampleTrade(id = 'trd_sample') {
+  const offered = sampleRecords(2, undefined, 'collector');
+  const requested = sampleRecords(2);
+  return TradeOfferSchema.parse({
+    id,
+    proposerId: 'collector',
+    recipientId: 'sample',
+    offeredXalianIds: offered.map((record) => record.id),
+    requestedXalianIds: requested.map((record) => record.id),
+    status: 'open',
+    createdAt: '2026-09-12T12:00:00Z',
+  });
+}
+
+export const callCreateTrade = (proposal) => {
+  if (useCache()) {
+    pullCounter += 1;
+    const trade = TradeOfferSchema.parse({
+      ...proposal,
+      id: `trd_sample_${pullCounter}`,
+      proposerId: 'sample',
+      recipientId: proposal.recipientId.toLowerCase(),
+      status: 'open',
+      createdAt: new Date().toISOString(),
+    });
+    if (trade.counterTo) {
+      const original = sampleTradeCache.get(trade.counterTo);
+      if (original) sampleTradeCache.set(original.id, { ...original, status: 'countered', respondedAt: trade.createdAt });
+    }
+    sampleTradeCache.set(trade.id, trade);
+    return Promise.resolve(trade);
+  }
+  return callCreate(`${API}/trades`, proposal).then((data) => TradeOfferSchema.parse(data));
+};
+
+export const callGetTrade = (id) => {
+  if (useCache()) {
+    if (!sampleTradeCache.has(id)) sampleTradeCache.set(id, sampleTrade(id));
+    return Promise.resolve(TradeOfferSchema.parse(sampleTradeCache.get(id)));
+  }
+  return requestJson(`${API}/trades/${encodeURIComponent(id)}`)
+    .then((data) => TradeOfferSchema.parse(data));
+};
+
+export const callAcceptTrade = (id) => {
+  if (useCache()) {
+    const current = sampleTradeCache.get(id) || sampleTrade(id);
+    const trade = TradeOfferSchema.parse({ ...current, status: 'accepted', respondedAt: new Date().toISOString() });
+    sampleTradeCache.set(id, trade);
+    return Promise.resolve(trade);
+  }
+  return callCreate(`${API}/trades/${encodeURIComponent(id)}/accept`, {})
+    .then((data) => TradeOfferSchema.parse(data));
+};
+
+export const callCancelTrade = (id) => {
+  if (useCache()) {
+    const current = sampleTradeCache.get(id) || sampleTrade(id);
+    const trade = TradeOfferSchema.parse({ ...current, status: 'cancelled', respondedAt: new Date().toISOString() });
+    sampleTradeCache.set(id, trade);
+    return Promise.resolve(trade);
+  }
+  return callCreate(`${API}/trades/${encodeURIComponent(id)}/cancel`, {})
+    .then((data) => TradeOfferSchema.parse(data));
 };
 
 // ---------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -81,12 +81,14 @@ resource "aws_iam_role_policy" "dynamodb_policy" {
           "dynamodb:Query",
           "dynamodb:DeleteItem",
           "dynamodb:ConditionCheckItem",
+          "dynamodb:TransactWriteItems",
         ]
         Resource = [
           "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/XalianUsersTable",
           # Exact table names, not a table-level wildcard, so each table needs its own
           # ARN here. The index wildcard below covers XalianRegistry's byOwner GSI.
           "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/XalianRegistry",
+          "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/XalianTradeOffers",
           "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/Xalian*/index/*",
         ]
       },
@@ -462,6 +464,75 @@ module "release_registry_xalian_lambda_module" {
   iam_role_arn                    = aws_iam_role.lambda_exec.arn
   apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
   apigw_lambda_route_key          = "DELETE /xalians/{xalianId}"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "JWT"
+  authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+}
+#####                                               #####
+#########################################################
+
+#########################################################
+#####               LAMBDA INSTANCE                 #####
+##                 Create Trade Lambda                 ##
+#########################################################
+module "create_trade_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "CreateTrade"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "createTrade/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "POST /trades"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "JWT"
+  authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+}
+
+module "retrieve_trade_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "RetrieveTrade"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "retrieveTrade/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "GET /trades/{tradeId}"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "NONE"
+}
+
+module "accept_trade_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "AcceptTrade"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "acceptTrade/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "POST /trades/{tradeId}/accept"
+  base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
+  authorization_type              = "JWT"
+  authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
+}
+
+module "cancel_trade_lambda_module" {
+  source = "./terraform/modules/lambda"
+
+  function_name                   = "CancelTrade"
+  lambda_bucket_id                = aws_s3_bucket.lambda_bucket.id
+  lambda_bucket_object_key        = aws_s3_object.lambda_bucket_object.key
+  lambda_handler_path             = "cancelTrade/index.handler"
+  lambda_archive_file_output_hash = data.archive_file.lambda_zip_file.output_base64sha256
+  iam_role_arn                    = aws_iam_role.lambda_exec.arn
+  apigw_lambda_id                 = aws_apigatewayv2_api.lambda.id
+  apigw_lambda_route_key          = "POST /trades/{tradeId}/cancel"
   base_apigw_lambda_execution_arn = aws_apigatewayv2_api.lambda.execution_arn
   authorization_type              = "JWT"
   authorizer_id                   = aws_apigatewayv2_authorizer.cognito.id
@@ -1161,6 +1232,28 @@ resource "aws_dynamodb_table" "xalian_registry" {
     hash_key        = "ownerId"
     range_key       = "generatedAt"
     projection_type = "ALL"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Direct-swap proposals. The item is immutable except for its status and response time;
+# ownership transfers happen in a transaction with the registry rows, so no partial
+# trade can be committed.
+resource "aws_dynamodb_table" "xalian_trade_offers" {
+  name         = "XalianTradeOffers"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "tradeId"
+
+  attribute {
+    name = "tradeId"
+    type = "S"
   }
 
   point_in_time_recovery {

--- a/packages/content/src/schema/index.ts
+++ b/packages/content/src/schema/index.ts
@@ -14,3 +14,4 @@ export * from './encyclopedia.ts';
 export * from './user.ts';
 export * from './lore.ts';
 export * from './legacy.ts';
+export * from './trade.ts';

--- a/packages/content/src/schema/trade.ts
+++ b/packages/content/src/schema/trade.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const XalianIdSchema = z.string().regex(/^xal_/, 'xalian id must start with "xal_"');
+const TradeSideSchema = z
+  .array(XalianIdSchema)
+  .min(1)
+  .max(6)
+  .refine((ids) => new Set(ids).size === ids.length, 'a trade side cannot repeat a Xalian');
+
+export const TradeStatusSchema = z.enum(['open', 'accepted', 'cancelled', 'countered']);
+export type TradeStatus = z.infer<typeof TradeStatusSchema>;
+
+// A trade is a direct, creature-for-creature proposal between two owners. It carries
+// record ids rather than prices or game stats: Xalian records are immutable and games
+// remain responsible for interpreting them.
+export const TradeOfferSchema = z
+  .object({
+    id: z.string().regex(/^trd_/, 'trade id must start with "trd_"'),
+    proposerId: z.string().min(1),
+    recipientId: z.string().min(1),
+    offeredXalianIds: TradeSideSchema,
+    requestedXalianIds: TradeSideSchema,
+    status: TradeStatusSchema,
+    createdAt: z.string().datetime({ offset: true }),
+    respondedAt: z.string().datetime({ offset: true }).optional(),
+    counterTo: z.string().regex(/^trd_/, 'counter trade id must start with "trd_"').optional(),
+  })
+  .refine((trade) => trade.proposerId !== trade.recipientId, {
+    message: 'a trade must involve two different owners',
+    path: ['recipientId'],
+  })
+  .refine(
+    (trade) => trade.offeredXalianIds.every((id) => !trade.requestedXalianIds.includes(id)),
+    { message: 'the same Xalian cannot appear on both sides', path: ['requestedXalianIds'] }
+  );
+
+export type TradeOffer = z.infer<typeof TradeOfferSchema>;


### PR DESCRIPTION
## What changed
- add direct creature-for-creature proposal builder from public binders
- add public trade links with recipient-only accept, counteroffer, and proposer cancellation controls
- transfer every offered/requested registry record in one DynamoDB transaction
- reject stale ownership without partial transfers
- add a protected trade-offer table and authenticated/public API routes
- add explicit confirmation before the final ownership swap

This implements direct swaps only. It adds no marketplace, prices, listings, auctions, currency, or game-specific power model.

## Validation
- content, API, and web type checks
- API and web production builds
- bundle budgets
- Terraform formatting
- desktop and mobile visual review of proposal, public offer, counteroffer, and acceptance confirmation

No Playwright or new automated test work was added.